### PR TITLE
[SYCL] Update the reason InOrderQueueDeps is disabled with Level Zero

### DIFF
--- a/SYCL/Scheduler/InOrderQueueDeps.cpp
+++ b/SYCL/Scheduler/InOrderQueueDeps.cpp
@@ -4,7 +4,8 @@
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
 
-// The test is hanging on Level_Zero plugin
+// The tested functionality is disabled with Level Zero until it is supported by
+// the plugin.
 // UNSUPPORTED: level_zero
 //==----------------------- InOrderQueueDeps.cpp ---------------------------==//
 //


### PR DESCRIPTION
The test was initially disabled due to a bug in the Level Zero plugin that led
to a hang, which has already been fixed in
https://github.com/intel/llvm/pull/3081

Despite that, the test should stay disabled since the tested
functionality is to be temporarily turned off for Level Zero in
https://github.com/intel/llvm/pull/3188