### PR TITLE
Reenable matrix_transpose_glb.cpp

### DIFF
--- a/SYCL/ESIMD/matrix_transpose_glb.cpp
+++ b/SYCL/ESIMD/matrix_transpose_glb.cpp
@@ -9,7 +9,6 @@
 // REQUIRES: linux && gpu && opencl
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
-// XFAIL: linux
 
 #include "esimd_test_utils.hpp"
 


### PR DESCRIPTION
Regression was fixed in a newer version of the NEO runtime.