### PR TITLE
[SYCL] Make LIT use compiler provided by user

### DIFF
--- a/SYCL/Basic/device_code_dae.cpp
+++ b/SYCL/Basic/device_code_dae.cpp
@@ -1,6 +1,6 @@
 // NOTE A temporary test before this compilation flow is enabled by default in
 // driver
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda,cl_options
 // CUDA does not support SPIR-V.
 // RUN: %clangxx -fsycl-device-only -Xclang -fenable-sycl-dae -Xclang -fsycl-int-header=int_header.h %s -c -o device_code.bc -I %sycl_include -Wno-sycl-strict
 // RUN: %clangxx -include int_header.h -g -c %s -o host_code.o -I %sycl_include -Wno-sycl-strict

--- a/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -7,20 +7,20 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: aoc, accelerator
-// REQUIRES: system-windows
+// REQUIRES: system-windows, cl_options
 
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image. To avoid appending objects to
 // leftover archives, remove one if exists.
 // RUN: rm %t_image.a || true
-// RUN: %clang_cl -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
+// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object
-// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj
+// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj
 
 // AOCX with source
-// RUN: %clang_cl -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
+// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clang_cl -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
+// RUN: %clangxx -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
 //
 // RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_src.out
 // RUN: env SYCL_DEVICE_TYPE=ACC %t_aocx_obj.out

--- a/SYCL/Basic/fpga_tests/fpga_queue.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_queue.cpp
@@ -1,6 +1,6 @@
-// REQUIRES: opencl
+// REQUIRES: opencl, opencl_icd
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %opencl_lib
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/handler/interop_task.cpp
+++ b/SYCL/Basic/handler/interop_task.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: opencl
-// RUN: %clangxx -fsycl %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// REQUIRES: opencl, opencl_icd
+// RUN: %clangxx -fsycl %s -o %t.out %opencl_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/Basic/sampler/sampler.cpp
+++ b/SYCL/Basic/sampler/sampler.cpp
@@ -1,4 +1,5 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-dead-args-optimization %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// REQUIRES: opencl, opencl_icd
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-dead-args-optimization %s -o %t.out %opencl_lib
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/sampler/sampler_ocl.cpp
+++ b/SYCL/Basic/sampler/sampler_ocl.cpp
@@ -1,6 +1,6 @@
-// REQUIRES: opencl
+// REQUIRES: opencl, opencl_icd
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %opencl_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/Config/kernel_from_file.cpp
+++ b/SYCL/Config/kernel_from_file.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda,cl_options
 // CUDA does not support SPIR-V.
 
 // RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict

--- a/SYCL/DeviceLib/separate_compile_test.cpp
+++ b/SYCL/DeviceLib/separate_compile_test.cpp
@@ -13,3 +13,4 @@
 // RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -o %t_fp64.out -lsycl
 // RUN: %CPU_RUN_PLACEHOLDER %t_fp64.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_fp64.out
+// UNSUPPORTED: cl_options

--- a/SYCL/InorderQueue/in_order_buffs_ocl.cpp
+++ b/SYCL/InorderQueue/in_order_buffs_ocl.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl_icd,opencl
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %opencl_lib
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InorderQueue/in_order_dmemll_ocl.cpp
+++ b/SYCL/InorderQueue/in_order_dmemll_ocl.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl_icd,opencl
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out %opencl_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out

--- a/SYCL/InorderQueue/prop.cpp
+++ b/SYCL/InorderQueue/prop.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl_icd,opencl
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out %opencl_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out

--- a/SYCL/KernelAndProgram/kernel-and-program-interop.cpp
+++ b/SYCL/KernelAndProgram/kernel-and-program-interop.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl, opencl_icd
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -L %opencl_libs_dir -lOpenCL
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %opencl_lib
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Regression/cache_test.cpp
+++ b/SYCL/Regression/cache_test.cpp
@@ -2,6 +2,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // REQUIRES: level_zero
+// UNSUPPORTED: cl_options
 
 #include <algorithm>
 #include <level_zero/ze_api.h>

--- a/SYCL/Regression/msvc_crt.cpp
+++ b/SYCL/Regression/msvc_crt.cpp
@@ -1,14 +1,14 @@
-// RUN: %clang_cl -fsycl /MD -o %t1.exe %s
+// RUN: %clangxx -fsycl /MD -o %t1.exe %s
 // RUN: %HOST_RUN_PLACEHOLDER %t1.exe
 // RUN: %CPU_RUN_PLACEHOLDER %t1.exe
 // RUN: %GPU_RUN_PLACEHOLDER %t1.exe
 // RUN: %ACC_RUN_PLACEHOLDER %t1.exe
-// RUN: %clang_cl -fsycl /MDd -o %t2.exe %s
+// RUN: %clangxx -fsycl /MDd -o %t2.exe %s
 // RUN: %HOST_RUN_PLACEHOLDER %t2.exe
 // RUN: %CPU_RUN_PLACEHOLDER %t2.exe
 // RUN: %GPU_RUN_PLACEHOLDER %t2.exe
 // RUN: %ACC_RUN_PLACEHOLDER %t2.exe
-// REQUIRES: system-windows
+// REQUIRES: system-windows, cl_options
 //==-------------- msvc_crt.cpp - SYCL MSVC CRT test -----------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/SeparateCompile/test.cpp
+++ b/SYCL/SeparateCompile/test.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda,cl_options
 // CUDA does not support SPIR-V.
 //
 // >> ---- compile src1

--- a/SYCL/USM/source_kernel_indirect_access.cpp
+++ b/SYCL/USM/source_kernel_indirect_access.cpp
@@ -1,8 +1,8 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -lOpenCL %s -o %t1.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %opencl_lib %s -o %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
-// REQUIRES: opencl
+// REQUIRES: opencl,opencl_icd
 
 #include <CL/cl.h>
 #include <CL/sycl.hpp>

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -34,6 +34,9 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = config.sycl_obj_root
 
