### PR TITLE
[SYCL] Fix test build with MS VS 2019

### DIFF
--- a/SYCL/Regression/get_subgroup_sizes.cpp
+++ b/SYCL/Regression/get_subgroup_sizes.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl.hpp>
+#include <algorithm>
 
 using namespace cl::sycl;
 


### PR DESCRIPTION
Header include is missed for std::max_element. The problem is exposed
only for MS VS 2019