### PR TITLE
Remove use of deprecated environment variables (SYCL_BE,

### DIFF
--- a/SYCL/Basic/device_code_dae.cpp
+++ b/SYCL/Basic/device_code_dae.cpp
@@ -11,7 +11,7 @@
 // RUN: clang-offload-wrapper -o wrapper.bc -host=x86_64 -kind=sycl -target=spir64 -batch table.txt
 // RUN: %clangxx -c wrapper.bc -o wrapper.o
 // RUN: %clangxx wrapper.o host_code.o -o app.exe -lsycl
-// RUN: env SYCL_BE=%sycl_be ./app.exe
+// RUN: %BE_RUN_PLACEHOLDER ./app.exe
 
 //==---------device_code_dae.cpp - dead argument elimination test ----------==//
 //

--- a/SYCL/Basic/fpga_tests/fpga_aocx.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx.cpp
@@ -21,5 +21,5 @@
 // AOCX with object
 // RUN: %clangxx -fsycl -fintelfpga %t.o %t_image.a -o %t_aocx_obj.out
 //
-// RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_src.out
-// RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_obj.out
+// RUN: %ACC_RUN_PLACEHOLDER %t_aocx_src.out
+// RUN: %ACC_RUN_PLACEHOLDER %t_aocx_obj.out

--- a/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -22,5 +22,5 @@
 // AOCX with object
 // RUN: %clang_cl -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
 //
-// RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_src.out
-// RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_obj.out
+// RUN: %ACC_RUN_PLACEHOLDER %t_aocx_src.out
+// RUN: %ACC_RUN_PLACEHOLDER %t_aocx_obj.out

--- a/SYCL/Basic/queue/queue.cpp
+++ b/SYCL/Basic/queue/queue.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_BE=%sycl_be %t.out
+// RUN: %BE_RUN_PLACEHOLDER %t.out
 //==--------------- queue.cpp - SYCL queue test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/Config/kernel_from_file.cpp
+++ b/SYCL/Config/kernel_from_file.cpp
@@ -3,7 +3,7 @@
 
 // RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
 // RUN: %clangxx -include %t.h %s -o %t.out -lsycl -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning
-// RUN: env SYCL_BE=%sycl_be SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
+// RUN: %BE_RUN_PLACEHOLDER env SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
 // CHECK: Passed
 
 #include <CL/sycl.hpp>

--- a/SYCL/DeviceLib/assert-windows.cpp
+++ b/SYCL/DeviceLib/assert-windows.cpp
@@ -13,8 +13,8 @@
 // explicitly. Since the test is going to crash, we'll have to follow a similar
 // approach as on Linux - call the test in a subprocess.
 //
-// RUN: env SYCL_PI_TRACE=1 SYCL_DEVICELIB_INHIBIT_NATIVE=1 CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU %t.out >%t.stdout.pi.fallback
-// RUN: env SHOULD_CRASH=1 SYCL_DEVICELIB_INHIBIT_NATIVE=1 CL_CONFIG_USE_VECTORIZER=False SYCL_DEVICE_TYPE=CPU %t.out >%t.stdout.msg.fallback
+// RUN: %CPU_RUN_PLACEHOLDER env SYCL_PI_TRACE=1 SYCL_DEVICELIB_INHIBIT_NATIVE=1 CL_CONFIG_USE_VECTORIZER=False %t.out >%t.stdout.pi.fallback
+// RUN: %CPU_RUN_PLACEHOLDER env SHOULD_CRASH=1 SYCL_DEVICELIB_INHIBIT_NATIVE=1 CL_CONFIG_USE_VECTORIZER=False %t.out >%t.stdout.msg.fallback
 //
 // RUN: FileCheck %s --check-prefix=CHECK-MESSAGE --input-file %t.stdout.msg.fallback
 // CHECK-MESSAGE: {{.*}}assert-windows.cpp:{{[0-9]+}}: (null): global id:

--- a/SYCL/DeviceLib/assert.cpp
+++ b/SYCL/DeviceLib/assert.cpp
@@ -71,7 +71,7 @@
 //
 // Overall this sounds stable enough. What could possibly go wrong?
 //
-// RUN: env SYCL_PI_TRACE=2 SHOULD_CRASH=1 SYCL_DEVICE_TYPE=CPU EXPECTED_SIGNAL=SIGABRT SKIP_IF_NO_EXT=1 %t.out 2>%t.stderr.native >%t.stdout.native
+// RUN: %CPU_RUN_PLACEHOLDER env SYCL_PI_TRACE=2 SHOULD_CRASH=1 EXPECTED_SIGNAL=SIGABRT SKIP_IF_NO_EXT=1 %t.out 2>%t.stderr.native >%t.stdout.native
 // RUN: FileCheck %s --input-file %t.stdout.native --check-prefixes=CHECK-NATIVE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED
 // RUN: FileCheck %s --input-file %t.stderr.native --check-prefixes=CHECK-MESSAGE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED
 //

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <string>
 #include <vector>
 
 using namespace cl::sycl;
@@ -30,19 +31,21 @@ namespace esimd_test {
 // was returned for all devices, then the selection process will cause an
 // exception.
 class ESIMDSelector : public device_selector {
-  // Require GPU device unless HOST is requested in SYCL_DEVICE_TYPE env
+  // Require GPU device unless HOST is requested in SYCL_DEVICE_FILTER env
   virtual int operator()(const device &device) const {
-    if (const char *dev_type = getenv("SYCL_DEVICE_TYPE")) {
-      if (!strcmp(dev_type, "GPU"))
+    if (const char *dev_filter = getenv("SYCL_DEVICE_FILTER")) {
+      std::string filter_string(dev_filter);
+      if (filter_string.find("gpu") != std::string::npos)
         return device.is_gpu() ? 1000 : -1;
-      if (!strcmp(dev_type, "HOST"))
+      if (filter_string.find("host") != std::string::npos)
         return device.is_host() ? 1000 : -1;
-      std::cerr << "Supported 'SYCL_DEVICE_TYPE' env var values are 'GPU' and "
-                   "'HOST', '"
-                << dev_type << "' is not.\n";
+      std::cerr
+          << "Supported 'SYCL_DEVICE_FILTER' env var values are 'gpu' and "
+             "'host', '"
+          << filter_string << "' does not contain such substrings.\n";
       return -1;
     }
-    // If "SYCL_DEVICE_TYPE" not defined, only allow gpu device
+    // If "SYCL_DEVICE_FILTER" not defined, only allow gpu device
     return device.is_gpu() ? 1000 : -1;
   }
 };

--- a/SYCL/External/README.md
+++ b/SYCL/External/README.md
@@ -22,7 +22,7 @@ cd build
 cmake -G Ninja \
         -DTEST_SUITE_SUBDIRS=SYCL \
         -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> \
-        -DCHECK_SYCL_ALL="PI_OPENCL:cpu,acc,gpu,host;PI_LEVEL_ZERO:gpu,host" \
+        -DCHECK_SYCL_ALL="opencl:cpu,acc,gpu,host;level_zero:gpu,host" \
         -DCMAKE_CXX_COMPILER=<PATH_TO_sycl_compiler> \
         -DSYCL_EXTERNAL_TESTS="RSBench" \
         ..
@@ -37,7 +37,7 @@ llvm-lit . --show-tests
 # Run specific test (e.g. RSBench only)
 llvm-lit SYCL/External/RSBench
 # Run tests with parameters
-llvm-lit --param target_devices=host,gpu --param sycl_be=PI_LEVEL_ZERO \
+llvm-lit --param target_devices=host,gpu --param sycl_be=level_zero \
         --param dpcpp_compiler=path/to/clang++ --param dump_ir=True SYCL/External/RSBench
 ```
 

--- a/SYCL/Plugin/interop-opencl.cpp
+++ b/SYCL/Plugin/interop-opencl.cpp
@@ -1,9 +1,9 @@
 // REQUIRES: opencl
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out
-// RUN: env SYCL_BE=PI_OPENCL %CPU_RUN_PLACEHOLDER %t.out
-// RUN: env SYCL_BE=PI_OPENCL %GPU_RUN_PLACEHOLDER %t.out
-// RUN: env SYCL_BE=PI_OPENCL %ACC_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_DEVICE_FILTER=opencl %CPU_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_DEVICE_FILTER=opencl %GPU_RUN_PLACEHOLDER %t.out
+// RUN: env SYCL_DEVICE_FILTER=opencl %ACC_RUN_PLACEHOLDER %t.out
 
 //==-- interop-opencl.cpp - SYCL test for OpenCL interop API --------------===//
 //

--- a/SYCL/Plugin/sycl-ls-gpu-cuda.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-cuda.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: gpu, cuda
 
-// RUN: env SYCL_BE=PI_CUDA sycl-ls --verbose >%t.cuda.out
+// RUN: env SYCL_DEVICE_FILTER=cuda sycl-ls --verbose >%t.cuda.out
 // RUN: FileCheck %s --check-prefixes=CHECK-BUILTIN-GPU-CUDA,CHECK-CUSTOM-GPU-CUDA --input-file %t.cuda.out
 
 // CHECK-BUILTIN-GPU-CUDA: gpu_selector(){{.*}}GPU :{{.*}}CUDA

--- a/SYCL/Plugin/sycl-ls-gpu-default.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-default.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: gpu
 
-// RUN: env --unset=SYCL_BE sycl-ls --verbose >%t.default.out
+// RUN: env --unset=SYCL_DEVICE_FILTER sycl-ls --verbose >%t.default.out
 // RUN: FileCheck %s --check-prefixes=CHECK-GPU-BUILTIN,CHECK-GPU-CUSTOM --input-file %t.default.out
 
 // CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}Level-Zero

--- a/SYCL/Plugin/sycl-ls-gpu-opencl.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-opencl.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: gpu, opencl
 
-// RUN: env SYCL_BE=PI_OPENCL sycl-ls --verbose >%t.opencl.out
+// RUN: env SYCL_DEVICE_FILTER=opencl sycl-ls --verbose >%t.opencl.out
 // RUN: FileCheck %s --check-prefixes=CHECK-GPU-BUILTIN,CHECK-GPU-CUSTOM --input-file %t.opencl.out
 
 // CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}OpenCL

--- a/SYCL/Plugin/sycl-ls-gpu-sycl-be.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-sycl-be.cpp
@@ -3,13 +3,13 @@
 // RUN: sycl-ls --verbose >%t.default.out
 // RUN: FileCheck %s --check-prefixes=CHECK-BUILTIN-GPU-OPENCL,CHECK-CUSTOM-GPU-OPENCL --input-file %t.default.out
 
-// RUN: env SYCL_BE=PI_OPENCL sycl-ls --verbose >%t.opencl.out
+// RUN: env SYCL_DEVICE_FILTER=opencl sycl-ls --verbose >%t.opencl.out
 // RUN: FileCheck %s --check-prefixes=CHECK-BUILTIN-GPU-OPENCL,CHECK-CUSTOM-GPU-OPENCL --input-file %t.opencl.out
 
 // CHECK-BUILTIN-GPU-OPENCL: gpu_selector(){{.*}}GPU : OpenCL
 // CHECK-CUSTOM-GPU-OPENCL: custom_selector(gpu){{.*}}GPU : OpenCL
 
-// RUN: env SYCL_BE=PI_CUDA sycl-ls --verbose >%t.cuda.out
+// RUN: env SYCL_DEVICE_FILTER=cuda sycl-ls --verbose >%t.cuda.out
 // RUN: FileCheck %s --check-prefixes=CHECK-BUILTIN-GPU-CUDA,CHECK-CUSTOM-GPU-CUDA --input-file %t.cuda.out
 
 // CHECK-BUILTIN-GPU-CUDA: gpu_selector(){{.*}}GPU : CUDA

--- a/SYCL/Plugin/sycl-targets-order.cpp
+++ b/SYCL/Plugin/sycl-targets-order.cpp
@@ -1,9 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice,nvptx64-unknown-unknown-sycldevice %s -o %t-spir64-nvptx64.out
-// RUN: env SYCL_BE=PI_OPENCL %t-spir64-nvptx64.out
-// RUN: env SYCL_BE=PI_CUDA   %t-spir64-nvptx64.out
+// RUN: env SYCL_DEVICE_FILTER=opencl %t-spir64-nvptx64.out
+// RUN: env SYCL_DEVICE_FILTER=cuda   %t-spir64-nvptx64.out
 // RUN: %clangxx -fsycl -fsycl-targets=nvptx64-unknown-unknown-sycldevice,spir64-unknown-unknown-sycldevice %s -o %t-nvptx64-spir64.out
-// RUN: env SYCL_BE=PI_OPENCL %t-nvptx64-spir64.out
-// RUN: env SYCL_BE=PI_CUDA   %t-nvptx64-spir64.out
+// RUN: env SYCL_DEVICE_FILTER=opencl %t-nvptx64-spir64.out
+// RUN: env SYCL_DEVICE_FILTER=cuda   %t-nvptx64-spir64.out
 
 // REQUIRES: opencl, cuda
 

--- a/SYCL/README.md
+++ b/SYCL/README.md
@@ -24,7 +24,7 @@ cd build
 cmake -G Ninja \
         -DTEST_SUITE_SUBDIRS=SYCL \
         -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> \
-        -DCHECK_SYCL_ALL="PI_OPENCL:cpu,acc,gpu,host;PI_OPENCL:cpu;PI_OPENCL:gpu;PI_OPENCL:acc;PI_OPENCL:host;PI_LEVEL_ZERO:gpu,host;PI_LEVEL_ZERO:gpu;PI_LEVEL_ZERO:host" \
+        -DCHECK_SYCL_ALL="opencl:cpu,acc,gpu,host;opencl:cpu;opencl:gpu;opencl:acc;opencl:host;opencl:gpu,host;level_zero:gpu;level_zero:host" \
         -DSYCL_EXTERNAL_TESTS="RSBench" \
         ..
 # Build and run full list of tests for all supported combinations of target
@@ -35,7 +35,7 @@ llvm-lit . --show-tests
 # Run specific test
 llvm-lit <path_to_test>
 # Run tests with parameters
-llvm-lit --param target_devices=host,gpu --param sycl_be=PI_LEVEL_ZERO \
+llvm-lit --param target_devices=host,gpu --param sycl_be=level_zero \
         --param dpcpp_compiler=path/to/clang++ --param dump_ir=True .
 ```
 
@@ -62,21 +62,23 @@ value is cpu,gpu,acc,host). Supported target_devices values are:
  - **acc**  - FPGA emulator device available in OpenCL backend only;
  - **host** - SYCL Host device availabel with all backends.
 
-***SYCL_BE*** defined SYCL backend to be used for testing (default is
-PI_OPENCL).
-Supported sycl_be values:
- - PI_OPENCL - for OpenCL backend;
- - PI_CUDA - for CUDA backend;
- - PI_LEVEL_ZERO - Level Zero backend.
+***SYCL_BE*** defined SYCL backend to be used for testing.
+Supported sycl_be values are:
+ - opencl - for OpenCL backend;
+ - cuda - for CUDA backend;
+ - level_zero - Level Zero backend.
 
 ***CHECK_SYCL_ALL*** allows selection of multiple SYCL backends with set of
 target devices per each to be tested iteratively. Value may contain semicolon-
 separated list of configurations. Each configuration includes backend separated
 from comma-separated list of target devices with colon (e.g.
--DCHECK_SYCL_ALL="PI_OPENCL:cpu,host;PI_LEVEL_ZERO:gpu,host"). The testing is
+-DCHECK_SYCL_ALL="opencl:cpu,host;level_zero:gpu,host"). The testing is
 done using check-sycl-all target. It is recommended to pass -k0 parameter to
 build command line to avoid break execution on test failures for the first
 backend.
+
+Note: for compatibility reasons old values for SYCL backend selections are
+supported temporarely (PI_OPENCL, PI_CUDA, PI_LEVEL_ZERO).
 
 ***SYCL_EXTERNAL_TESTS*** semicolon-separate names of external SYCL applications
 which are built and run as part of the testing. Name is equal to subdirectory in
@@ -98,37 +100,37 @@ compilers, etc) are available in the system.
 See examples below for configuring tests targeting different devices:
  - Multiple backends iterative mode
 ```
-cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DCHECK_SYCL_ALL="PI_OPENCL:acc,gpu,cpu,host;PI_LEVEL_ZERO:gpu,host;PI_CUDA:gpu,host" -C../cmake/caches/clang_fsycl.cmake  ..
+cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DCHECK_SYCL_ALL="opencl:acc,gpu,cpu,host;level_zero:gpu,host;cuda:gpu,host" -C../cmake/caches/clang_fsycl.cmake  ..
 ninja -k0 check-sycl-all
 ```
  - SYCL host:
 ```
-cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=PI_OPENCL -DSYCL_TARGET_DEVICES="host" -C../cmake/caches/clang_fsycl.cmake  ..
+cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=opencl -DSYCL_TARGET_DEVICES="host" -C../cmake/caches/clang_fsycl.cmake  ..
 ninja check
 ```
  - OpenCL GPU
 ```
-cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=PI_OPENCL -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
+cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=opencl -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
 ninja check
 ```
  - OpenCL CPU
 ```
-cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=PI_OPENCL -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
+cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=opencl -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
 ninja check
 ```
  - OpenCL FPGA emulator
 ```
-cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=PI_OPENCL -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
+cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=opencl -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
 ninja check
 ```
  - CUDA GPU
 ```
-cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=PI_CUDA -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl_cuda.cmake  ..
+cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=cuda -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl_cuda.cmake  ..
 ninja check
 ```
  - Level Zero GPU
 ```
-cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=PI_LEVEL_ZERO -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
+cmake -G Ninja  -DTEST_SUITE_COLLECT_CODE_SIZE=OFF  -DTEST_SUITE_COLLECT_COMPILE_TIME=OFF -DTEST_SUITE_SUBDIRS=SYCL  -DTEST_SUITE_LIT=<PATH_TO_llvm-lit> -DSYCL_BE=level_zero -DSYCL_TARGET_DEVICES="gpu" -C../cmake/caches/clang_fsycl.cmake  ..
 ninja check
 ```
 
