### PR TITLE
[SYCL] Fix test compilation on windows

### DIFF
--- a/SYCL/Config/allowlist.cpp
+++ b/SYCL/Config/allowlist.cpp
@@ -11,6 +11,7 @@
 // RUN: env TEST_INCORRECT_VALUE=1 env SYCL_DEVICE_ALLOWLIST="IncorrectKey:{{.*}}" %t.out
 
 #include <CL/sycl.hpp>
+#include <algorithm>
 #include <cstdlib>
 #include <exception>
 #include <iostream>

--- a/SYCL/SubGroup/generic-shuffle.cpp
+++ b/SYCL/SubGroup/generic-shuffle.cpp
@@ -14,7 +14,9 @@
 
 #include "helper.hpp"
 #include <CL/sycl.hpp>
+#include <algorithm>
 #include <complex>
+#include <vector>
 template <typename T> class pointer_kernel;
 
 using namespace cl::sycl;


### PR DESCRIPTION
The impacted tests use functions defined in <algorithm>. The header is
not included implicitely on the latest MS VC compiler causing
compilation error. The tests are updated with explicit include of
missing headers.