### PR TITLE
Add inline asm

### DIFF
--- a/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "movi (M1_NM, 8) tmp1(0,1)<1>  tmp2(0,0)\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("syntax error") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
@@ -25,7 +25,6 @@ struct KernelFunctor {
 int main() {
   KernelFunctor f;
   launchInlineASMTest(f, /* sg size */ true,
-                      /* exception is expected */ false,
                       /* exception string*/ "syntax error, unexpected IDENT");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,8 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("syntax error") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(f, /* sg size */ true,
+                      /* exception is expected */ false,
+                      /* exception string*/ "syntax error, unexpected IDENT");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "mov (M1_NM, 8) tmp1(0,1)<1>:f tmp2(0,0)<1;1,0>\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("syntax error") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
@@ -25,7 +25,6 @@ struct KernelFunctor {
 int main() {
   KernelFunctor f;
   launchInlineASMTest(f, /* sg size */ true,
-                      /* exception is expected */ false,
                       /* exception string*/ "syntax error, unexpected FTYPE");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,8 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("syntax error") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(f, /* sg size */ true,
+                      /* exception is expected */ false,
+                      /* exception string*/ "syntax error, unexpected FTYPE");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "check_label0:\ncheck_label0:\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::exception &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("OpenCL API failed") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,8 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::exception &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("OpenCL API failed") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(f, /* sg size */ true,
+                      /* exception is expected */ false,
+                      /* exception string*/ "for the exact error messages");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
@@ -25,7 +25,6 @@ struct KernelFunctor {
 int main() {
   KernelFunctor f;
   launchInlineASMTest(f, /* sg size */ true,
-                      /* exception is expected */ false,
                       /* exception string*/ "for the exact error messages");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
+++ b/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "mov (M1_NM, 6) tmp1(0,1)<1>  tmp2(0,0)<1;1,0>\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("invalid execution size") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
+++ b/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,8 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("invalid execution size") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(f, /* sg size */ true,
+                      /* exception is expected */ false,
+                      /* exception string*/ "invalid execution size");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
+++ b/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
@@ -25,7 +25,6 @@ struct KernelFunctor {
 int main() {
   KernelFunctor f;
   launchInlineASMTest(f, /* sg size */ true,
-                      /* exception is expected */ false,
                       /* exception string*/ "invalid execution size");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_missing_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_label.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "goto (M1, 16) check_label0\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("OpenCL API failed") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_missing_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_label.cpp
@@ -25,7 +25,6 @@ struct KernelFunctor {
 int main() {
   KernelFunctor f;
   launchInlineASMTest(f, /* sg size */ true,
-                      /* exception is expected */ false,
                       /* exception string*/ "for the exact error messages");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_missing_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_label.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,8 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("OpenCL API failed") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(f, /* sg size */ true,
+                      /* exception is expected */ false,
+                      /* exception string*/ "for the exact error messages");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_missing_region.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_region.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "mov (M1_NM, 8) tmp1(0,1)<1>  tmp2(0,0)\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("syntax error") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_missing_region.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_region.cpp
@@ -26,7 +26,6 @@ int main() {
   KernelFunctor f;
   launchInlineASMTest(
       f, /* sg size */ true,
-      /* exception is expected */ false,
       /* exception string*/ "unexpected NEWLINE, expecting LANGLE");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_missing_region.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_region.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,9 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("syntax error") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(
+      f, /* sg size */ true,
+      /* exception is expected */ false,
+      /* exception string*/ "unexpected NEWLINE, expecting LANGLE");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_simple.cpp
+++ b/SYCL/InlineAsm/Negative/asm_simple.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "@@\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("syntax error") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_simple.cpp
+++ b/SYCL/InlineAsm/Negative/asm_simple.cpp
@@ -26,7 +26,6 @@ int main() {
   KernelFunctor f;
   launchInlineASMTest(
       f, /* sg size */ true,
-      /* exception is expected */ false,
       /* exception string*/ "syntax error, unexpected $undefined");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_simple.cpp
+++ b/SYCL/InlineAsm/Negative/asm_simple.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,9 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("syntax error") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(
+      f, /* sg size */ true,
+      /* exception is expected */ false,
+      /* exception string*/ "syntax error, unexpected $undefined");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "mov (M1_NM, 8) tmp1(0,1)<1>  my_super_var(0,0)\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("syntax error") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
@@ -26,7 +26,6 @@ int main() {
   KernelFunctor f;
   launchInlineASMTest(
       f, /* sg size */ true,
-      /* exception is expected */ false,
       /* exception string*/ "unexpected NEWLINE, expecting LANGLE");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,9 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("syntax error") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(
+      f, /* sg size */ true,
+      /* exception is expected */ false,
+      /* exception string*/ "unexpected NEWLINE, expecting LANGLE");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       "cmp.lt (M1_NM, 8) P3 tmp1(0,0)<0;1,0> 0x3:ud\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("undefined predicate variable") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,8 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("undefined predicate variable") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(f, /* sg size */ true,
+                      /* exception is expected */ false,
+                      /* exception string*/ "P3: undefined predicate variable");
+  return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
@@ -25,7 +25,6 @@ struct KernelFunctor {
 int main() {
   KernelFunctor f;
   launchInlineASMTest(f, /* sg size */ true,
-                      /* exception is expected */ false,
                       /* exception string*/ "P3: undefined predicate variable");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
+++ b/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
@@ -1,0 +1,40 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -o %t.out
+// TODO: enable the line below once we update NEO driver in our CI
+// RUNx: %t.out
+
+#include "../include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+struct KernelFunctor {
+  KernelFunctor() {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    cgh.parallel_for<KernelFunctor>(
+        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
+                       ".decl TMP v_type=G type=f\n");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor f;
+  try {
+    launchInlineASMTest(f, /* sg size */ true,
+                        /* exception is expected */ true);
+  } catch (const cl::sycl::compile_program_error &e) {
+    std::string what = e.what();
+    // TODO: check for precise exception class and message once they are known
+    // (pending driver update)
+    if (what.find("syntax error") != std::string::npos) {
+      return 0;
+    }
+  }
+  std::cout << "Expected an exception about syntax error" << std::endl;
+  return 1;
+}

--- a/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
+++ b/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
@@ -26,7 +26,6 @@ int main() {
   KernelFunctor f;
   launchInlineASMTest(
       f, /* sg size */ true,
-      /* exception is expected */ false,
       /* exception string*/ "unexpected NEWLINE, expecting NUM_ELTS_EQ");
   return 0;
 }

--- a/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
+++ b/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
@@ -1,8 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
-// TODO: enable the line below once we update NEO driver in our CI
-// RUNx: %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "../include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,7 +11,8 @@ struct KernelFunctor {
 
   void operator()(cl::sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
-        cl::sycl::range<1>{16}, [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        cl::sycl::range<1>{16}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -24,17 +24,9 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  try {
-    launchInlineASMTest(f, /* sg size */ true,
-                        /* exception is expected */ true);
-  } catch (const cl::sycl::compile_program_error &e) {
-    std::string what = e.what();
-    // TODO: check for precise exception class and message once they are known
-    // (pending driver update)
-    if (what.find("syntax error") != std::string::npos) {
-      return 0;
-    }
-  }
-  std::cout << "Expected an exception about syntax error" << std::endl;
-  return 1;
+  launchInlineASMTest(
+      f, /* sg size */ true,
+      /* exception is expected */ false,
+      /* exception string*/ "unexpected NEWLINE, expecting NUM_ELTS_EQ");
+  return 0;
 }

--- a/SYCL/InlineAsm/asm_16_empty.cpp
+++ b/SYCL/InlineAsm/asm_16_empty.cpp
@@ -1,0 +1,43 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+          // clang-format on
+          C[wiID] = 43;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), 43))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_16_empty.cpp
+++ b/SYCL/InlineAsm/asm_16_empty.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,19 +10,17 @@
 
 using dataType = cl::sycl::cl_int;
 
-template <typename T = dataType>
-struct KernelFunctor : WithOutputBuffer<T> {
+template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
           C[wiID] = 43;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("");
 #endif
         });

--- a/SYCL/InlineAsm/asm_16_matrix_mult.cpp
+++ b/SYCL/InlineAsm/asm_16_matrix_mult.cpp
@@ -1,0 +1,47 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+          // clang-format on
+          volatile int output = 0;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d"
+                       : "=rw"(output));
+#else
+          output = 7;
+#endif
+          C[wiID] = output;
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), 7))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_16_matrix_mult.cpp
+++ b/SYCL/InlineAsm/asm_16_matrix_mult.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,21 +10,18 @@
 
 using dataType = cl::sycl::cl_int;
 
-template <typename T = dataType>
-struct KernelFunctor : WithOutputBuffer<T> {
+template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
           volatile int output = 0;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
-          asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d"
-                       : "=rw"(output));
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d" : "=rw"(output));
 #else
           output = 7;
 #endif

--- a/SYCL/InlineAsm/asm_16_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_16_no_input_int.cpp
@@ -1,0 +1,47 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+          // clang-format on
+          volatile int output = 0;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d"
+                       : "=rw"(output));
+#else
+          output = 7;
+#endif
+          C[wiID] = output;
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), 7))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_16_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_16_no_input_int.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,21 +10,18 @@
 
 using dataType = cl::sycl::cl_int;
 
-template <typename T = dataType>
-struct KernelFunctor : WithOutputBuffer<T> {
+template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
           volatile int output = 0;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
-          asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d"
-                       : "=rw"(output));
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d" : "=rw"(output));
 #else
           output = 7;
 #endif

--- a/SYCL/InlineAsm/asm_16_no_opts.cpp
+++ b/SYCL/InlineAsm/asm_16_no_opts.cpp
@@ -1,0 +1,48 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+          // clang-format on
+          for (int i = 0; i < 10; ++i) {
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+            asm("fence_sw");
+            C[wiID] += i;
+
+#else
+            C[wiID] += i;
+#endif
+          }
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), 45))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_16_no_opts.cpp
+++ b/SYCL/InlineAsm/asm_16_no_opts.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,19 +10,17 @@
 
 using dataType = cl::sycl::cl_int;
 
