### PR TITLE
[SYCL] Add possibility to specify DPC++ RT directory

### DIFF
--- a/SYCL/README.md
+++ b/SYCL/README.md
@@ -56,9 +56,9 @@ argument to for the lit-runner.py script.
 ***CMAKE_CXX_COMPILER*** should point to the SYCL compiler
 
 ***SYCL_RT_LIBRARY_DIR*** (optional) if present sets location for DPC++ runtime
- libraries to be used on the test execution. The test built is done with
- libraries which are part of the DPC++ compiler. This parameter can be used to
- verify DPC++ compiler and runtime cross-build compatibility.
+ libraries to be used during tests execution. Tests are built with libraries
+ which are part of the DPC++ compiler. This parameter can be used to verify
+ DPC++ compiler and runtime cross-build compatibility.
 
 ***SYCL_TARGET_DEVICES*** defines comma separated target device types (default
 value is cpu,gpu,acc,host). Supported target_devices values are:
@@ -147,8 +147,8 @@ ninja check
    added to test environment. Can be also set by LIT_EXTRA_ENVIRONMENT variable
    in cmake.
  * **sycl_rt_library_dir** - the directory containing SYCL libraries to be used
-   for SYCL applications execution. This parameter can be used to verify SYCL
-   compiler and runtime cross-build compatibility.
+   for SYCL tests execution. This parameter can be used to verify SYCL compiler
+   and runtime cross-build compatibility.
 
 # LIT features which can be used to configure test execution:
  * **windows**, **linux** - host OS;

--- a/SYCL/README.md
+++ b/SYCL/README.md
@@ -36,7 +36,7 @@ llvm-lit . --show-tests
 llvm-lit <path_to_test>
 # Run tests with parameters
 llvm-lit --param target_devices=host,gpu --param sycl_be=PI_LEVEL_ZERO \
-        --param dpcpp_compiler=path/to/clang++ --param dump_ir=True .
+        --param sycl_compiler=path/to/clang++ --param dump_ir=True .
 ```
 
 Notes:
@@ -53,9 +53,9 @@ available in the same directory with llvm-lit.
 It is possible to change test scope by specifying test directory/file in first
 argument to for the lit-runner.py script.
 
-***CMAKE_CXX_COMPILER*** should point to the DPCPP compiler
+***CMAKE_CXX_COMPILER*** should point to the SYCL compiler
 
-***DPCPP_RT_LIBRARY_DIR*** (optional) if present sets location for DPC++ runtime
+***SYCL_RT_LIBRARY_DIR*** (optional) if present sets location for DPC++ runtime
  libraries to be used on the test execution. The test built is done with
  libraries which are part of the DPC++ compiler. This parameter can be used to
  verify DPC++ compiler and runtime cross-build compatibility.
@@ -138,7 +138,7 @@ ninja check
 ```
 
 # LIT parameters accepted by LIT executor:
- * **dpcpp_compiler** - full path to dpcpp compiler;
+ * **sycl_compiler** - full path to SYCL compiler;
  * **target_devices** - comma-separated list of target devices (cpu, gpu, acc,
    host);
  * **sycl_be** - SYCL backend to be used (PI_OPENCL, PI_LEVEL_ZERO, PI_CUDA);
@@ -146,9 +146,9 @@ ninja check
  * **extra_environment** - comma-separated list of variables with values to be
    added to test environment. Can be also set by LIT_EXTRA_ENVIRONMENT variable
    in cmake.
- * **dpcpp_rt_library_dir** - the directory containing DPC++ libraries to be
-   used for DPC++ applications execution. This parameter can be used to verify
-   DPC++ compiler and runtime cross-build compatibility.
+ * **sycl_rt_library_dir** - the directory containing SYCL libraries to be used
+   for SYCL applications execution. This parameter can be used to verify SYCL
+   compiler and runtime cross-build compatibility.
 
 # LIT features which can be used to configure test execution:
  * **windows**, **linux** - host OS;

