### PR TITLE
[SYCL] Fix tests to behave correctly on devices w/o host unified memory

### DIFF
--- a/SYCL/Basic/host-task-dependency.cpp
+++ b/SYCL/Basic/host-task-dependency.cpp
@@ -181,7 +181,7 @@ int main() {
 // CHECK: GeneratorTask
 // CHECK:---> piEnqueueKernelLaunch(
 // prepare for host task
-// CHECK:---> piEnqueueMemBufferMap(
+// CHECK:---> piEnqueueMemBuffer{{Map|Read}}(
 // launch of CopierTask kernel
 // CHECK:---> piKernelCreate(
 // CHECK: CopierTask

--- a/SYCL/Basic/subdevice_pi.cpp
+++ b/SYCL/Basic/subdevice_pi.cpp
@@ -74,7 +74,7 @@ static bool check_separate(device dev, buffer<int, 1> buf,
   // CHECK-SEPARATE: ---> piMemBufferCreate
   //
   // Verify that we have a memcpy between subdevices in this case
-  // CHECK-SEPARATE: ---> piEnqueueMemBufferMap
+  // CHECK-SEPARATE: ---> piEnqueueMemBuffer{{Map|Read}}
   // CHECK-SEPARATE: ---> piEnqueueMemBufferWrite
   //
   // CHECK-SEPARATE: ---> piEnqueueKernelLaunch

--- a/SYCL/Scheduler/MemObjRemapping.cpp
+++ b/SYCL/Scheduler/MemObjRemapping.cpp
@@ -16,6 +16,9 @@ class Bar;
 // read-write.
 int main() {
   queue Q;
+  // Mapping is not used for devices without host unified memory support.
+  if (!Q.get_device().get_info<info::device::host_unified_memory>())
+    return 0;
 
   std::size_t Size = 64;
   range<1> Range{Size};


### PR DESCRIPTION
- Do not run Scheduler/MemObjRemapping on such devices since remapping
isn't used there.
- Adjust Basic/host-task-dependency and Basic/subdevice_pi to accept
read operations in addition to map ones.
- Fix reliance on undefined behaviour that doesn't work without host
unified memory in USM/math.