-template <typename T = dataType>
-struct KernelFunctor : WithOutputBuffer<T> {
+template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
           for (int i = 0; i < 10; ++i) {
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
             asm("fence_sw");
             C[wiID] += i;
 

--- a/SYCL/InlineAsm/asm_8_empty.cpp
+++ b/SYCL/InlineAsm/asm_8_empty.cpp
@@ -1,0 +1,43 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+          // clang-format on
+          C[wiID] = 43;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("");
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), 43))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_8_empty.cpp
+++ b/SYCL/InlineAsm/asm_8_empty.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,19 +10,17 @@
 
 using dataType = cl::sycl::cl_int;
 
-template <typename T = dataType>
-struct KernelFunctor : WithOutputBuffer<T> {
+template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
           C[wiID] = 43;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("");
 #endif
         });

--- a/SYCL/InlineAsm/asm_8_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_8_no_input_int.cpp
@@ -1,0 +1,47 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+          // clang-format on
+          volatile int output = 0;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("mov (M1,8) %0(0,0)<1> 0x7:d"
+                       : "=rw"(output));
+#else
+          output = 7;
+#endif
+          C[wiID] = output;
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), 7))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_8_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_8_no_input_int.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,21 +10,18 @@
 
 using dataType = cl::sycl::cl_int;
 
-template <typename T = dataType>
-struct KernelFunctor : WithOutputBuffer<T> {
+template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
           volatile int output = 0;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
-          asm volatile("mov (M1,8) %0(0,0)<1> 0x7:d"
-                       : "=rw"(output));
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("mov (M1,8) %0(0,0)<1> 0x7:d" : "=rw"(output));
 #else
           output = 7;
 #endif

--- a/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
+++ b/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
@@ -1,0 +1,63 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// This test is disabled because there is a bug somewhere either in test or in
+// the inline asm support
+// FIXME: debug an issue and enable test back
+// RUNx: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUNx: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2, const std::vector<T> &input3) : WithInputBuffers<T, 3>(input1, input2, input3), WithOutputBuffer<T>(input1.size()) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getInputBuffer(2).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto D = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("mad (M1, 8) %0(0, 0)<1> %3(0, 0)<1;1,0> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
+              : "=rw"(D[wiID])
+              : "rw"(A[wiID]), "rw"(B[wiID]), "rw"(C[wiID]));
+#else
+          D[wiID] = A[wiID] * B[wiID] + C[wiID];
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE), inputC(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    inputA[i] = i;
+    inputB[i] = i;
+    inputC[i] = DEFAULT_PROBLEM_SIZE - i * i;
+  }
+
+  KernelFunctor<> f(inputA, inputB, inputC);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &D = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; ++i) {
+    if (D[i] != inputA[i] * inputB[i] + inputC[i]) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << D[i] << " != " << inputA[i] * inputB[i] + inputC[i] << "\n";
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
+++ b/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
@@ -1,12 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// This test is disabled because there is a bug somewhere either in test or in
-// the inline asm support
-// FIXME: debug an issue and enable test back
-// RUNx: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUNx: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -17,19 +12,27 @@ using dataType = cl::sycl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2, const std::vector<T> &input3) : WithInputBuffers<T, 3>(input1, input2, input3), WithOutputBuffer<T>(input1.size()) {}
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2,
+                const std::vector<T> &input3)
+      : WithInputBuffers<T, 3>(input1, input2, input3), WithOutputBuffer<T>(
+                                                            input1.size()) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto C = this->getInputBuffer(2).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto D = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getInputBuffer(2)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto D = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
         cl::sycl::range<1>{this->getOutputBufferSize()}, [=
     ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
-          asm("mad (M1, 8) %0(0, 0)<1> %3(0, 0)<1;1,0> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm("mad (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0> %3(0, "
+              "0)<1;1,0>"
               : "=rw"(D[wiID])
               : "rw"(A[wiID]), "rw"(B[wiID]), "rw"(C[wiID]));
 #else
@@ -40,7 +43,8 @@ struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
 };
 
 int main() {
-  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE), inputC(DEFAULT_PROBLEM_SIZE);
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE),
+      inputB(DEFAULT_PROBLEM_SIZE), inputC(DEFAULT_PROBLEM_SIZE);
   for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
     inputA[i] = i;
     inputB[i] = i;

--- a/SYCL/InlineAsm/asm_decl_in_scope.cpp
+++ b/SYCL/InlineAsm/asm_decl_in_scope.cpp
@@ -1,0 +1,69 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(input1.size()) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+    // clang-format on
+    // declaration of temp within and outside the scope
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("{\n"
+              ".decl temp v_type=G type=d num_elts=16 align=GRF\n"
+              "mov (M1, 16) temp(0, 0)<1> %1(0, 0)<1;1,0>\n"
+              "mov (M1, 16) %0(0, 0)<1>  temp(0, 0)<1;1,0>\n"
+              "}\n"
+              ".decl temp v_type=G type=d num_elts=16 align=GRF\n"
+              "mul (M1, 16) temp(0, 0)<1> %2(0, 0)<1;1,0> %0(0, 0)<1;1,0>\n"
+              "mov (M1, 16) %0(0, 0)<1>  temp(0, 0)<1;1,0>\n"
+              : "+rw"(C[wiID])
+              : "rw"(A[wiID]), "rw"(B[wiID]));
+#else
+          C[wiID] = A[wiID];
+          C[wiID] *= B[wiID];
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    inputA[i] = i;
+    inputB[i] = 2;
+  }
+
+  KernelFunctor<> f(inputA, inputB);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &C = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; ++i) {
+    if (C[i] != inputA[i] * inputB[i]) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << C[i] << " != " << inputA[i] * inputB[i] << "\n";
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_decl_in_scope.cpp
+++ b/SYCL/InlineAsm/asm_decl_in_scope.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -14,20 +12,23 @@ using dataType = cl::sycl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(input1.size()) {}
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2)
+      : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(
+                                                    input1.size()) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
-    // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
     // declaration of temp within and outside the scope
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm("{\n"
               ".decl temp v_type=G type=d num_elts=16 align=GRF\n"
               "mov (M1, 16) temp(0, 0)<1> %1(0, 0)<1;1,0>\n"
@@ -47,7 +48,8 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
 };
 
 int main() {
-  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE);
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE),
+      inputB(DEFAULT_PROBLEM_SIZE);
   for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
     inputA[i] = i;
     inputB[i] = 2;

