### PR TITLE
[SYCL] Remove XFAIL after driver update

### DIFF
--- a/SYCL/InlineAsm/asm_if.cpp
+++ b/SYCL/InlineAsm/asm_if.cpp
@@ -3,7 +3,6 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// XFAIL:*
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
The failure in SYCL/InlineAsm/asm_if.cpp was fixed in GPU RT
21.04.18912.