### PR TITLE
[SYCL] Extend coverage of USM memcpy, fill, and memset

### DIFF
--- a/SYCL/USM/allocator_container.cpp
+++ b/SYCL/USM/allocator_container.cpp
@@ -1,0 +1,63 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
+// RUN: %HOST_RUN_PLACEHOLDER %t1.out
+// RUN: %CPU_RUN_PLACEHOLDER %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+// RUN: %ACC_RUN_PLACEHOLDER %t1.out
+
+//==------ allocator_container.cpp - USM allocator in containers test ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+#include <cassert>
+
+using namespace cl::sycl;
+
+constexpr int N = 100;
+
+template <usm::alloc AllocMode, class KernelName>
+void runTest(device dev, context ctxt, queue q) {
+  usm_allocator<int, AllocMode> alloc(ctxt, dev);
+
+  std::vector<int, decltype(alloc)> vec(alloc);
+  vec.resize(N);
+
+  for (int i = 0; i < N; i++) {
+    vec[i] = i;
+  }
+
+  int *vals = &vec[0];
+
+  q.submit([=](handler &h) {
+     h.single_task<KernelName>([=]() {
+       for (int i = 1; i < N; i++) {
+         vals[0] += vals[i];
+       }
+     });
+   }).wait();
+
+  assert(vals[0] == ((N * (N - 1)) / 2));
+}
+
+int main() {
+  queue q;
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
+
+  if (dev.get_info<info::device::usm_shared_allocations>()) {
+    runTest<usm::alloc::shared, class shared_test>(dev, ctxt, q);
+  }
+
+  if (dev.get_info<info::device::usm_host_allocations>()) {
+    runTest<usm::alloc::host, class host_test>(dev, ctxt, q);
+  }
+
+  // usm::alloc::device is not supported by usm_allocator
+
+  return 0;
+}

--- a/SYCL/USM/fill.cpp
+++ b/SYCL/USM/fill.cpp
@@ -16,24 +16,149 @@
 
 using namespace cl::sycl;
 