--- a/SYCL/InlineAsm/asm_float_add.cpp
+++ b/SYCL/InlineAsm/asm_float_add.cpp
@@ -1,0 +1,62 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_double;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(input1.size()) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+    // clang-format on
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("add (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
+              : "=rw"(C[wiID])
+              : "rw"(A[wiID]), "rw"(B[wiID]));
+#else
+          C[wiID] = A[wiID] + B[wiID];
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    inputA[i] = (double)1 / std::pow(2, i);
+    inputB[i] = (double)2 / std::pow(2, i);
+  }
+
+  KernelFunctor<> f(inputA, inputB);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &C = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    if (C[i] != inputA[i] + inputB[i]) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << C[i] << " != " << inputA[i] + inputB[i] << "\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_float_add.cpp
+++ b/SYCL/InlineAsm/asm_float_add.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -15,19 +13,22 @@ using dataType = cl::sycl::cl_double;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(input1.size()) {}
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2)
+      : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(
+                                                    input1.size()) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-    // clang-format on
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
           asm("add (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
               : "=rw"(C[wiID])
               : "rw"(A[wiID]), "rw"(B[wiID]));
@@ -39,7 +40,8 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
 };
 
 int main() {
-  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE);
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE),
+      inputB(DEFAULT_PROBLEM_SIZE);
   for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
     inputA[i] = (double)1 / std::pow(2, i);
     inputB[i] = (double)2 / std::pow(2, i);

--- a/SYCL/InlineAsm/asm_float_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_float_imm_arg.cpp
@@ -1,0 +1,57 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+constexpr double IMM_ARGUMENT = 0.5;
+using dataType = cl::sycl::cl_double;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input) : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("mul (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2"
+              : "=rw"(B[wiID])
+              : "rw"(A[wiID]), "i"(IMM_ARGUMENT));
+#else
+          B[wiID] = A[wiID] * IMM_ARGUMENT;
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> input(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++)
+    input[i] = (double)1 / std::pow(2, i);
+
+  KernelFunctor<> f(input);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &B = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; ++i) {
+    if (B[i] != input[i] * IMM_ARGUMENT) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << B[i] << " != " << input[i] * IMM_ARGUMENT << "\n";
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_float_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_float_imm_arg.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -16,16 +14,19 @@ using dataType = cl::sycl::cl_double;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input) : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
+  KernelFunctor(const std::vector<T> &input)
+      : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
         cl::sycl::range<1>{this->getOutputBufferSize()}, [=
     ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm("mul (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2"
               : "=rw"(B[wiID])
               : "rw"(A[wiID]), "i"(IMM_ARGUMENT));

--- a/SYCL/InlineAsm/asm_float_neg.cpp
+++ b/SYCL/InlineAsm/asm_float_neg.cpp
@@ -1,0 +1,60 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_float;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input) : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer().template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+    // clang-format on
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("mov (M1, 8) %0(0, 0)<1> (-)%1(0, 0)<1;1,0>"
+              : "=rw"(B[wiID])
+              : "rw"(A[wiID]));
+#else
+          B[wiID] = -A[wiID];
+#endif
+        });
+  }
+
+  size_t problem_size = 0;
+};
+
+int main() {
+  std::vector<dataType> input(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++)
+    input[i] = 1.0 / i;
+
+  KernelFunctor<> f(input);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &R = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; ++i) {
+    if (R[i] != -input[i]) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << R[i] << " != " << -input[i] << "\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_float_neg.cpp
+++ b/SYCL/InlineAsm/asm_float_neg.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -14,18 +12,19 @@ using dataType = cl::sycl::cl_float;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input) : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
+  KernelFunctor(const std::vector<T> &input)
+      : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer().template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer()
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-    // clang-format on
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
           asm("mov (M1, 8) %0(0, 0)<1> (-)%1(0, 0)<1;1,0>"
               : "=rw"(B[wiID])
               : "rw"(A[wiID]));

--- a/SYCL/InlineAsm/asm_if.cpp
+++ b/SYCL/InlineAsm/asm_if.cpp
@@ -1,0 +1,53 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+using DataType = cl::sycl::cl_int;
+
+template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t ProblemSize) : WithOutputBuffer<T>(ProblemSize) {}
+
+  void operator()(cl::sycl::handler &CGH) {
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(CGH);
+    bool switchField = false;
+    // clang-format off
+    CGH.parallel_for<KernelFunctor<T>>(
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+          // clang-format on
+          int Output = 0;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl P1 v_type=P num_elts=1\n"
+                       "cmp.eq (M1_NM, 8) P1 %1(0,0)<0;1,0> 0x0:b\n"
+                       "(P1) sel (M1_NM, 8) %0(0,0)<1> 0x7:d 0x8:d"
+                       : "=rw"(Output)
+                       : "rw"(switchField));
+
+#else
+          if (switchField == false)
+            Output = 7;
+          else
+            Output = 8;
+#endif
+          C[wiID] = Output;
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> Functor(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(Functor))
+    return 0;
+
+  if (verify_all_the_same(Functor.getOutputBufferData(), 7))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_if.cpp
+++ b/SYCL/InlineAsm/asm_if.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.ref.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -17,13 +15,11 @@ template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
     auto C = this->getOutputBuffer()
                  .template get_access<cl::sycl::access::mode::write>(CGH);
     bool switchField = false;
-    // clang-format off
     CGH.parallel_for<KernelFunctor<T>>(
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
           int Output = 0;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl P1 v_type=P num_elts=1\n"
                        "cmp.eq (M1_NM, 8) P1 %1(0,0)<0;1,0> 0x0:b\n"
                        "(P1) sel (M1_NM, 8) %0(0,0)<1> 0x7:d 0x8:d"

--- a/SYCL/InlineAsm/asm_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_imm_arg.cpp
@@ -1,0 +1,56 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+constexpr int CONST_ARGUMENT = 0xabc;
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input) : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("add (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2"
+              : "=rw"(B[wiID])
+              : "rw"(A[wiID]), "i"(CONST_ARGUMENT));
+#else
+          B[wiID] = A[wiID] + CONST_ARGUMENT;
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> input(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++)
+    input[i] = i;
+
+  KernelFunctor<> f(input);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &B = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; ++i) {
+    if (B[i] != input[i] + CONST_ARGUMENT) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << B[i] << " != " << input[i] + CONST_ARGUMENT << "\n";
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_imm_arg.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -15,16 +13,19 @@ using dataType = cl::sycl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input) : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
+  KernelFunctor(const std::vector<T> &input)
+      : WithInputBuffers<T, 1>(input), WithOutputBuffer<T>(input.size()) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
         cl::sycl::range<1>{this->getOutputBufferSize()}, [=
     ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm("add (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2"
               : "=rw"(B[wiID])
               : "rw"(A[wiID]), "i"(CONST_ARGUMENT));

--- a/SYCL/InlineAsm/asm_loop.cpp
+++ b/SYCL/InlineAsm/asm_loop.cpp
@@ -1,0 +1,82 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using DataType = cl::sycl::cl_int;
+
+template <typename T = DataType>
+struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2)
+      : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(
+                                                    input1.size()) {}
+
+  void operator()(cl::sycl::handler &CGH) {
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(CGH);
+    auto B = this->getInputBuffer(1)
+                 .template get_access<cl::sycl::access::mode::read>(CGH);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(CGH);
+    // clang-format off
+    CGH.parallel_for<KernelFunctor<T>>(
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+// clang-format on
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl P1 v_type=P num_elts=8\n"
+                       ".decl P2 v_type=P num_elts=8\n"
+                       ".decl temp v_type=G type=d num_elts=8 align=dword\n"
+                       "mov (M1, 8) %0(0, 0)<1> 0x0:d\n"
+                       "cmp.le (M1, 8) P1 %1(0,0)<1;1,0> 0x0:d\n"
+                       "(P1) goto (M1, 8) label0\n"
+                       "mov (M1, 8) temp(0,0)<1> 0x0:d\n"
+                       "label1:\n"
+                       "add (M1, 8) temp(0,0)<1> temp(0,0)<1;1,0> 0x1:w\n"
+                       "add (M1, 8) %0(0,0)<1> %0(0,0)<1;1,0> %2(0,0)<1;1,0>\n"
+                       "cmp.lt (M1, 8) P2 temp(0,0)<0;8,1> %1(0,0)<0;8,1>\n"
+                       "(P2) goto (M1, 8) label1\n"
+                       "label0:"
+                       : "+rw"(C[wiID])
+                       : "rw"(A[wiID]), "rw"(B[wiID]));
+#else
+          C[wiID] = 0;
+          for (int i = 0; i < A[wiID]; ++i) {
+            C[wiID] = C[wiID] + B[wiID];
+          }
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<DataType> InputA(DEFAULT_PROBLEM_SIZE),
+      InputB(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    InputA[i] = i;
+    InputB[i] = 2 * i;
+  }
+
+  KernelFunctor<> Functor(InputA, InputB);
+  if (!launchInlineASMTest(Functor))
+    return 0;
+
+  auto &C = Functor.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    if (C[i] != InputA[i] * InputB[i]) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << C[i] << " != " << InputA[i] * InputB[i] << "\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_loop.cpp
+++ b/SYCL/InlineAsm/asm_loop.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.ref.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -26,12 +24,10 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
                  .template get_access<cl::sycl::access::mode::read>(CGH);
     auto C = this->getOutputBuffer()
                  .template get_access<cl::sycl::access::mode::write>(CGH);
-    // clang-format off
     CGH.parallel_for<KernelFunctor<T>>(
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-// clang-format on
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl P1 v_type=P num_elts=8\n"
                        ".decl P2 v_type=P num_elts=8\n"
                        ".decl temp v_type=G type=d num_elts=8 align=dword\n"

--- a/SYCL/InlineAsm/asm_mul.cpp
+++ b/SYCL/InlineAsm/asm_mul.cpp
@@ -1,0 +1,60 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(input1.size()) {}
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+    // clang-format on
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("mul (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
+              : "=rw"(C[wiID])
+              : "rw"(A[wiID]), "rw"(B[wiID]));
+#else
+          C[wiID] = A[wiID] * B[wiID];
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    inputA[i] = i;
+    inputB[i] = DEFAULT_PROBLEM_SIZE - i;
+  }
+
+  KernelFunctor<> f(inputA, inputB);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &C = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; ++i) {
+    if (C[i] != inputA[i] * inputB[i]) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << C[i] << " != " << inputA[i] * inputB[i] << "\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_mul.cpp
+++ b/SYCL/InlineAsm/asm_mul.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -14,18 +12,21 @@ using dataType = cl::sycl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(input1.size()) {}
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2)
+      : WithInputBuffers<T, 2>(input1, input2), WithOutputBuffer<T>(
+                                                    input1.size()) {}
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getInputBuffer(1)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-    // clang-format on
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
           asm("mul (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
               : "=rw"(C[wiID])
               : "rw"(A[wiID]), "rw"(B[wiID]));
