### PR TITLE
[SYCL][ESIMD] Fixed mandelbrot tests on Windows

### DIFF
--- a/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
   }
 
   char *out_file = argv[1];
-  FILE *dumpfile = fopen(out_file, "w");
+  FILE *dumpfile = fopen(out_file, "wb");
   if (!dumpfile) {
     std::cerr << "Cannot open " << out_file << std::endl;
     return -2;

--- a/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
   }
 
   char *out_file = argv[1];
-  FILE *dumpfile = fopen(out_file, "w");
+  FILE *dumpfile = fopen(out_file, "wb");
   if (!dumpfile) {
     std::cerr << "Cannot open " << out_file << std::endl;
     return -2;


### PR DESCRIPTION
On Windows \n (\x0a) translates into CRLF.