### PR TITLE
[SYCL] Enable function pointers tests back for L0

### DIFF
--- a/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
+++ b/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
@@ -1,7 +1,6 @@
 // UNSUPPORTED: windows
-// UNSUPPORTED: cuda || level_zero
+// UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
-// Hangs on level zero
 
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
+++ b/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
@@ -1,7 +1,6 @@
 // UNSUPPORTED: windows
-// UNSUPPORTED: cuda || level_zero
+// UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
-// Hangs on level zero
 
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This patch enables function pointers tests back for Level Zero backend
after fix in Level Zero runtime which resolves hang.