### PR TITLE
[SYCL]Remove usage of fsycl-device-lib=all/libm-fp64

### DIFF
--- a/SYCL/DeviceLib/cmath-aot.cpp
+++ b/SYCL/DeviceLib/cmath-aot.cpp
@@ -4,11 +4,11 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/cmath_test.cpp -o %t.cmath.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.cmath.out
 
-// RUN: %clangxx -fsycl -fsycl-device-lib=libm-fp64 -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/cmath_fp64_test.cpp -o %t.cmath.fp64.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/cmath_fp64_test.cpp -o %t.cmath.fp64.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.cmath.fp64.out
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/std_complex_math_test.cpp -o %t.complex.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.complex.out
 
-// RUN: %clangxx -fsycl -fsycl-device-lib=libm-fp64 -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/std_complex_math_fp64_test.cpp -o %t.complex.fp64.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown-sycldevice %S/std_complex_math_fp64_test.cpp -o %t.complex.fp64.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.complex.fp64.out

--- a/SYCL/DeviceLib/cmath_fp64_test.cpp
+++ b/SYCL/DeviceLib/cmath_fp64_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-lib=libm-fp64 %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/math_fp64_test.cpp
+++ b/SYCL/DeviceLib/math_fp64_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-lib=libm-fp64 %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/separate_compile_test.cpp
+++ b/SYCL/DeviceLib/separate_compile_test.cpp
@@ -6,7 +6,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// RUN: %clangxx -fsycl -fsycl-link -fsycl-device-lib=all %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o
+// RUN: %clangxx -fsycl -fsycl-link  %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -I %sycl_include -Wno-sycl-strict
 // >> host compilation...
 // RUN: %clangxx -include std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o -I %sycl_include -Wno-sycl-strict

--- a/SYCL/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/SYCL/DeviceLib/std_complex_math_fp64_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-lib=libm-fp64 %s -o %t.out
+// RUN: %clangxx -fsycl  %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Signed-off-by: gejin <ge.jin@intel.com>

This PR removes "-fsycl-device-lib=all/libm-fp64" in SYCL devicelib fp64 tests since fp64 devicelib has been linked by default in latest intel/llvm.