@@ -37,7 +38,8 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
 };
 
 int main() {
-  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE);
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE),
+      inputB(DEFAULT_PROBLEM_SIZE);
   for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
     inputA[i] = i;
     inputB[i] = DEFAULT_PROBLEM_SIZE - i;

--- a/SYCL/InlineAsm/asm_multiple_instructions.cpp
+++ b/SYCL/InlineAsm/asm_multiple_instructions.cpp
@@ -1,0 +1,65 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// This test is disabled because there is a bug somewhere either in test or in
+// the inline asm support
+// FIXME: debug an issue and enable test back
+// RUNx: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUNx: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2, const std::vector<T> &input3) : WithInputBuffers<T, 3>(input1, input2, input3), WithOutputBuffer<T>(input1.size()) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getInputBuffer(2).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto D = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+    // clang-format on
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("{\n"
+              "add (M1, 8) %1(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>\n"
+              "add (M1, 8) %1(0, 0)<1> %1(0, 0)<1;1,0> %3(0, 0)<1;1,0>\n"
+              "mov (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0>\n"
+              "}\n"
+              : "=rw"(D[wiID]), "+rw"(A[wiID])
+              : "rw"(B[wiID]), "rw"(C[wiID]));
+#else
+          A[wiID] += B[wiID];
+          A[wiID] += C[wiID];
+          D[wiID] = A[wiID];
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE), inputC(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    inputA[i] = inputB[i] = i;
+    inputC[i] = DEFAULT_PROBLEM_SIZE - 2 * i; // A[i] + B[i] + C[i] = LIST_SIZE
+  }
+
+  KernelFunctor<> f(inputA, inputB, inputC);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), (dataType)DEFAULT_PROBLEM_SIZE))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_multiple_instructions.cpp
+++ b/SYCL/InlineAsm/asm_multiple_instructions.cpp
@@ -1,13 +1,12 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// This test is disabled because there is a bug somewhere either in test or in
-// the inline asm support
-// FIXME: debug an issue and enable test back
-// RUNx: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUNx: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
-
+// RUN: %clangxx -fsycl -DTO_PASS %s -o %t.out.pass
+// RUN: %GPU_RUN_PLACEHOLDER %t.out.pass
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// The test is failing when writing directly to output buffer.
+// If temporary variable is used (see TO_PASS mode) the test succeeded.
+// XFAIL: gpu
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
 #include <iostream>
@@ -17,21 +16,46 @@ using dataType = cl::sycl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2, const std::vector<T> &input3) : WithInputBuffers<T, 3>(input1, input2, input3), WithOutputBuffer<T>(input1.size()) {}
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2,
+                const std::vector<T> &input3)
+      : WithInputBuffers<T, 3>(input1, input2, input3), WithOutputBuffer<T>(
+                                                            input1.size()) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read_write>(cgh);
-    auto B = this->getInputBuffer(1).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto C = this->getInputBuffer(2).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto D = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read_write>(cgh);
+    auto B = this->getInputBuffer(1)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto C = this->getInputBuffer(2)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto D = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-    // clang-format on
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
-          asm("{\n"
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+#if defined(TO_PASS)
+          // The code below passing verification
+          volatile int output = -1;
+
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(
+              "{\n"
+              "add (M1, 8) %1(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>\n"
+              "add (M1, 8) %1(0, 0)<1> %1(0, 0)<1;1,0> %3(0, 0)<1;1,0>\n"
+              "mov (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0>\n"
+              "}\n"
+              : "=rw"(output), "+rw"(A[wiID])
+              : "rw"(B[wiID]), "rw"(C[wiID]));
+#else
+          A[wiID] += B[wiID];
+          A[wiID] += C[wiID];
+          output = A[wiID];
+#endif
+          D[wiID] = output;
+#else
+#if defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("{\n"
               "add (M1, 8) %1(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>\n"
               "add (M1, 8) %1(0, 0)<1> %1(0, 0)<1;1,0> %3(0, 0)<1;1,0>\n"
               "mov (M1, 8) %0(0, 0)<1> %1(0, 0)<1;1,0>\n"
@@ -43,12 +67,14 @@ struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
           A[wiID] += C[wiID];
           D[wiID] = A[wiID];
 #endif
+#endif
         });
   }
 };
 
 int main() {
-  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE), inputC(DEFAULT_PROBLEM_SIZE);
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE),
+      inputB(DEFAULT_PROBLEM_SIZE), inputC(DEFAULT_PROBLEM_SIZE);
   for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
     inputA[i] = inputB[i] = i;
     inputC[i] = DEFAULT_PROBLEM_SIZE - 2 * i; // A[i] + B[i] + C[i] = LIST_SIZE