@@ -136,7 +138,7 @@ ninja check
  * **dpcpp_compiler** - full path to dpcpp compiler;
  * **target_device** - comma-separated list of target devices (cpu, gpu, acc,
    host);
- * **sycl_be** - SYCL backend to be used (PI_OPENCL, PI_LEVEL_ZERO, PI_CUDA);
+ * **sycl_be** - SYCL backend to be used (opencl, level_zero, cuda);
  * **dump_ir** - if IR dumping is supported for compiler (True, False);
  * **extra_environment** - comma-separated list of variables with values to be
    added to test environment. Can be also set by LIT_EXTRA_ENVIRONMENT variable

--- a/SYCL/SeparateCompile/test.cpp
+++ b/SYCL/SeparateCompile/test.cpp
@@ -37,7 +37,7 @@
 //
 // >> ---- link the full hetero app
 // RUN: %clangxx wrapper.o a.o b.o -o app.exe -lsycl
-// RUN: env SYCL_BE=%sycl_be ./app.exe | FileCheck %s
+// RUN: %BE_RUN_PLACEHOLDER ./app.exe | FileCheck %s
 // CHECK: pass
 
 //==----------- test.cpp - Tests SYCL separate compilation -----------------==//

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -79,28 +79,31 @@ llvm_config.use_clang()
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 
 if not config.sycl_be:
