### PR TITLE
[SYCL] Add a LIT test for +=,*=,|=,^=,&= operations usable for reduce…

### DIFF
--- a/SYCL/Reduction/reduction_reducer_op_eq.cpp
+++ b/SYCL/Reduction/reduction_reducer_op_eq.cpp
@@ -31,8 +31,7 @@ enum OperationEqual {
 };
 
 namespace std {
-template<>
-struct plus<XY> {
+template <> struct plus<XY> {
   using result_type = XY;
   using first_argument_type = XY;
   using second_argument_type = XY;
@@ -41,8 +40,7 @@ struct plus<XY> {
   }
 };
 
-template<>
-struct multiplies<XY> {
+template <> struct multiplies<XY> {
   using result_type = XY;
   using first_argument_type = XY;
   using second_argument_type = XY;
@@ -51,8 +49,7 @@ struct multiplies<XY> {
   }
 };
 
-template<>
-struct bit_or<XY> {
+template <> struct bit_or<XY> {
   using result_type = XY;
   using first_argument_type = XY;
   using second_argument_type = XY;
@@ -61,8 +58,7 @@ struct bit_or<XY> {
   }
 };
 
-template<>
-struct bit_xor<XY> {
+template <> struct bit_xor<XY> {
   using result_type = XY;
   using first_argument_type = XY;
   using second_argument_type = XY;
@@ -71,8 +67,7 @@ struct bit_xor<XY> {
   }
 };
 
-template<>
-struct bit_and<XY> {
+template <> struct bit_and<XY> {
   using result_type = XY;
   using first_argument_type = XY;
   using second_argument_type = XY;
@@ -82,7 +77,8 @@ struct bit_and<XY> {
 };
 } // namespace std
 
-template <typename T, typename BinaryOperation, OperationEqual OpEq, bool IsFP = false>
+template <typename T, typename BinaryOperation, OperationEqual OpEq,
+          bool IsFP = false>
 int test(T Identity) {
   constexpr size_t N = 16;
   constexpr size_t L = 4;
@@ -102,29 +98,29 @@ int test(T Identity) {
   nd_range<1> NDR{N, L};
   if constexpr (OpEq == PlusEq) {
     auto Lambda = [=](nd_item<1> ID, auto &Sum) {
-                              Sum += Data[ID.get_global_id(0)];
-                              };
-    Q.submit([&](handler &H) {H.parallel_for(NDR, Red, Lambda);}).wait();
+      Sum += Data[ID.get_global_id(0)];
+    };
+    Q.submit([&](handler &H) { H.parallel_for(NDR, Red, Lambda); }).wait();
   } else if constexpr (OpEq == MultipliesEq) {
     auto Lambda = [=](nd_item<1> ID, auto &Sum) {
-                              Sum *= Data[ID.get_global_id(0)];
-                              };
-    Q.submit([&](handler &H) {H.parallel_for(NDR, Red, Lambda);}).wait();
+      Sum *= Data[ID.get_global_id(0)];
+    };
+    Q.submit([&](handler &H) { H.parallel_for(NDR, Red, Lambda); }).wait();
   } else if constexpr (OpEq == BitwiseOREq) {
     auto Lambda = [=](nd_item<1> ID, auto &Sum) {
-                              Sum |= Data[ID.get_global_id(0)];
-                              };
-    Q.submit([&](handler &H) {H.parallel_for(NDR, Red, Lambda);}).wait();
+      Sum |= Data[ID.get_global_id(0)];
+    };
+    Q.submit([&](handler &H) { H.parallel_for(NDR, Red, Lambda); }).wait();
   } else if constexpr (OpEq == BitwiseXOREq) {
     auto Lambda = [=](nd_item<1> ID, auto &Sum) {
-                              Sum ^= Data[ID.get_global_id(0)];
-                              };
-    Q.submit([&](handler &H) {H.parallel_for(NDR, Red, Lambda);}).wait();
+      Sum ^= Data[ID.get_global_id(0)];
+    };
+    Q.submit([&](handler &H) { H.parallel_for(NDR, Red, Lambda); }).wait();
   } else if constexpr (OpEq == BitwiseANDEq) {
     auto Lambda = [=](nd_item<1> ID, auto &Sum) {
-                              Sum &= Data[ID.get_global_id(0)];
-                              };
-    Q.submit([&](handler &H) {H.parallel_for(NDR, Red, Lambda);}).wait();
+      Sum &= Data[ID.get_global_id(0)];
+    };
+    Q.submit([&](handler &H) { H.parallel_for(NDR, Red, Lambda); }).wait();
   }
 
   int Error = 0;
@@ -143,8 +139,7 @@ int test(T Identity) {
   return Error;
 }
 
-template <typename T>
-int testFPPack() {
+template <typename T> int testFPPack() {
   int Error = 0;
   Error += test<T, std::plus<>, PlusEq, true>(T{});
   Error += test<T, std::plus<T>, PlusEq, true>(T{});
@@ -153,8 +148,7 @@ int testFPPack() {
   return Error;
 }
 
-template <typename T>
-int testINTPack() {
+template <typename T> int testINTPack() {
   int Error = 0;
   Error += test<T, std::plus<T>, PlusEq>(T{});
   Error += test<T, std::multiplies<T>, MultipliesEq>(T{1, 1});

--- a/SYCL/Reduction/reduction_reducer_op_eq.cpp
+++ b/SYCL/Reduction/reduction_reducer_op_eq.cpp
@@ -1,0 +1,79 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// This test checks that if the custom type supports operations like +=, then
+// such operations can be used for the reduction objects in kernels..
+
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <random>
+
+using namespace sycl;
+using namespace sycl::ONEAPI;
+
+struct XY {
+  XY() : X(0), Y(0) {}
+  XY(float X, float Y) : X(X), Y(Y) {}
+  float X;
+  float Y;
+  float x() const { return X; };
+  float y() const { return Y; };
+  XY &operator+=(const XY &RHS) {
+    X += RHS.X;
+    Y += RHS.Y;
+    return *this;
+  }
+};
+
+void setXY(float2 &Data, float X, float Y) { Data = {X, Y}; }
+void setXY(XY &Data, float X, float Y) {
+  Data.X = X;
+  Data.Y = Y;
+}
+
+template <typename Name, typename T, typename BinaryOperation>
+int test(T Identity, BinaryOperation BOp) {
+  constexpr size_t N = 16;
+  constexpr size_t L = 4;
+
+  queue Q;
+  T *Data = malloc_shared<T>(N, Q);
+  T *Res = malloc_shared<T>(1, Q);
+  T Expected = Identity;
+  for (size_t I = 0; I < N; I++) {
+    setXY(Data[I], I, I + 1);
+    setXY(Expected, Expected.x() + I, Expected.y() + I + 1);
+  }
+
+  *Res = Identity;
+  auto Red = reduction(Res, Identity, BOp);
+  Q.submit([&](handler &H) {
+     H.parallel_for<Name>(nd_range<1>{N, L}, Red,
+                          [=](nd_item<1> ID, auto &Sum) {
+                            size_t GID = ID.get_global_id(0);
+                            Sum += Data[GID];
+                          });
+   }).wait();
+
+  int Error = 0;
+  if (Expected.x() != Res->x() || Expected.y() != Res->y()) {
+    std::cerr << "Error: expected = (" << Expected.x() << ", " << Expected.y()
+              << "); computed = (" << Res->x() << ", " << Res->y() << ")\n";
+    Error = 1;
+  }
+  free(Res, Q);
+  free(Data, Q);
+  return Error;
+}
+
+int main() {
+  int Error = 0;
+  Error += test<class A, float2>(float2{}, std::plus<>{});
+  Error += test<class B, XY>(
+      XY{}, [](auto A, auto B) { return XY(A.X + B.X, A.Y + B.Y); });
+  if (!Error)
+    std::cout << "Passed.\n";
+  return Error;
+}


### PR DESCRIPTION
…r objects

This test verifies this change-set: https://github.com/intel/llvm/pull/3193

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>