### PR TITLE
[SYCL] Disable memory-consumption.cpp due to flaky failures

### DIFF
--- a/SYCL/Basic/memory-consumption.cpp
+++ b/SYCL/Basic/memory-consumption.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
+// Issue #106: Disable on Linux until flaky failures are fixed
+// REQUIRES: TEMPORARY_DISABLED
 // UNSUPPORTED: windows
 //
 //==-----memory-consumption.cpp - SYCL memory consumption basic test ------==//


### PR DESCRIPTION
The test has been disabled to have 100 pass rate in CI. The failure is covered by Issue #106