### PR TITLE
[SYC] Test for integrated/discrete GPU buffer creation.

### DIFF
--- a/SYCL/Basic/buffer/buffer_create.cpp
+++ b/SYCL/Basic/buffer/buffer_create.cpp
@@ -1,0 +1,29 @@
+// REQUIRES: gpu,level_zero
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env ZE_DEBUG=1 %GPU_RUN_PLACEHOLDER %t.out 2> %t1.out; cat %t1.out %GPU_CHECK_PLACEHOLDER
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+int main() {
+  constexpr int Size = 100;
+  queue Queue;
+  auto D = Queue.get_device();
+
+  buffer<::cl_int, 1> Buffer(Size);
+  Queue.submit([&](handler &cgh) {
+    accessor Accessor{Buffer, cgh, read_write};
+    if (D.get_info<info::device::host_unified_memory>())
+      std::cerr << "Integrated GPU should use zeMemAllocHost\n";
+    else
+      std::cerr << "Discrete GPU should use zeMemAllocDevice\n";
+    cgh.parallel_for<class CreateBuffer>(range<1>(Size), [=](id<1> ID) {});
+  });
+  Queue.wait();
+
+  return 0;
+}
+
+// CHECK: {{Integrated|Discrete}} GPU should use [[API:zeMemAllocHost|zeMemAllocDevice]]
+// CHECK: ZE ---> [[API]](


### PR DESCRIPTION
This test checks if the expected level_zero API is used for buffer creation on integrated vs discrete GPUs.
Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>