### PR TITLE
Temporary disable complex_global_object.cpp

### DIFF
--- a/SYCL/Regression/complex_global_object.cpp
+++ b/SYCL/Regression/complex_global_object.cpp
@@ -9,7 +9,7 @@
 // such objects do not cause problems if the first call to SYCL is inside main
 // and the last call is in global destructor.
 
-// UNSUPPORTED: windows,linux
+// REQUIRES: TEMPORARY_DISABLED
 // Disable test due to flacky failures
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
The test fails sporadically, disabling it to avoid pre-commit fails
on unrelated changes.