--- a/SYCL/README.md
+++ b/SYCL/README.md
@@ -55,6 +55,11 @@ argument to for the lit-runner.py script.
 
 ***CMAKE_CXX_COMPILER*** should point to the DPCPP compiler
 
+***DPCPP_RT_LIBRARY_DIR*** (optional) if present sets location for DPC++ runtime
+ libraries to be used on the test execution. The test built is done with
+ libraries which are part of the DPC++ compiler. This parameter can be used to
+ verify DPC++ compiler and runtime cross-build compatibility.
+
 ***SYCL_TARGET_DEVICES*** defines comma separated target device types (default
 value is cpu,gpu,acc,host). Supported target_devices values are:
  - **cpu**  - CPU device available in OpenCL backend only;
@@ -134,13 +139,16 @@ ninja check
 
 # LIT parameters accepted by LIT executor:
  * **dpcpp_compiler** - full path to dpcpp compiler;
- * **target_device** - comma-separated list of target devices (cpu, gpu, acc,
+ * **target_devices** - comma-separated list of target devices (cpu, gpu, acc,
    host);
  * **sycl_be** - SYCL backend to be used (PI_OPENCL, PI_LEVEL_ZERO, PI_CUDA);
  * **dump_ir** - if IR dumping is supported for compiler (True, False);
  * **extra_environment** - comma-separated list of variables with values to be
    added to test environment. Can be also set by LIT_EXTRA_ENVIRONMENT variable
    in cmake.
+ * **dpcpp_rt_library_dir** - the directory containing DPC++ libraries to be
+   used for DPC++ applications execution. This parameter can be used to verify
+   DPC++ compiler and runtime cross-build compatibility.
 
 # LIT features which can be used to configure test execution:
  * **windows**, **linux** - host OS;

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -106,7 +106,7 @@ if "opencl" in config.available_features:
                                   ' ' + '-fsycl-explicit-simd' + ' ' +
                                   config.cxx_flags ) )
 
-config.substitutions.append( ('%clangxx', ' '+ config.syclcompiler + ' ' + config.cxx_flags ) )
+config.substitutions.append( ('%clangxx', ' '+ config.sycl_compiler + ' ' + config.cxx_flags ) )
 config.substitutions.append( ('%clang', ' ' + config.sycl_compiler + ' ' + config.c_flags ) )
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -50,6 +50,8 @@ elif platform.system() == "Windows":
     config.available_features.add('windows')
     llvm_config.with_system_environment('PATH')
     llvm_config.with_environment('PATH', config.sycl_libs_dir, append_path=True)
+    llvm_config.with_system_environment('LIB')
+    llvm_config.with_environment('LIB', os.path.join(config.sycl_root_dir, 'lib'), append_path=True)
 
 elif platform.system() == "Darwin":
     # FIXME: surely there is a more elegant way to instantiate the Xcode directories.

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -49,7 +49,6 @@ if platform.system() == "Linux":
 elif platform.system() == "Windows":
     config.available_features.add('windows')
     llvm_config.with_system_environment('LIB')
-    llvm_config.with_environment('LIB', config.sycl_libs_dir, append_path=True)
     llvm_config.with_environment('PATH', config.sycl_libs_dir, append_path=True)
     llvm_config.with_environment('LIB', os.path.join(config.dpcpp_root_dir, 'lib'), append_path=True)
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -48,9 +48,8 @@ if platform.system() == "Linux":
 
 elif platform.system() == "Windows":
     config.available_features.add('windows')
-    llvm_config.with_system_environment('LIB')
+    llvm_config.with_system_environment('PATH')
     llvm_config.with_environment('PATH', config.sycl_libs_dir, append_path=True)
-    llvm_config.with_environment('LIB', os.path.join(config.dpcpp_root_dir, 'lib'), append_path=True)
 
 elif platform.system() == "Darwin":
     # FIXME: surely there is a more elegant way to instantiate the Xcode directories.
@@ -103,12 +102,12 @@ else:
 if "opencl" in config.available_features:
     esimd_run_substitute = " env SYCL_BE=PI_OPENCL SYCL_DEVICE_TYPE=GPU SYCL_PROGRAM_COMPILE_OPTIONS=-vc-codegen"
     config.substitutions.append( ('%ESIMD_RUN_PLACEHOLDER',  esimd_run_substitute) )