@@ -58,7 +84,8 @@ int main() {
   if (!launchInlineASMTest(f))
     return 0;
 
-  if (verify_all_the_same(f.getOutputBufferData(), (dataType)DEFAULT_PROBLEM_SIZE))
+  if (verify_all_the_same(f.getOutputBufferData(),
+                          (dataType)DEFAULT_PROBLEM_SIZE))
     return 0;
 
   return 1;

--- a/SYCL/InlineAsm/asm_no_operands.cpp
+++ b/SYCL/InlineAsm/asm_no_operands.cpp
@@ -1,0 +1,37 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+class no_operands_kernel;
+
+int main() {
+  // Creating SYCL queue
+  cl::sycl::queue Queue;
+  cl::sycl::device Device = Queue.get_device();
+
+  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+    std::cout << "Skipping test\n";
+    return 0;
+  }
+  // Size of index space for kernel
+  cl::sycl::range<1> NumOfWorkItems{16};
+
+  // Submitting command group(work) to queue
+  Queue.submit([&](cl::sycl::handler &cgh) {
+    // Executing kernel
+    cgh.parallel_for<no_operands_kernel>(
+        NumOfWorkItems, [=](cl::sycl::id<1> WIid)
+                            [[intel::reqd_sub_group_size(8)]] {
+// clang-format off
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("barrier");
+#endif
+        });
+    // clang-format on
+  });
+}

--- a/SYCL/InlineAsm/asm_no_operands.cpp
+++ b/SYCL/InlineAsm/asm_no_operands.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -14,7 +12,8 @@ int main() {
   cl::sycl::queue Queue;
   cl::sycl::device Device = Queue.get_device();
 
-  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+  if (!isInlineASMSupported(Device) ||
+      !Device.has_extension("cl_intel_required_subgroup_size")) {
     std::cout << "Skipping test\n";
     return 0;
   }
@@ -27,11 +26,9 @@ int main() {
     cgh.parallel_for<no_operands_kernel>(
         NumOfWorkItems, [=](cl::sycl::id<1> WIid)
                             [[intel::reqd_sub_group_size(8)]] {
-// clang-format off
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
-          asm("barrier");
+#if defined(__SYCL_DEVICE_ONLY__)
+                              asm("barrier");
 #endif
-        });
-    // clang-format on
+                            });
   });
 }

--- a/SYCL/InlineAsm/asm_no_output.cpp
+++ b/SYCL/InlineAsm/asm_no_output.cpp
@@ -1,0 +1,50 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+          // clang-format on
+          volatile int local_var = 47;
+          local_var += C[0];
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile("{\n"
+                       ".decl temp v_type=G type=w num_elts=8 align=GRF\n"
+                       "mov (M1,16) temp(0, 0)<1> %0(0,0)<1;1,0>\n"
+                       "}\n" ::"rw"(local_var));
+#else
+          volatile int temp = 0;
+          temp = local_var;
+#endif
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  if (verify_all_the_same(f.getOutputBufferData(), 0))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_no_output.cpp
+++ b/SYCL/InlineAsm/asm_no_output.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -12,20 +10,18 @@
 
 using dataType = cl::sycl::cl_int;
 
-template <typename T = dataType>
-struct KernelFunctor : WithOutputBuffer<T> {
+template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto C = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
           volatile int local_var = 47;
           local_var += C[0];
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("{\n"
                        ".decl temp v_type=G type=w num_elts=8 align=GRF\n"
                        "mov (M1,16) temp(0, 0)<1> %0(0,0)<1;1,0>\n"

--- a/SYCL/InlineAsm/asm_plus_mod.cpp
+++ b/SYCL/InlineAsm/asm_plus_mod.cpp
@@ -1,0 +1,61 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <vector>
+
+using dataType = cl::sycl::cl_int;
+
+template <typename T = dataType>
+struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 1>(input1), WithOutputBuffer<T>(input2) {}
+
+  void operator()(cl::sycl::handler &cgh) {
+    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+
+    cgh.parallel_for<KernelFunctor<T>>(
+        // clang-format off
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+    // clang-format on
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm("add (M1, 16) %0(0, 0)<1> %0(0, 0)<1;1,0> %1(0, 0)<1;1,0>"
+              : "+rw"(B[wiID])
+              : "rw"(A[wiID]));
+#else
+          B[wiID] += A[wiID];
+#endif
+        });
+  }
+};
+
+int main() {
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE), R(DEFAULT_PROBLEM_SIZE);
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
+    inputA[i] = i;
+    inputB[i] = DEFAULT_PROBLEM_SIZE - i;
+    R[i] = inputA[i] + inputB[i];
+  }
+
+  KernelFunctor<> f(inputA, inputB);
+  if (!launchInlineASMTest(f))
+    return 0;
+
+  auto &B = f.getOutputBufferData();
+  for (int i = 0; i < DEFAULT_PROBLEM_SIZE; ++i) {
+    if (B[i] != R[i]) {
+      std::cerr << "At index: " << i << ". ";
+      std::cerr << B[i] << " != " << R[i] << "\n";
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/SYCL/InlineAsm/asm_plus_mod.cpp
+++ b/SYCL/InlineAsm/asm_plus_mod.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -14,18 +12,19 @@ using dataType = cl::sycl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
-  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2) : WithInputBuffers<T, 1>(input1), WithOutputBuffer<T>(input2) {}
+  KernelFunctor(const std::vector<T> &input1, const std::vector<T> &input2)
+      : WithInputBuffers<T, 1>(input1), WithOutputBuffer<T>(input2) {}
 
   void operator()(cl::sycl::handler &cgh) {
-    auto A = this->getInputBuffer(0).template get_access<cl::sycl::access::mode::read>(cgh);
-    auto B = this->getOutputBuffer().template get_access<cl::sycl::access::mode::write>(cgh);
+    auto A = this->getInputBuffer(0)
+                 .template get_access<cl::sycl::access::mode::read>(cgh);
+    auto B = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(cgh);
 
     cgh.parallel_for<KernelFunctor<T>>(
-        // clang-format off
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
-    // clang-format on
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
           asm("add (M1, 16) %0(0, 0)<1> %0(0, 0)<1;1,0> %1(0, 0)<1;1,0>"
               : "+rw"(B[wiID])
               : "rw"(A[wiID]));
@@ -37,7 +36,8 @@ struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
 };
 
 int main() {
-  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE), inputB(DEFAULT_PROBLEM_SIZE), R(DEFAULT_PROBLEM_SIZE);
+  std::vector<dataType> inputA(DEFAULT_PROBLEM_SIZE),
+      inputB(DEFAULT_PROBLEM_SIZE), R(DEFAULT_PROBLEM_SIZE);
   for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++) {
     inputA[i] = i;
     inputB[i] = DEFAULT_PROBLEM_SIZE - i;

--- a/SYCL/InlineAsm/asm_switch.cpp
+++ b/SYCL/InlineAsm/asm_switch.cpp
@@ -1,0 +1,73 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+
+using DataType = cl::sycl::cl_int;
+
+template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
+  KernelFunctor(size_t ProblemSize) : WithOutputBuffer<T>(ProblemSize) {}
+
+  void operator()(cl::sycl::handler &CGH) {
+    auto C = this->getOutputBuffer()
+                 .template get_access<cl::sycl::access::mode::write>(CGH);
+    int switchField = 2;
+    // clang-format off
+    CGH.parallel_for<KernelFunctor<T>>(
+        cl::sycl::range<1>{this->getOutputBufferSize()},
+    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+          // clang-format on
+          int Output = 0;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+          asm volatile(".decl P1 v_type=P num_elts=1\n"
+                       ".decl P2 v_type=P num_elts=1\n"
+                       ".decl P3 v_type=P num_elts=1\n"
+                       "cmp.ne (M1_NM, 8) P1 %1(0,0)<0;1,0> 0x0:d\n"
+                       "(P1) goto (M1, 1) label0\n"
+                       "mov (M1, 8) %0(0,0)<1> 0x9:d\n"
+                       "(P1) goto (M1, 1) label0\n"
+                       "label0:\n"
+                       "cmp.ne (M1_NM, 8) P2 %1(0,0)<0;1,0> 0x1:d\n"
+                       "(P2) goto (M1, 1) label1\n"
+                       "mov (M1, 8) %0(0,0)<1> 0x8:d\n"
+                       "label1:\n"
+                       "cmp.ne (M1_NM, 8) P3 %1(0,0)<0;1,0> 0x2:d\n"
+                       "(P3) goto (M1, 1) label2\n"
+                       "mov (M1, 8) %0(0,0)<1> 0x7:d\n"
+                       "label2:"
+                       : "=rw"(Output)
+                       : "rw"(switchField));
+
+#else
+          switch (switchField) {
+          case 0:
+            Output = 9;
+            break;
+          case 1:
+            Output = 8;
+            break;
+          case 2:
+            Output = 7;
+            break;
+          }
+#endif
+          C[wiID] = Output;
+        });
+  }
+};
+
+int main() {
+  KernelFunctor<> Functor(DEFAULT_PROBLEM_SIZE);
+  if (!launchInlineASMTest(Functor))
+    return 0;
+
+  if (verify_all_the_same(Functor.getOutputBufferData(), 7))
+    return 0;
+
+  return 1;
+}