+config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
+config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
+
 llvm_config.use_clang()
 
 # Propagate some variables from the host environment.
@@ -112,8 +115,6 @@ config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
                               ' ' + '-fsycl-explicit-simd' + ' ' +
                               config.cxx_flags ) )
 
-config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
-config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -93,9 +93,19 @@ if config.extra_environment:
 
 config.substitutions.append( ('%sycl_libs_dir',  config.sycl_libs_dir ) )
 config.substitutions.append( ('%sycl_include',  config.sycl_include ) )
+
+# check if compiler supports CL command line options
+cl_options=False
+sp = subprocess.getstatusoutput(config.dpcpp_compiler+' /help')
+if sp[0] == 0:
+    cl_options=True
+
 if config.opencl_libs_dir:
-  config.substitutions.append( ('%opencl_libs_dir',  config.opencl_libs_dir) )
-  config.available_features.add('opencl_icd')
+    if cl_options:
+        config.substitutions.append( ('%opencl_lib',  '/LIBPATH:'+config.opencl_libs_dir+' OpenCL.lib') )
+    else:
+        config.substitutions.append( ('%opencl_lib',  '-L'+config.opencl_libs_dir+' -lOpenCL') )
+    config.available_features.add('opencl_icd')
 config.substitutions.append( ('%opencl_include_dir',  config.opencl_include_dir) )
 
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -115,6 +115,8 @@ else:
 esimd_run_substitute = "env SYCL_BE={SYCL_BE} SYCL_DEVICE_TYPE=GPU SYCL_PROGRAM_COMPILE_OPTIONS=-vc-codegen".format(SYCL_BE=config.sycl_be)
 config.substitutions.append( ('%ESIMD_RUN_PLACEHOLDER',  esimd_run_substitute) )
 
+config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
+config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -37,9 +37,7 @@ config.test_exec_root = config.sycl_obj_root
 config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
                               ' ' + '-fsycl-explicit-simd' + ' ' +
                               config.cxx_flags ) )
-#config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
-#config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
-
+llvm_config.with_environment('CLANG', config.dpcpp_compiler)
 llvm_config.use_clang()
 
 # Propagate some variables from the host environment.
@@ -115,8 +113,6 @@ else:
 esimd_run_substitute = "env SYCL_BE={SYCL_BE} SYCL_DEVICE_TYPE=GPU SYCL_PROGRAM_COMPILE_OPTIONS=-vc-codegen".format(SYCL_BE=config.sycl_be)
 config.substitutions.append( ('%ESIMD_RUN_PLACEHOLDER',  esimd_run_substitute) )
 
-config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
-config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -99,10 +99,11 @@ cl_options=False
 sp = subprocess.getstatusoutput(config.dpcpp_compiler+' /help')
 if sp[0] == 0:
     cl_options=True
+    config.available_features.add('cl_options')
 
 if config.opencl_libs_dir:
     if cl_options:
-        config.substitutions.append( ('%opencl_lib',  '/LIBPATH:'+config.opencl_libs_dir+' OpenCL.lib') )
+        config.substitutions.append( ('%opencl_lib',  ' '+config.opencl_libs_dir+'/OpenCL.lib') )
     else:
         config.substitutions.append( ('%opencl_lib',  '-L'+config.opencl_libs_dir+' -lOpenCL') )
     config.available_features.add('opencl_icd')

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -34,6 +34,9 @@ config.test_source_root = os.path.dirname(__file__)
 # test_exec_root: The root path where tests should be run.
 config.test_exec_root = config.sycl_obj_root
 
+config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
+                              ' ' + '-fsycl-explicit-simd' + ' ' +
+                              config.cxx_flags ) )
 config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
 config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
 
@@ -111,9 +114,6 @@ else:
 
 esimd_run_substitute = "env SYCL_BE={SYCL_BE} SYCL_DEVICE_TYPE=GPU SYCL_PROGRAM_COMPILE_OPTIONS=-vc-codegen".format(SYCL_BE=config.sycl_be)
 config.substitutions.append( ('%ESIMD_RUN_PLACEHOLDER',  esimd_run_substitute) )
-config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
-                              ' ' + '-fsycl-explicit-simd' + ' ' +
-                              config.cxx_flags ) )
 
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -37,8 +37,8 @@ config.test_exec_root = config.sycl_obj_root
 config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
                               ' ' + '-fsycl-explicit-simd' + ' ' +
                               config.cxx_flags ) )
-config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
-config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
+#config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
+#config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
 
 llvm_config.use_clang()
 

--- a/cmake/caches/clang_fsycl.cmake
+++ b/cmake/caches/clang_fsycl.cmake
@@ -1,4 +1,4 @@
 # Default open source clang configuration with SYCL support.
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
-set(CMAKE_CXX_FLAGS "-fsycl" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "" CACHE STRING "")

--- a/cmake/caches/clang_fsycl_cuda.cmake
+++ b/cmake/caches/clang_fsycl_cuda.cmake
@@ -1,4 +1,4 @@
 # Default open source clang configuration with SYCL support.
 
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
-set(CMAKE_CXX_FLAGS "-fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice -Xsycl-target-backend --cuda-gpu-arch=sm_32" CACHE STRING "")
+set(CMAKE_CXX_FLAGS "-fsycl-targets=nvptx64-nvidia-cuda-sycldevice -Xsycl-target-backend --cuda-gpu-arch=sm_32" CACHE STRING "")


### PR DESCRIPTION
%clangxx and %clang were always set to clang which is not expected.
After the fix the substitutions above are set to the compiler passed by user.