-    config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
+    config.substitutions.append( ('%clangxx-esimd',  config.sycl_compiler +
                                   ' ' + '-fsycl-explicit-simd' + ' ' +
                                   config.cxx_flags ) )
 
-config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
-config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
+config.substitutions.append( ('%clangxx', ' '+ config.syclcompiler + ' ' + config.cxx_flags ) )
+config.substitutions.append( ('%clang', ' ' + config.sycl_compiler + ' ' + config.c_flags ) )
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 
 

--- a/SYCL/lit.site.cfg.py.in
+++ b/SYCL/lit.site.cfg.py.in
@@ -4,19 +4,19 @@ import sys
 import platform
 
 
-config.dpcpp_compiler = lit_config.params.get("dpcpp_compiler", "@CMAKE_CXX_COMPILER@")
-config.dpcpp_root_dir= os.path.dirname(os.path.dirname(config.dpcpp_compiler))
+config.sycl_compiler = lit_config.params.get("sycl_compiler", "@CMAKE_CXX_COMPILER@")
+config.sycl_root_dir= os.path.dirname(os.path.dirname(config.sycl_compiler))
 
-config.llvm_tools_dir = os.path.join(config.dpcpp_root_dir, 'bin')
+config.llvm_tools_dir = os.path.join(config.sycl_root_dir, 'bin')
 config.lit_tools_dir = os.path.dirname("@TEST_SUITE_LIT@")
 config.dump_ir_supported = lit_config.params.get("dump_ir", ("@DUMP_IR_SUPPORTED@" if "@DUMP_IR_SUPPORTED@" else False))
 config.sycl_tools_dir = config.llvm_tools_dir
-config.sycl_include = os.path.join(config.dpcpp_root_dir, 'include', 'sycl')
+config.sycl_include = os.path.join(config.sycl_root_dir, 'include', 'sycl')
 config.sycl_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
-config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.system() == "Windows" else 'lib'))
+config.sycl_libs_dir =  os.path.join(config.sycl_root_dir, ('bin' if platform.system() == "Windows" else 'lib'))
 # Use DPC++ RT library different from the one in compiler build if
 # corresponding LIT or CMake parameter is present.
-config.sycl_libs_dir = lit_config.params.get("dpcpp_rt_library_dir", "@DPCPP_RT_LIBRARY_DIR@" if "@DPCPP_RT_LIBRARY_DIR@" else config.sycl_libs_dir)
+config.sycl_libs_dir = lit_config.params.get("sycl_rt_library_dir", "@SYCL_RT_LIBRARY_DIR@" if "@SYCL_RT_LIBRARY_DIR@" else config.sycl_libs_dir)
 config.target_triple = "x86_64-unknown-unknown-gnu"
 config.host_triple = "x86_64-unknown-unknown-gnu" 
 

--- a/SYCL/lit.site.cfg.py.in
+++ b/SYCL/lit.site.cfg.py.in
@@ -14,6 +14,9 @@ config.sycl_tools_dir = config.llvm_tools_dir
 config.sycl_include = os.path.join(config.dpcpp_root_dir, 'include', 'sycl')
 config.sycl_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
 config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.system() == "Windows" else 'lib'))
+# Use DPC++ RT library different from the one in compiler build if
+# corresponding LIT or CMake parameter is present.
+config.sycl_libs_dir = lit_config.params.get("dpcpp_rt_library_dir", "@DPCPP_RT_LIBRARY_DIR@" if "@DPCPP_RT_LIBRARY_DIR@" else config.sycl_libs_dir)
 config.target_triple = "x86_64-unknown-unknown-gnu"
 config.host_triple = "x86_64-unknown-unknown-gnu" 
 


### PR DESCRIPTION
The libraries in the specified RT directory will be used when a DPC++
test is executed. The DPC++ test build is done with libraries which
are part of DPC++ compiler. These parameters allow to verify DPC++
compiler and runtime cross-build compatibility.