--- a/SYCL/InlineAsm/asm_switch.cpp
+++ b/SYCL/InlineAsm/asm_switch.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.ref.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -17,13 +15,11 @@ template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
     auto C = this->getOutputBuffer()
                  .template get_access<cl::sycl::access::mode::write>(CGH);
     int switchField = 2;
-    // clang-format off
     CGH.parallel_for<KernelFunctor<T>>(
-        cl::sycl::range<1>{this->getOutputBufferSize()},
-    [=](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
-          // clang-format on
+        cl::sycl::range<1>{this->getOutputBufferSize()}, [=
+    ](cl::sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
           int Output = 0;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl P1 v_type=P num_elts=1\n"
                        ".decl P2 v_type=P num_elts=1\n"
                        ".decl P3 v_type=P num_elts=1\n"

--- a/SYCL/InlineAsm/include/asmhelper.h
+++ b/SYCL/InlineAsm/include/asmhelper.h
@@ -1,0 +1,150 @@
+#include <CL/sycl.hpp>
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+constexpr const size_t DEFAULT_PROBLEM_SIZE = 16;
+
+template <typename T>
+struct WithOutputBuffer {
+  WithOutputBuffer(size_t size) {
+    _output_buffer_data.resize(size);
+    _output_buffer.reset(new cl::sycl::buffer<T>(_output_buffer_data.data(), _output_buffer_data.size()));
+  }
+
+  WithOutputBuffer(const std::vector<T> &data) {
+    _output_buffer_data = data;
+    _output_buffer.reset(new cl::sycl::buffer<T>(_output_buffer_data.data(), _output_buffer_data.size()));
+  }
+
+  const std::vector<T> &getOutputBufferData() {
+    // We cannoe access the data until the buffer is still alive
+    _output_buffer.reset();
+    return _output_buffer_data;
+  }
+
+  size_t getOutputBufferSize() const {
+    return _output_buffer_data.size();
+  }
+
+protected:
+  cl::sycl::buffer<T> &getOutputBuffer() {
+    return *_output_buffer;
+  }
+
+  // Functor is being passed by-copy into cl::sycl::queue::submit and destroyed
+  // one more time in there. We need to make sure that buffer is only released
+  // once.
+  std::shared_ptr<cl::sycl::buffer<T>> _output_buffer = nullptr;
+  std::vector<T> _output_buffer_data;
+};
+
+template <typename T, size_t N>
+struct WithInputBuffers {
+
+  template <typename... Args>
+  WithInputBuffers(Args... inputs) {
+    static_assert(sizeof...(Args) == N, "All input buffers must be initialized");
+    constructorHelper<0>(inputs...);
+  }
+
+  cl::sycl::buffer<T> &getInputBuffer(size_t i = 0) {
+    return *_input_buffers[i];
+  }
+
+protected:
+  std::shared_ptr<cl::sycl::buffer<T>> _input_buffers[N] = {nullptr};
+  std::vector<T> _input_buffers_data[N];
+
+private:
+  template <int Index, typename... Args>
+  void constructorHelper(const std::vector<T> &data, Args... rest) {
+    _input_buffers_data[Index] = data;
+    _input_buffers[Index].reset(new cl::sycl::buffer<T>(_input_buffers_data[Index].data(), _input_buffers_data[Index].size()));
+    _input_buffers[Index]->set_final_data(nullptr);
+    constructorHelper<Index + 1>(rest...);
+  }
+
+  template <int Index>
+  void constructorHelper() {
+    // nothing to do, recursion stop
+  }
+};
+
+bool isInlineASMSupported(sycl::device Device) {
+
+  sycl::string_class DriverVersion = Device.get_info<sycl::info::device::driver_version>();
+  sycl::string_class DeviceVendorName = Device.get_info<sycl::info::device::vendor>();
+  // TODO: query for some extension/capability/whatever once interface is
+  // defined
+  if (DeviceVendorName.find("Intel") == sycl::string_class::npos)
+    return false;
+
+  return true;
+}
+
+auto exception_handler = [](sycl::exception_list exceptions) {
+  for (std::exception_ptr const &e : exceptions) {
+    try {
+      std::rethrow_exception(e);
+    } catch(sycl::exception const &e) {
+      std::cout << "Caught asynchronous SYCL exception:\n"
+                << e.what() << std::endl;
+    }
+  }
+};
+
+template <typename F>
+bool launchInlineASMTestImpl(F &f, bool requires_particular_sg_size = true) {
+  cl::sycl::queue deviceQueue(cl::sycl::gpu_selector{}, exception_handler);
+  cl::sycl::device device = deviceQueue.get_device();
+
+#if defined(INLINE_ASM)
+  if (!isInlineASMSupported(device)) {
+    std::cout << "Skipping test\n";
+    return false;
+  }
+#endif
+
+  if (requires_particular_sg_size &&
+      !device.has_extension("cl_intel_required_subgroup_size")) {
+    std::cout << "Skipping test\n";
+    return false;
+  }
+
+  deviceQueue.submit(f).wait_and_throw();
+
+  return true;
+}
+
+/// checks if device suppots inline asm feature and launches a test
+///
+/// \returns false if test wasn't launched (i.e.was skipped) and true otherwise
+template <typename F>
+bool launchInlineASMTest(F &f, bool requires_particular_sg_size = true,
+                         bool need_to_throw_exception = false) {
+  if (need_to_throw_exception) {
+    return launchInlineASMTestImpl(f, requires_particular_sg_size);
+  } else {
+    bool result = false;
+    try {
+      result = launchInlineASMTestImpl(f, requires_particular_sg_size);
+    } catch (cl::sycl::exception &e) {
+      std::cerr << "Caught exception: " << e.what() << std::endl;
+    }
+
+    return result;
+  }
+}
+
+template <typename T>
+bool verify_all_the_same(const std::vector<T> &input, T reference_value) {
+  for (int i = 0; i < input.size(); ++i)
+    if (input[i] != reference_value) {
+      std::cerr << "At index: " << i << " ";
+      std::cerr << input[i] << " != " << reference_value << "\n";
+      return false;
+    }
+  return true;
+}

--- a/SYCL/InlineAsm/include/asmhelper.h
+++ b/SYCL/InlineAsm/include/asmhelper.h
@@ -129,8 +129,8 @@ bool launchInlineASMTest(F &f, bool requires_particular_sg_size = true,
       if (what.find(exception_string) != std::string::npos) {
         std::cout << "Caught expected exception: " << what << std::endl;
       } else {
-        std::cout << "Failed to catch expected exception: "
-                  << exception_string << std::endl;
+        std::cout << "Failed to catch expected exception: " << exception_string
+                  << std::endl;
         throw e;
       }
     } else {

--- a/SYCL/InlineAsm/include/asmhelper.h
+++ b/SYCL/InlineAsm/include/asmhelper.h
@@ -119,31 +119,26 @@ bool launchInlineASMTestImpl(F &f, bool requires_particular_sg_size = true) {
 /// \returns false if test wasn't launched (i.e.was skipped) and true otherwise
 template <typename F>
 bool launchInlineASMTest(F &f, bool requires_particular_sg_size = true,
-                         bool need_to_throw_exception = false,
                          std::string exception_string = "") {
-  if (need_to_throw_exception) {
-    return launchInlineASMTestImpl(f, requires_particular_sg_size);
-  } else {
-    bool result = false;
-    try {
-      result = launchInlineASMTestImpl(f, requires_particular_sg_size);
-    } catch (cl::sycl::exception &e) {
-      std::string what = e.what();
-      if (!exception_string.empty()) {
-        if (what.find(exception_string) != std::string::npos) {
-          std::cout << "Caught expected exception: " << what << std::endl;
-        } else {
-          std::cout << "Failed to catch expected exception: "
-                    << exception_string << std::endl;
-          throw e;
-        }
+  bool result = false;
+  try {
+    result = launchInlineASMTestImpl(f, requires_particular_sg_size);
+  } catch (cl::sycl::exception &e) {
+    std::string what = e.what();
+    if (!exception_string.empty()) {
+      if (what.find(exception_string) != std::string::npos) {
+        std::cout << "Caught expected exception: " << what << std::endl;
       } else {
-        std::cout << "Caught unexpected exception: " << std::endl;
+        std::cout << "Failed to catch expected exception: "
+                  << exception_string << std::endl;
         throw e;
       }
+    } else {
+      std::cout << "Caught unexpected exception: " << std::endl;
+      throw e;
     }
-    return result;
   }
+  return result;
 }
 
 template <typename T>

--- a/SYCL/InlineAsm/letter_example.cpp
+++ b/SYCL/InlineAsm/letter_example.cpp
@@ -1,0 +1,70 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+
+constexpr size_t problem_size = 16;
+
+class kernel_name;
+
+int main() {
+  cl::sycl::queue q;
+  cl::sycl::device Device = q.get_device();
+
+  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+    std::cout << "Skipping test\n";
+    return 0;
+  }
+  auto ctx = q.get_context();
+  int *a = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  for (int i = 0; i < problem_size; i++) {
+    a[i] = i;
+  }
+  q.submit([&](cl::sycl::handler &cgh) {
+     cgh.parallel_for<kernel_name>(
+         // clang-format off
+         cl::sycl::range<1>(problem_size),
+     [=](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
+    // clang-format on
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+                                                 int i = idx[0];
+                                                 asm volatile("{\n.decl V52 v_type=G type=d num_elts=16 align=GRF\n"
+                                                              "svm_gather.4.1 (M1, 16) %0.0 V52.0\n"
+                                                              "add(M1, 16) V52(0, 0)<1> V52(0, 0)<1; 1, 0> 0x1:w\n"
+                                                              "svm_scatter.4.1 (M1, 16) %0.0 V52.0\n}"
+                                                              :
+                                                              : "rw"(&a[i]));
+#else
+           // clang-format off
+                                                 a[idx[0]]++;
+      // clang-format on
+#endif
+                                               });
+   }).wait();
+
+  bool currect = true;
+  for (int i = 0; i < problem_size; i++) {
+    if (a[i] != (i + 1)) {
+      currect = false;
+      std::cerr << "error in a[" << i << "]="
+                << a[i] << "!=" << (i + 1) << std::endl;
+      break;
+    }
+  }
+
+  if (!currect) {
+    std::cerr << "Error" << std::endl;
+    cl::sycl::free(a, ctx);
+    return 1;
+  }
+
+  std::cerr << "Pass" << std::endl;
+  cl::sycl::free(a, ctx);
+  return 0;
+}

--- a/SYCL/InlineAsm/letter_example.cpp
+++ b/SYCL/InlineAsm/letter_example.cpp
@@ -1,9 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
-// RUN: %clangxx -fsycl %s -o %t.ref.out
-// RUN: %t.ref.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -17,43 +15,41 @@ int main() {
   cl::sycl::queue q;
   cl::sycl::device Device = q.get_device();
 
-  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+  if (!isInlineASMSupported(Device) ||
+      !Device.has_extension("cl_intel_required_subgroup_size")) {
     std::cout << "Skipping test\n";
     return 0;
   }
   auto ctx = q.get_context();
-  int *a = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  int *a =
+      (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
   for (int i = 0; i < problem_size; i++) {
     a[i] = i;
   }
   q.submit([&](cl::sycl::handler &cgh) {
      cgh.parallel_for<kernel_name>(
-         // clang-format off
-         cl::sycl::range<1>(problem_size),
-     [=](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
-    // clang-format on
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
-                                                 int i = idx[0];
-                                                 asm volatile("{\n.decl V52 v_type=G type=d num_elts=16 align=GRF\n"
-                                                              "svm_gather.4.1 (M1, 16) %0.0 V52.0\n"
-                                                              "add(M1, 16) V52(0, 0)<1> V52(0, 0)<1; 1, 0> 0x1:w\n"
-                                                              "svm_scatter.4.1 (M1, 16) %0.0 V52.0\n}"
-                                                              :
-                                                              : "rw"(&a[i]));
+         cl::sycl::range<1>(problem_size), [=
+     ](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
+#if defined(__SYCL_DEVICE_ONLY__)
+           int i = idx[0];
+           asm volatile("{\n.decl V52 v_type=G type=d num_elts=16 align=GRF\n"
+                        "svm_gather.4.1 (M1, 16) %0.0 V52.0\n"
+                        "add(M1, 16) V52(0, 0)<1> V52(0, 0)<1; 1, 0> 0x1:w\n"
+                        "svm_scatter.4.1 (M1, 16) %0.0 V52.0\n}"
+                        :
+                        : "rw"(&a[i]));
 #else
-           // clang-format off
                                                  a[idx[0]]++;
-      // clang-format on
 #endif
-                                               });
+         });
    }).wait();
 
   bool currect = true;
   for (int i = 0; i < problem_size; i++) {
     if (a[i] != (i + 1)) {
       currect = false;
-      std::cerr << "error in a[" << i << "]="
-                << a[i] << "!=" << (i + 1) << std::endl;
+      std::cerr << "error in a[" << i << "]=" << a[i] << "!=" << (i + 1)
+                << std::endl;
       break;
     }
   }

--- a/SYCL/InlineAsm/malloc_shared_32.cpp
+++ b/SYCL/InlineAsm/malloc_shared_32.cpp
@@ -1,0 +1,95 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+
+constexpr size_t problem_size = 32;
+
+class kernel_name;
+
+int main() {
+  cl::sycl::queue q;
+
+  cl::sycl::device Device = q.get_device();
+
+  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+    std::cout << "Skipping test\n";
+    return 0;
+  }
+
+  auto ctx = q.get_context();
+  int *a = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  int *b = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  int *c = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  for (int i = 0; i < problem_size; i++) {
+    b[i] = -10;
+    a[i] = i;
+    c[i] = i;
+  }
+
+  q.submit([&](cl::sycl::handler &cgh) {
+     cgh.parallel_for<kernel_name>(
+         // clang-format off
+         cl::sycl::range<1>(problem_size),
+     [=](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(32)]] {
+           // clang-format on
+           int i = idx[0];
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+           asm volatile(R"a(
+    {
+        .decl V52 v_type=G type=d num_elts=16 align=GRF
+        .decl V53 v_type=G type=d num_elts=16 align=GRF
+        .decl V54 v_type=G type=d num_elts=16 align=GRF
+        .decl V55 v_type=G type=d num_elts=16 align=GRF
+        .decl V56 v_type=G type=d num_elts=16 align=GRF
+        .decl V57 v_type=G type=d num_elts=16 align=GRF
+        svm_gather.4.1 (M1, 16) %2.0 V54.0
+        svm_gather.4.1 (M1, 16) %3.0 V55.0
+        svm_gather.4.1 (M1, 16) %4.0 V56.0
+        svm_gather.4.1 (M1, 16) %5.0 V57.0
+        mul (M1, 16) V52(0,0)<1> V54(0,0)<1;1,0> V56(0,0)<1;1,0>
+        mul (M1, 16) V53(0,0)<1> V55(0,0)<1;1,0> V57(0,0)<1;1,0>
+        svm_scatter.4.1 (M1, 16) %0.0 V52.0
+        svm_scatter.4.1 (M1, 16) %1.0 V53.0
+    }
+    )a" ::"rw"(&b[i]),
+                        // clang-format off
+                            "rw"(&b[i] + 16), "rw"(&a[i]), "rw"(&a[i] + 16), "rw"(&c[i]),
+                            "rw"(&c[i] + 16));
+#else
+               b[i] = a[i] * c[i];
+#endif
+             });
+   }).wait();
+
+  // clang-format on
+  bool currect = true;
+  for (int i = 0; i < problem_size; i++) {
+    if (b[i] != a[i] * c[i]) {
+      currect = false;
+      std::cerr << "error in a[" << i << "]=" << b[i] << "!=" << a[i] * c[i]
+                << std::endl;
+      break;
+    }
+  }
+
+  if (!currect) {
+    std::cerr << "Error" << std::endl;
+    cl::sycl::free(a, ctx);
+    cl::sycl::free(b, ctx);
+    cl::sycl::free(c, ctx);
+    return 1;
+  }
+
+  std::cerr << "Pass" << std::endl;
+  cl::sycl::free(a, ctx);
+  cl::sycl::free(b, ctx);
+  cl::sycl::free(c, ctx);
+  return 0;
+}

--- a/SYCL/InlineAsm/malloc_shared_in_out_dif.cpp
+++ b/SYCL/InlineAsm/malloc_shared_in_out_dif.cpp
@@ -1,0 +1,72 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+
+constexpr size_t problem_size = 100;
+
+class kernel_name;
+
+int main() {
+  cl::sycl::queue q;
+
+  cl::sycl::device Device = q.get_device();
+
+  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+    std::cout << "Skipping test\n";
+    return 0;
+  }
+
+  auto ctx = q.get_context();
+  int *a = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  int *b = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  for (int i = 0; i < problem_size; i++) {
+    b[i] = -1;
+    a[i] = i;
+  }
+
+  q.submit([&](cl::sycl::handler &cgh) {
+     cgh.parallel_for<kernel_name>(
+         // clang-format off
+         cl::sycl::range<1>(problem_size),
+     [=](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
+           // clang-format on
+           int i = idx[0];
+           volatile int tmp = a[i];
+           tmp += 1;
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+           asm volatile(" add (M1, 16) %0(0,0)<1> %0(0,0)<1;1,0> %1(0,0)<1;1,0>"
+                        : "+rw"(b[i])
+                        : "rw"(tmp));
+#else
+           b[i] += tmp;
+#endif
+         });
+   }).wait();
+
+  bool currect = true;
+  for (int i = 0; i < problem_size; i++) {
+    if (b[i] != a[i]) {
+      currect = false;
+      std::cerr << "error in a[" << i << "]="
+                << b[i] << "!=" << a[i] << std::endl;
+      break;
+    }
+  }
+
+  if (!currect) {
+    std::cerr << "Error" << std::endl;
+    cl::sycl::free(a, ctx);
+    cl::sycl::free(b, ctx);
+    return 1;
+  }
+
+  std::cerr << "Pass" << std::endl;
+  cl::sycl::free(a, ctx);
+  cl::sycl::free(b, ctx);
+  return 0;
+}

--- a/SYCL/InlineAsm/malloc_shared_in_out_dif.cpp
+++ b/SYCL/InlineAsm/malloc_shared_in_out_dif.cpp
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda
 // REQUIRES: gpu,linux
-// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
-// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
@@ -16,14 +16,17 @@ int main() {
 
   cl::sycl::device Device = q.get_device();
 
-  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+  if (!isInlineASMSupported(Device) ||
+      !Device.has_extension("cl_intel_required_subgroup_size")) {
     std::cout << "Skipping test\n";
     return 0;
   }
 
   auto ctx = q.get_context();
-  int *a = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
-  int *b = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  int *a =
+      (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  int *b =
+      (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
   for (int i = 0; i < problem_size; i++) {
     b[i] = -1;
     a[i] = i;
@@ -31,14 +34,12 @@ int main() {
 
   q.submit([&](cl::sycl::handler &cgh) {
      cgh.parallel_for<kernel_name>(
-         // clang-format off
-         cl::sycl::range<1>(problem_size),
-     [=](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
-           // clang-format on
+         cl::sycl::range<1>(problem_size), [=
+     ](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
            int i = idx[0];
            volatile int tmp = a[i];
            tmp += 1;
-#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+#if defined(__SYCL_DEVICE_ONLY__)
            asm volatile(" add (M1, 16) %0(0,0)<1> %0(0,0)<1;1,0> %1(0,0)<1;1,0>"
                         : "+rw"(b[i])
                         : "rw"(tmp));
@@ -52,8 +53,8 @@ int main() {
   for (int i = 0; i < problem_size; i++) {
     if (b[i] != a[i]) {
       currect = false;
-      std::cerr << "error in a[" << i << "]="
-                << b[i] << "!=" << a[i] << std::endl;
+      std::cerr << "error in a[" << i << "]=" << b[i] << "!=" << a[i]
+                << std::endl;
       break;
     }
   }

--- a/SYCL/InlineAsm/malloc_shared_no_input.cpp
+++ b/SYCL/InlineAsm/malloc_shared_no_input.cpp
@@ -1,0 +1,64 @@
+// UNSUPPORTED: cuda
+// REQUIRES: gpu,linux
+// RUN: %clangxx -fsycl %s -DINLINE_ASM -o %t.out
+// RUN: %t.out
+// RUN: %clangxx -fsycl %s -o %t.ref.out
+// RUN: %t.ref.out
+
+#include "include/asmhelper.h"
+#include <CL/sycl.hpp>
+#include <iostream>
+
+constexpr size_t problem_size = 16;
+
+class kernel_name;
+
+int main() {
+  cl::sycl::queue q;
+  cl::sycl::device Device = q.get_device();
+
+  if (!isInlineASMSupported(Device) || !Device.has_extension("cl_intel_required_subgroup_size")) {
+    std::cout << "Skipping test\n";
+    return 0;
+  }
+  auto ctx = q.get_context();
+  int *a = (int *)malloc_shared(sizeof(int) * problem_size, q.get_device(), ctx);
+  for (int i = 0; i < problem_size; i++)
+    a[i] = i;
+
+  q.submit([&](cl::sycl::handler &cgh) {
+     cgh.parallel_for<kernel_name>(
+         // clang-format off
+         cl::sycl::range<1>(problem_size),
+     [=](cl::sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
+           // clang-format on
+           int i = idx[0];
+#if defined(INLINE_ASM) && defined(__SYCL_DEVICE_ONLY__)
+           asm volatile("mov (M1, 16) %0(0,0)<1> 0x7:d"
+                        : "=rw"(a[i]));
+#else
+           a[i] = 7;
+#endif
+         });
+   }).wait();
+
+  bool currect = true;
+  for (int i = 0; i < problem_size; i++) {
+    if (a[i] != 7) {
+      currect = false;
+      std::cerr << "error in a[" << i << "]="
+                << a[i] << "!=" << 7 << std::endl;
+      break;
+    }
+  }
+
+  if (!currect) {
+    std::cerr << "Error" << std::endl;
+    cl::sycl::free(a, ctx);
+    return 1;
+  }
+
+  std::cerr << "Pass" << std::endl;
+  cl::sycl::free(a, ctx);
+  return 0;
+}


### PR DESCRIPTION
The first commit in review matches unchanged tests from intel/llvm repository. The next commits are changes done to match llvm-test-suite requirements:
 - enable all disabled tests;
 - fix failing tests;
 - disable execution on non-GPU as it is skipped due to missed support on other devices;
 - apply clang-format;
 - fix test issue in asm_arbitrary_ops_order.cpp;
 - XFAIL asm_multiple_instructions.cpp.