### PR TITLE
Temporary disable release_resources test

### DIFF
--- a/SYCL/Basic/stream/release_resources_test.cpp
+++ b/SYCL/Basic/stream/release_resources_test.cpp
@@ -3,8 +3,8 @@
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
 
-// The test is flaky on Linux-OpenCL
-// UNSUPPORTED: linux && opencl
+// Disabled until sporadic failure is fixed
+// REQUIRES: TEMPORARY_DISABLED
 
 // Check that buffer used by a stream object is released.
 


### PR DESCRIPTION
The test has failed on an unrelated patch [1] on L0 BE.

[1] https://github.com/intel/llvm/pull/3096