### PR TITLE
[SYCL] Mark tests failing with 27.20.100.9168 XFAIL.

### DIFF
--- a/SYCL/AOT/gpu.cpp
+++ b/SYCL/AOT/gpu.cpp
@@ -9,6 +9,8 @@
 // REQUIRES: ocloc, gpu
 // UNSUPPORTED: cuda
 // CUDA is not compatible with SPIR.
+// Issue #128: The test fails for driver 27.20.100.9168
+// XFAIL: windows
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen-unknown-unknown-sycldevice -Xsycl-target-backend=spir64_gen-unknown-unknown-sycldevice "-device *" %S/Inputs/aot.cpp -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/AOT/multiple-devices.cpp
+++ b/SYCL/AOT/multiple-devices.cpp
@@ -9,6 +9,8 @@
 // REQUIRES: opencl-aot, ocloc, aoc, cpu, gpu, accelerator
 // UNSUPPORTED: cuda
 // CUDA is not compatible with SPIR.
+// Issue #128: The test fails for driver 27.20.100.9168
+// XFAIL: windows && gpu
 
 // 1-command compilation case
 // Targeting CPU, GPU, FPGA

--- a/SYCL/Basic/DeviceCodeSplit/aot-gpu.cpp
+++ b/SYCL/Basic/DeviceCodeSplit/aot-gpu.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: ocloc, gpu
 // UNSUPPORTED: cuda
 // CUDA does neither support device code splitting nor SPIR.
+// Issue #128: The test fails for driver 27.20.100.9168
+// XFAIL: windows
 //
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source \
 // RUN:   -fsycl-targets=spir64_gen-unknown-unknown-sycldevice \


### PR DESCRIPTION
The test started to fail after uplift of GPU runtime on windows up to 27.20.100.9168.