-    config.sycl_be="PI_OPENCL"
+     lit_config.error("SYCL backend is not specified")
+
+# Mapping from SYCL_BE backend definition style to SYCL_DEVICE_FILTER used
+# for backward compatibility
+try:
+  config.sycl_be = { 'PI_OPENCL': 'opencl',  'PI_CUDA': 'cuda', 'PI_LEVEL_ZERO': 'level_zero'}[config.sycl_be]
+except:
+  # do nothing a we expect that new format of plugin values are used
+  pass
+
+lit_config.note("Backend: {BACKEND}".format(BACKEND=config.sycl_be))
 
 config.substitutions.append( ('%sycl_be', config.sycl_be) )
-lit_config.note("Backend: {BACKEND}".format(BACKEND=config.sycl_be))
+config.available_features.add(config.sycl_be)
+config.substitutions.append( ('%BE_RUN_PLACEHOLDER', "env SYCL_DEVICE_FILTER={SYCL_PLUGIN} ".format(SYCL_PLUGIN=config.sycl_be)) )
 
 if config.dump_ir_supported:
    config.available_features.add('dump_ir')
 
-cuda = False
-if ( config.sycl_be == "PI_OPENCL" ):
-    config.available_features.add('opencl')
-elif ( config.sycl_be == "PI_CUDA" ):
-    config.available_features.add('cuda')
-    cuda = True
-elif ( config.sycl_be == "PI_LEVEL_ZERO" ):
-    config.available_features.add('level_zero')
-else:
+if config.sycl_be not in ['host', 'opencl','cuda', 'level_zero']:
     lit_config.error("Unknown SYCL BE specified '" +
                      config.sycl_be +
-                     "' supported values are PI_OPENCL, PI_CUDA, PI_LEVEL_ZERO")
+                     "' supported values are opencl, cuda, level_zero")
 