-constexpr int count = 100;
-constexpr int pattern = 42;
+template <typename T> class usm_device_transfer;
+template <typename T> class usm_aligned_device_transfer;
+
+static constexpr int N = 100;
+
+struct test_struct {
+  short a;
+  int b;
+  long c;
+  long long d;
+  sycl::half e;
+  float f;
+  double g;
+};
+
+bool operator==(const test_struct &lhs, const test_struct &rhs) {
+  return lhs.a == rhs.a && lhs.b == rhs.b && lhs.c == rhs.c && lhs.d == rhs.d &&
+         lhs.e == rhs.e && lhs.f == rhs.f && lhs.g == rhs.g;
+}
+
+template <typename T>
+void runHostTests(device dev, context ctxt, queue q, T val) {
+  T *array;
+
+  array = (T *)malloc_host(N * sizeof(T), q);
+  q.submit([&](handler &h) { h.fill(array, val, N); }).wait();
+  for (int i = 0; i < N; ++i) {
+    assert(array[i] == val);
+  }
+  free(array, ctxt);
+
+  array = (T *)aligned_alloc_host(alignof(long long), N * sizeof(T), ctxt);
+  q.submit([&](handler &h) { h.fill(array, val, N); }).wait();
+  for (int i = 0; i < N; ++i) {
+    assert(array[i] == val);
+  }
+  free(array, ctxt);
+}
+
+template <typename T>
+void runSharedTests(device dev, context ctxt, queue q, T val) {
+  T *array;
+
+  array = (T *)malloc_shared(N * sizeof(T), q);
+  q.submit([&](handler &h) { h.fill(array, val, N); }).wait();
+  for (int i = 0; i < N; ++i) {
+    assert(array[i] == val);
+  }
+  free(array, ctxt);
+
+  array =
+      (T *)aligned_alloc_shared(alignof(long long), N * sizeof(T), dev, ctxt);
+  q.submit([&](handler &h) { h.fill(array, val, N); }).wait();
+  for (int i = 0; i < N; ++i) {
+    assert(array[i] == val);
+  }
+  free(array, ctxt);
+}
+
+template <typename T>
+void runDeviceTests(device dev, context ctxt, queue q, T val) {
+  T *array;
+  std::vector<T> out;
+  out.resize(N);
+
+  array = (T *)malloc_device(N * sizeof(T), q);
+  q.submit([&](handler &h) { h.fill(array, val, N); }).wait();
+
+  {
+    buffer<T, 1> buf{&out[0], range<1>{N}};
+    q.submit([&](handler &h) {
+       auto acc = buf.template get_access<access::mode::write>(h);
+       h.parallel_for<usm_device_transfer<T>>(
+           range<1>(N), [=](id<1> item) { acc[item] = array[item]; });
+     }).wait();
+  }
+
+  for (int i = 0; i < N; ++i) {
+    assert(out[i] == val);
+  }
+  free(array, ctxt);
+
+  out.clear();
+  out.resize(N);
+
+  array =
+      (T *)aligned_alloc_device(alignof(long long), N * sizeof(T), dev, ctxt);
+  q.submit([&](handler &h) { h.fill(array, val, N); }).wait();
+
+  {
+    buffer<T, 1> buf{&out[0], range<1>{N}};
+    q.submit([&](handler &h) {
+       auto acc = buf.template get_access<access::mode::write>(h);
+       h.parallel_for<usm_aligned_device_transfer<T>>(
+           range<1>(N), [=](id<1> item) { acc[item] = array[item]; });
+     }).wait();
+  }
+
+  for (int i = 0; i < N; ++i) {
+    assert(out[i] == val);
+  }
+  free(array, ctxt);
+}
 
 int main() {
   queue q;
-  if (q.get_device().get_info<info::device::usm_shared_allocations>()) {
-    int *mem = malloc_shared<int>(count, q);
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
 
-    for (int i = 0; i < count; i++)
-      mem[i] = 0;
+  test_struct test_obj{4, 42, 424, 4242, 4.2f, 4.242, 4.24242};
 
-    q.fill(mem, pattern, count);
-    q.wait();
-
-    for (int i = 0; i < count; i++) {
-      assert(mem[i] == pattern);
-    }
+  if (dev.get_info<info::device::usm_host_allocations>()) {
+    runHostTests<short>(dev, ctxt, q, 4);
+    runHostTests<int>(dev, ctxt, q, 42);
+    runHostTests<long>(dev, ctxt, q, 424);
+    runHostTests<long long>(dev, ctxt, q, 4242);
+    runHostTests<sycl::half>(dev, ctxt, q, sycl::half(4.2f));
+    runHostTests<float>(dev, ctxt, q, 4.242f);
+    runHostTests<double>(dev, ctxt, q, 4.24242);
+    runHostTests<test_struct>(dev, ctxt, q, test_obj);
   }
-  std::cout << "Passed\n";
+
+  if (dev.get_info<info::device::usm_shared_allocations>()) {
+    runSharedTests<short>(dev, ctxt, q, 4);
+    runSharedTests<int>(dev, ctxt, q, 42);
+    runSharedTests<long>(dev, ctxt, q, 424);
+    runSharedTests<long long>(dev, ctxt, q, 4242);
+    runSharedTests<sycl::half>(dev, ctxt, q, sycl::half(4.2f));
+    runSharedTests<float>(dev, ctxt, q, 4.242f);
+    runSharedTests<double>(dev, ctxt, q, 4.24242);
+    runSharedTests<test_struct>(dev, ctxt, q, test_obj);
+  }
+
+  if (dev.get_info<info::device::usm_device_allocations>()) {
+    runDeviceTests<short>(dev, ctxt, q, 4);
+    runDeviceTests<int>(dev, ctxt, q, 42);
+    runDeviceTests<long>(dev, ctxt, q, 420);
+    runDeviceTests<long long>(dev, ctxt, q, 4242);
+    runDeviceTests<sycl::half>(dev, ctxt, q, sycl::half(4.2f));
+    runDeviceTests<float>(dev, ctxt, q, 4.242f);
+    runDeviceTests<double>(dev, ctxt, q, 4.24242);
+    runDeviceTests<test_struct>(dev, ctxt, q, test_obj);
+  }
+
   return 0;
 }

--- a/SYCL/USM/memcpy.cpp
+++ b/SYCL/USM/memcpy.cpp
@@ -16,51 +16,321 @@
 
 using namespace cl::sycl;
 
-static constexpr int count = 100;
+static constexpr int N = 100;
+static constexpr int VAL = 42;
+
+void init_on_host(queue q, int *arr) {
+  for (int i = 0; i < N; ++i) {
+    arr[i] = VAL;
+  }
+}
+
+void check_on_host(queue q, int *arr) {
+  for (int i = 0; i < N; ++i) {
+    assert(arr[i] == VAL);
+  }
+}
+
+void init_on_device(queue q, int *arr) {
+  q.submit([&](handler &h) {
+     h.parallel_for<class usm_device_init>(
+         range<1>(N), [=](id<1> item) { arr[item] = VAL; });
+   }).wait();
+}
+
+void check_on_device(queue q, int *arr) {
+  std::vector<int> out;
+  out.resize(N);
+  {
+    buffer<int, 1> buf{&out[0], range<1>{N}};
+    q.submit([&](handler &h) {
+       auto acc = buf.template get_access<access::mode::write>(h);
+       h.parallel_for<class usm_device_transfer>(
+           range<1>(N), [=](id<1> item) { acc[item] = arr[item]; });
+     }).wait();
+  }
+
+  for (int i = 0; i < N; ++i) {
+    assert(out[i] == VAL);
+  }
+}
+
+#define USM_MALLOC(ARR, ALLOC_TYPE)                                            \
+  ARR = (int *)malloc_##ALLOC_TYPE(N * sizeof(int), q);
+
+#define USM_ALIGNED_ALLOC_HOST(ARR)                                            \
+  ARR = (int *)aligned_alloc_host(alignof(long long), N * sizeof(int), ctxt);
+
+#define USM_ALIGNED_ALLOC_SHARED(ARR)                                          \
+  ARR = (int *)aligned_alloc_shared(alignof(long long), N * sizeof(int), dev,  \
+                                    ctxt);
+
+#define USM_ALIGNED_ALLOC_DEVICE(ARR)                                          \
+  ARR = (int *)aligned_alloc_device(alignof(long long), N * sizeof(int), dev,  \
+                                    ctxt);
+
+#define TEST_MEMCPY(FROM_ARR, FROM_INIT, TO_ARR, TO_CHECK)                     \
+  {                                                                            \
+    FROM_INIT(q, FROM_ARR);                                                    \
+    q.submit(                                                                  \
+        [&](handler &h) { h.memcpy(TO_ARR, FROM_ARR, N * sizeof(int)); });     \
+    q.wait_and_throw();                                                        \
+    TO_CHECK(q, TO_ARR);                                                       \
+    free(FROM_ARR, ctxt);                                                      \
+    free(TO_ARR, ctxt);                                                        \
+  }
+
+#define TEST_MEMCPY_TO_NULLPTR(ARR)                                            \
+  {                                                                            \
+    try {                                                                      \
+      /* Copying to nullptr should throw. */                                   \
+      q.submit(                                                                \
+          [&](handler &cgh) { cgh.memcpy(nullptr, ARR, sizeof(int) * N); });   \
+      q.wait_and_throw();                                                      \
+      assert(false && "Expected error from copying to nullptr");               \
+    } catch (runtime_error e) {                                                \
+    }                                                                          \
+    /* Copying to nullptr should throw. */                                     \
+    q.submit([&](handler &cgh) { cgh.memcpy(nullptr, ARR, 0); });              \
+    q.wait_and_throw();                                                        \
+    free(ARR, ctxt);                                                           \
+  }
 
 int main() {
   queue q([](exception_list el) {
     for (auto &e : el)
       std::rethrow_exception(e);
   });
-  if (q.get_device().get_info<info::device::usm_shared_allocations>()) {
-    float *src = (float *)malloc_shared(sizeof(float) * count, q.get_device(),
-                                        q.get_context());
-    float *dest = (float *)malloc_shared(sizeof(float) * count, q.get_device(),
-                                         q.get_context());
-    for (int i = 0; i < count; i++)
-      src[i] = i;
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
+  int *inArray;
+  int *outArray;
 
-    event init_copy = q.submit(
-        [&](handler &cgh) { cgh.memcpy(dest, src, sizeof(float) * count); });
+  if (dev.get_info<info::device::usm_host_allocations>()) {
+    // Test host to host
+    USM_MALLOC(inArray, host)
+    USM_MALLOC(outArray, host)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
 
-    q.submit([&](handler &cgh) {
-      cgh.depends_on(init_copy);
-      cgh.single_task<class double_dest>([=]() {
-        for (int i = 0; i < count; i++)
-          dest[i] *= 2;
-      });
-    });
-    q.wait_and_throw();
+    // Test aligned host to aligned host
+    USM_ALIGNED_ALLOC_HOST(inArray)
+    USM_ALIGNED_ALLOC_HOST(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
 
-    for (int i = 0; i < count; i++) {
-      assert(dest[i] == i * 2);
-    }
+    // Test host to aligned host
+    USM_MALLOC(inArray, host)
+    USM_ALIGNED_ALLOC_HOST(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
 
-    try {
-      // Copying to nullptr should throw.
-      q.submit([&](handler &cgh) {
-        cgh.memcpy(nullptr, src, sizeof(float) * count);
-      });
-      q.wait_and_throw();
-      assert(false && "Expected error from copying to nullptr");
-    } catch (runtime_error e) {
-    }
+    // Test aligned host to host
+    USM_ALIGNED_ALLOC_HOST(inArray)
+    USM_MALLOC(outArray, host)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
 
-    // Copying to nullptr is skipped if the number of bytes to copy is 0.
-    q.submit([&](handler &cgh) { cgh.memcpy(nullptr, src, 0); });
-    q.wait_and_throw();
+    // Test copy to null from host
+    USM_MALLOC(inArray, host)
+    TEST_MEMCPY_TO_NULLPTR(inArray)
+
+    // Test copy to null from aligned host
+    USM_ALIGNED_ALLOC_HOST(inArray)
+    TEST_MEMCPY_TO_NULLPTR(inArray)
   }
-  std::cout << "Passed\n";
+
+  if (dev.get_info<info::device::usm_shared_allocations>()) {
+    // Test shared to shared
+    USM_MALLOC(inArray, shared)
+    USM_MALLOC(outArray, shared)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test aligned shared to aligned shared
+    USM_ALIGNED_ALLOC_SHARED(inArray)
+    USM_ALIGNED_ALLOC_SHARED(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test shared to aligned shared
+    USM_MALLOC(inArray, shared)
+    USM_ALIGNED_ALLOC_SHARED(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test aligned shared to shared
+    USM_ALIGNED_ALLOC_SHARED(inArray)
+    USM_MALLOC(outArray, shared)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test copy to null from shared
+    USM_MALLOC(inArray, shared)
+    TEST_MEMCPY_TO_NULLPTR(inArray)
+
+    // Test copy to null from aligned shared
+    USM_ALIGNED_ALLOC_SHARED(inArray)
+    TEST_MEMCPY_TO_NULLPTR(inArray)
+  }
+
+  if (dev.get_info<info::device::usm_device_allocations>()) {
+    // Test device to device
+    USM_MALLOC(inArray, device)
+    USM_MALLOC(outArray, device)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_device)
+
+    // Test aligned device to aligned device
+    USM_ALIGNED_ALLOC_DEVICE(inArray)
+    USM_ALIGNED_ALLOC_DEVICE(outArray)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_device)
+
+    // Test device to aligned device
+    USM_MALLOC(inArray, shared)
+    USM_ALIGNED_ALLOC_DEVICE(outArray)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_device)
+
+    // Test aligned device to device
+    USM_ALIGNED_ALLOC_DEVICE(inArray)
+    USM_MALLOC(outArray, device)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_device)
+
+    // Test copy to null from device
+    USM_MALLOC(inArray, device)
+    TEST_MEMCPY_TO_NULLPTR(inArray)
+
+    // Test copy to null from aligned device
+    USM_ALIGNED_ALLOC_DEVICE(inArray)
+    TEST_MEMCPY_TO_NULLPTR(inArray)
+  }
+
+  if (dev.get_info<info::device::usm_host_allocations>() &&
+      dev.get_info<info::device::usm_shared_allocations>()) {
+    // Test host to shared
+    USM_MALLOC(inArray, host)
+    USM_MALLOC(outArray, shared)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test shared to host
+    USM_MALLOC(inArray, shared)
+    USM_MALLOC(outArray, host)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test aligned host to aligned shared
+    USM_ALIGNED_ALLOC_HOST(inArray)
+    USM_ALIGNED_ALLOC_SHARED(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test aligned shared to aligned host
+    USM_ALIGNED_ALLOC_SHARED(inArray)
+    USM_ALIGNED_ALLOC_HOST(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test host to aligned shared
+    USM_MALLOC(inArray, host)
+    USM_ALIGNED_ALLOC_SHARED(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test shared to aligned host
+    USM_MALLOC(inArray, shared)
+    USM_ALIGNED_ALLOC_HOST(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test aligned shared to host
+    USM_ALIGNED_ALLOC_SHARED(inArray)
+    USM_MALLOC(outArray, host)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+
+    // Test aligned host to shared
+    USM_ALIGNED_ALLOC_HOST(inArray)
+    USM_MALLOC(outArray, shared)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_host)
+  }
+
+  if (dev.get_info<info::device::usm_host_allocations>() &&
+      dev.get_info<info::device::usm_device_allocations>()) {
+    // Test host to device
+    USM_MALLOC(inArray, host)
+    USM_MALLOC(outArray, device)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+
+    // Test device to host
+    USM_MALLOC(inArray, device)
+    USM_MALLOC(outArray, host)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test aligned host to aligned device
+    USM_ALIGNED_ALLOC_HOST(inArray)
+    USM_ALIGNED_ALLOC_DEVICE(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+
+    // Test aligned device to aligned host
+    USM_ALIGNED_ALLOC_DEVICE(inArray)
+    USM_ALIGNED_ALLOC_HOST(outArray)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test host to aligned device
+    USM_MALLOC(inArray, host)
+    USM_ALIGNED_ALLOC_DEVICE(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+
+    // Test device to aligned host
+    USM_MALLOC(inArray, device)
+    USM_ALIGNED_ALLOC_HOST(outArray)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test aligned device to host
+    USM_ALIGNED_ALLOC_DEVICE(inArray)
+    USM_MALLOC(outArray, host)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test aligned host to device
+    USM_ALIGNED_ALLOC_HOST(inArray)
+    USM_MALLOC(outArray, device)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+  }
+
+  if (dev.get_info<info::device::usm_host_allocations>() &&
+      dev.get_info<info::device::usm_device_allocations>()) {
+    // Test shared to device
+    USM_MALLOC(inArray, shared)
+    USM_MALLOC(outArray, device)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+
+    // Test device to shared
+    USM_MALLOC(inArray, device)
+    USM_MALLOC(outArray, shared)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test aligned shared to aligned device
+    USM_ALIGNED_ALLOC_SHARED(inArray)
+    USM_ALIGNED_ALLOC_DEVICE(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+
+    // Test aligned device to aligned shared
+    USM_ALIGNED_ALLOC_DEVICE(inArray)
+    USM_ALIGNED_ALLOC_SHARED(outArray)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test shared to aligned device
+    USM_MALLOC(inArray, shared)
+    USM_ALIGNED_ALLOC_DEVICE(outArray)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+
+    // Test device to aligned shared
+    USM_MALLOC(inArray, device)
+    USM_ALIGNED_ALLOC_SHARED(outArray)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test aligned device to shared
+    USM_ALIGNED_ALLOC_DEVICE(inArray)
+    USM_MALLOC(outArray, shared)
+    TEST_MEMCPY(inArray, init_on_device, outArray, check_on_host)
+
+    // Test aligned shared to device
+    USM_ALIGNED_ALLOC_SHARED(inArray)
+    USM_MALLOC(outArray, device)
+    TEST_MEMCPY(inArray, init_on_host, outArray, check_on_device)
+  }
+
   return 0;
 }
+
+#undef TEST_MEMCPY_TO_NULLPTR
+#undef TEST_MEMCPY
+#undef USM_ALIGNED_ALLOC_HOST
+#undef USM_ALIGNED_ALLOC_SHARED
+#undef USM_ALIGNED_ALLOC_DEVICE
+#undef USM_MALLOC

--- a/SYCL/USM/memset.cpp
+++ b/SYCL/USM/memset.cpp
@@ -15,47 +15,126 @@
 
 using namespace cl::sycl;
 
-static constexpr int count = 100;
+static constexpr int N = 100;
+static constexpr int VAL = 3;
 
 int main() {
   queue q([](exception_list el) {
     for (auto &e : el)
       std::rethrow_exception(e);
   });
-  if (q.get_device().get_info<info::device::usm_shared_allocations>()) {
-    uint32_t *src = (uint32_t *)malloc_shared(sizeof(uint32_t) * count,
-                                              q.get_device(), q.get_context());
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
+  char *array;
 
-    event init_copy = q.submit(
-        [&](handler &cgh) { cgh.memset(src, 0x15, sizeof(uint32_t) * count); });
-
-    q.submit([&](handler &cgh) {
-      cgh.depends_on(init_copy);
-      cgh.single_task<class double_dest>([=]() {
-        for (int i = 0; i < count; i++)
-          src[i] *= 2;
-      });
-    });
-    q.wait_and_throw();
-
-    for (int i = 0; i < count; i++) {
-      assert(src[i] == 0x2a2a2a2a);
+  if (dev.get_info<info::device::usm_host_allocations>()) {
+    // Test memset on host
+    array = (char *)malloc_host(N * sizeof(char), q);
+    q.submit([&](handler &h) {
+       h.memset(array, VAL, N * sizeof(char));
+     }).wait();
+    for (int i = 0; i < N; ++i) {
+      assert(array[i] == VAL);
     }
+    free(array, ctxt);
 
-    try {
-      // Filling to nullptr should throw.
-      q.submit([&](handler &cgh) {
-        cgh.memset(nullptr, 0, sizeof(uint32_t) * count);
+    // Test memset on aligned host
+    array =
+        (char *)aligned_alloc_host(alignof(long long), N * sizeof(char), ctxt);
+    q.submit([&](handler &h) {
+       h.memset(array, VAL, N * sizeof(char));
+     }).wait();
+    for (int i = 0; i < N; ++i) {
+      assert(array[i] == VAL);
+    }
+    free(array, ctxt);
+  }
+
+  if (dev.get_info<info::device::usm_shared_allocations>()) {
+    // Test memset on shared
+    array = (char *)malloc_shared(N * sizeof(char), q);
+    q.submit([&](handler &h) {
+       h.memset(array, VAL, N * sizeof(char));
+     }).wait();
+    for (int i = 0; i < N; ++i) {
+      assert(array[i] == VAL);
+    }
+    free(array, ctxt);
+
+    // Test memset on aligned shared
+    array = (char *)aligned_alloc_shared(alignof(long long), N * sizeof(char),
+                                         dev, ctxt);
+    q.submit([&](handler &h) {
+       h.memset(array, VAL, N * sizeof(char));
+     }).wait();
+    for (int i = 0; i < N; ++i) {
+      assert(array[i] == VAL);
+    }
+    free(array, ctxt);
+  }
+
+  if (dev.get_info<info::device::usm_device_allocations>()) {
+    std::vector<char> out;
+    out.resize(N);
+
+    // Test memset on device
+    array = (char *)malloc_device(N * sizeof(char), q);
+    q.submit([&](handler &h) {
+       h.memset(array, VAL, N * sizeof(char));
+     }).wait();
+
+    {
+      buffer<char, 1> buf{&out[0], range<1>{N}};
+      q.submit([&](handler &h) {
+        auto acc = buf.template get_access<access::mode::write>(h);
+        h.parallel_for<class usm_device_transfer>(
+            range<1>(N), [=](id<1> item) { acc[item] = array[item]; });
       });
       q.wait_and_throw();
-      assert(false && "Expected error from writing to nullptr");
-    } catch (runtime_error e) {
     }
 
-    // Filling to nullptr is skipped if the number of bytes to fill is 0.
-    q.submit([&](handler &cgh) { cgh.memset(nullptr, 0, 0); });
-    q.wait_and_throw();
+    for (int i = 0; i < N; ++i) {
+      assert(out[i] == VAL);
+    }
+    free(array, ctxt);
+
+    out.clear();
+    out.resize(N);
+
+    // Test memset on aligned device
+    array = (char *)aligned_alloc_device(alignof(long long), N * sizeof(char),
+                                         dev, ctxt);
+    q.submit([&](handler &h) {
+       h.memset(array, VAL, N * sizeof(char));
+     }).wait();
+
+    {
+      buffer<char, 1> buf{&out[0], range<1>{N}};
+      q.submit([&](handler &h) {
+        auto acc = buf.template get_access<access::mode::write>(h);
+        h.parallel_for<class usm_aligned_device_transfer>(
+            range<1>(N), [=](id<1> item) { acc[item] = array[item]; });
+      });
+      q.wait_and_throw();
+    }
+
+    for (int i = 0; i < N; ++i) {
+      assert(out[i] == VAL);
+    }
+    free(array, ctxt);
   }
-  std::cout << "Passed\n";
+
+  try {
+    // Filling to nullptr should throw.
+    q.submit([&](handler &cgh) { cgh.memset(nullptr, 0, N * sizeof(char)); });
+    q.wait_and_throw();
+    assert(false && "Expected error from writing to nullptr");
+  } catch (runtime_error e) {
+  }
+
+  // Filling to nullptr is skipped if the number of bytes to fill is 0.
+  q.submit([&](handler &cgh) { cgh.memset(nullptr, 0, 0); });
+  q.wait_and_throw();
+
   return 0;
 }


### PR DESCRIPTION
Extends the coverage of the USM operations memcpy, fill, and memset by
testing for both regular and aligned allocations for the host, shared,
and device allocation types.

Migrated from: https://github.com/intel/llvm/pull/3189