### PR TITLE
[SYCL] disabled SYCL/ESIMD/vadd_2d_acc.cpp on CUDA

### DIFF
--- a/SYCL/ESIMD/vadd_2d_acc.cpp
+++ b/SYCL/ESIMD/vadd_2d_acc.cpp
@@ -10,6 +10,8 @@
 // RUN: %clangxx-esimd -fsycl %s -o %t.out
 // RUN: %ESIMD_RUN_PLACEHOLDER %t.out
 
+// UNSUPPORTED: cuda
+
 // The test checks that 2D workitem addressing works correctly with SIMD
 // kernels.
 


### PR DESCRIPTION
Fix for issue #99 as ESIMD is not supported on CUDA backend.