-esimd_run_substitute = "env SYCL_BE={SYCL_BE} SYCL_DEVICE_TYPE=GPU SYCL_PROGRAM_COMPILE_OPTIONS=-vc-codegen".format(SYCL_BE=config.sycl_be)
+esimd_run_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:gpu SYCL_PROGRAM_COMPILE_OPTIONS=-vc-codegen".format(SYCL_PLUGIN=config.sycl_be)
 config.substitutions.append( ('%ESIMD_RUN_PLACEHOLDER',  esimd_run_substitute) )
 config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
                               ' ' + '-fsycl-explicit-simd' + ' ' +
@@ -131,11 +134,11 @@ for target_device in config.target_devices.split(','):
 if 'host' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Test HOST device")
-    host_run_substitute = "env SYCL_DEVICE_TYPE=HOST SYCL_BE={SYCL_BE} ".format(SYCL_BE=config.sycl_be)
+    host_run_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:host ".format(SYCL_PLUGIN=config.sycl_be)
     host_check_substitute = "| FileCheck %s"
     config.available_features.add('host')
     if platform.system() == "Linux":
-        host_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=HOST SYCL_BE={SYCL_BE} ".format(SYCL_BE=config.sycl_be)
+        host_run_on_linux_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:host ".format(SYCL_PLUGIN=config.sycl_be)
         host_check_on_linux_substitute = "| FileCheck %s"
 else:
     lit_config.warning("HOST device not used")
@@ -153,11 +156,11 @@ cpu_check_on_linux_substitute = ""
 if 'cpu' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Test CPU device")
-    cpu_run_substitute = "env SYCL_DEVICE_TYPE=CPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=config.sycl_be)
+    cpu_run_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:cpu ".format(SYCL_PLUGIN=config.sycl_be)
     cpu_check_substitute = "| FileCheck %s"
     config.available_features.add('cpu')
     if platform.system() == "Linux":
-        cpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=CPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=config.sycl_be)
+        cpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:cpu ".format(SYCL_PLUGIN=config.sycl_be)
         cpu_check_on_linux_substitute = "| FileCheck %s"
 else:
     lit_config.warning("CPU device not used")
@@ -176,12 +179,12 @@ gpu_check_on_linux_substitute = ""
 if 'gpu' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Test GPU device")
-    gpu_run_substitute = " env SYCL_DEVICE_TYPE=GPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=config.sycl_be)
+    gpu_run_substitute = " env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:gpu ".format(SYCL_PLUGIN=config.sycl_be)
     gpu_check_substitute = "| FileCheck %s"
     config.available_features.add('gpu')
 
     if platform.system() == "Linux":
-        gpu_run_on_linux_substitute = "env SYCL_DEVICE_TYPE=GPU SYCL_BE={SYCL_BE} ".format(SYCL_BE=config.sycl_be)
+        gpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:gpu ".format(SYCL_PLUGIN=config.sycl_be)
         gpu_check_on_linux_substitute = "| FileCheck %s"
 
 else:
@@ -197,7 +200,7 @@ acc_check_substitute = ""
 if 'acc' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Tests accelerator device")
-    acc_run_substitute = " env SYCL_DEVICE_TYPE=ACC "
+    acc_run_substitute = " env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:acc ".format(SYCL_PLUGIN=config.sycl_be)
     acc_check_substitute = "| FileCheck %s"
     config.available_features.add('accelerator')
 else:
@@ -205,7 +208,7 @@ else:
 config.substitutions.append( ('%ACC_RUN_PLACEHOLDER',  acc_run_substitute) )
 config.substitutions.append( ('%ACC_CHECK_PLACEHOLDER',  acc_check_substitute) )
 
-if cuda:
+if config.sycl_be == 'cuda':
     config.substitutions.append( ('%sycl_triple',  "nvptx64-nvidia-cuda-sycldevice" ) )
 else:
     config.substitutions.append( ('%sycl_triple',  "spir64-unknown-linux-sycldevice" ) )


### PR DESCRIPTION
SYCL_DEVICE_TYPE) from LIT framework. Use SYCL_DEVICE_FILTER instead:

 - update [CPU|GPU|ACC]_RUN_PLACEHOLDER to use SYCL_DEVICE_FILTER;
 - change values format used to define a backend and a device type to
match SYCL_DEVICE_FILTER requirements;
 - add BE_RUN_PLACEHOLDER to set backend only for tests which require
that;
 - add maping from old SYCL backend name format to new one to avoid
   impact on CI automation.

Depends on intel/llvm#2826