### PR TITLE
Sampler Lit Tests

### DIFF
--- a/SYCL/Sampler/basic-rw.cpp
+++ b/SYCL/Sampler/basic-rw.cpp
@@ -1,0 +1,131 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data, and verifies that the
+   data can be read directly.
+
+    Use it as a base file for testing any condition.
+
+    clang++ -fsycl -sycl-std=121 -o binx.bin basic-rw.cpp
+
+    SYCL_DEVICE_FILTER=opencl:gpu ./binx.bin
+    SYCL_DEVICE_FILTER=level_zero:gpu ./binx.bin
+    SYCL_DEVICE_FILTER=opencl:cpu ./binx.bin
+
+    SYCL_DEVICE_FILTER=opencl:host ./binx.bin
+    SYCL_DEVICE_FILTER=opecl:acc ../binx.bin    <--  does not support image
+   operations at this time.
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+void test_rw(image_channel_order ChanOrder, image_channel_type ChanType) {
+  int numTests = 4; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_Unorm_Linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // verify our four pixels were set up correctly.
+        // 0-3 read four pixels. no sampler
+        test_acc[i++] = image_acc.read(0); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(1); // {49,48,47,46}
+        test_acc[i++] = image_acc.read(2); // {59,58,57,56}
+        test_acc[i++] = image_acc.read(3); // {11,12,13,14}
+
+        // Add more tests below. Just be sure to increase the numTests counter
+        // at the beginning of this function
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 0;
+        std::cout << "read four pixels, no sampler" << std::endl;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << i << /* " -- " << idx << */ ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_rw(image_channel_order::rgba, image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// CHECK: read four pixels, no sampler
+// CHECK-NEXT: 0: {1,2,3,4}
+// CHECK-NEXT: 1: {49,48,47,46}
+// CHECK-NEXT: 2: {59,58,57,56}
+// CHECK-NEXT: 3: {11,12,13,14}

--- a/SYCL/Sampler/basic-rw.cpp
+++ b/SYCL/Sampler/basic-rw.cpp
@@ -35,8 +35,6 @@ void outputPixel(sycl::uint4 somePixel) {
             << "," << somePixel[3] << "} ";
 }
 
-// some constants.
-
 // 4 pixels on a side. 1D at the moment
 constexpr long width = 4;
 

--- a/SYCL/Sampler/basic-rw.cpp
+++ b/SYCL/Sampler/basic-rw.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/basic-rw.cpp
+++ b/SYCL/Sampler/basic-rw.cpp
@@ -114,7 +114,9 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
-    test_rw(image_channel_order::rgba, image_channel_type::unsigned_int8);
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
+    test_rw(image_channel_order::rgba, image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-clamp-linear.cpp
+++ b/SYCL/Sampler/normalized-clamp-linear.cpp
@@ -1,0 +1,180 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+
+// GPU does not correctly interpolate when using clamp.  Waiting on fix.
+// Both OCL and LevelZero have this issue.
+// CPU failing all linear interpolation at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    CLAMP address_mode and LINEAR filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto linear = filtering_mode::linear;
+
+void test_normalized_clamp_linear_sampler(image_channel_order ChanOrder,
+                                          image_channel_type ChanType) {
+  int numTests = 9; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_Clamp_Linear_sampler =
+        sampler(normalized, addressing_mode::clamp, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-6 read seven pixels at 'boundary' locations, starting out of
+        // bounds,  sample:   Normalized +  Clamp  + Linear
+        test_acc[i++] =
+            image_acc.read(-0.25f, Norm_Clamp_Linear_sampler); // {0,0,0,0}
+        test_acc[i++] = image_acc.read(
+            0.00f,
+            Norm_Clamp_Linear_sampler); // {0,1,2,2} // interpolating with bg
+                                        // color. consistent with unnormalized.
+                                        // Doesn't seem 100% correct to me, but
+                                        // don't ahve anything to compare
+                                        // against presnetly
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_Clamp_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_Clamp_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_Clamp_Linear_sampler); // {35,35,35,35}
+        test_acc[i++] = image_acc.read(
+            1.00f,
+            Norm_Clamp_Linear_sampler); // {6,6,6,7}  // interpolating with bg
+        test_acc[i++] =
+            image_acc.read(1.25f, Norm_Clamp_Linear_sampler); // {0,0,0,0}
+
+        // 7-8 read two pixels on either side of first pixel. float coordinates.
+        // CLAMP
+        //  on GPU CLAMP is apparently stopping the interpolation. ( values on
+        //  right are expected value)
+        test_acc[i++] =
+            image_acc.read(0.2499f, Norm_Clamp_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(0.2501f, Norm_Clamp_Linear_sampler); // {25,25,25,25}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = -1;
+        std::cout << "read six pixels at 'boundary' locations, starting out of "
+                     "bounds,  sample:   Normalized +  Clamp  + Linear"
+                  << std::endl;
+      }
+      if (i == 7) {
+        idx = 1;
+        std::cout << "read two pixels on either side of first pixel. float "
+                     "coordinates. Normalized +  Clamp  + Linear"
+                  << std::endl;
+      }
+      if (i == 8) {
+        idx = 1;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_clamp_linear_sampler(image_channel_order::rgba,
+                                         image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read six pixels at 'boundary' locations, starting out of bounds,  sample:   Normalized +  Clamp  + Linear
+// CHECK-NEXT: 0 -- -1: {0,0,0,0} 
+// CHECK-NEXT: 1 -- 0: {0,1,2,2} 
+// CHECK-NEXT: 2 -- 1: {25,25,25,25} 
+// CHECK-NEXT: 3 -- 2: {54,53,52,51} 
+// CHECK-NEXT: 4 -- 3: {35,35,35,35} 
+// CHECK-NEXT: 5 -- 4: {6,6,6,7} 
+// CHECK-NEXT: 6 -- 5: {0,0,0,0} 
+// CHECK-NEXT: read two pixels on either side of first pixel. float coordinates. Normalized +  Clamp  + Linear
+// CHECK-NEXT: 7 -- 1: {25,25,25,25} 
+// CHECK-NEXT: 8 -- 1: {25,25,25,25}
+// clang-format on

--- a/SYCL/Sampler/normalized-clamp-linear.cpp
+++ b/SYCL/Sampler/normalized-clamp-linear.cpp
@@ -160,8 +160,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_clamp_linear_sampler(image_channel_order::rgba,
-                                         image_channel_type::unsigned_int8);
+                                         image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-clamp-linear.cpp
+++ b/SYCL/Sampler/normalized-clamp-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 
 // GPU does not correctly interpolate when using clamp.  Waiting on fix.
 // Both OCL and LevelZero have this issue.

--- a/SYCL/Sampler/normalized-clamp-linear.cpp
+++ b/SYCL/Sampler/normalized-clamp-linear.cpp
@@ -1,5 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// XFAIL: gpu && (level_zero || opencl)
+// XFAIL: cpu
 
 // GPU does not correctly interpolate when using clamp.  Waiting on fix.
 // Both OCL and LevelZero have this issue.

--- a/SYCL/Sampler/normalized-clamp-linear.cpp
+++ b/SYCL/Sampler/normalized-clamp-linear.cpp
@@ -2,12 +2,13 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// XFAIL: gpu && (level_zero || opencl)
+// XFAIL: gpu && (level_zero || opencl || cuda)
 // XFAIL: cpu
 
 // GPU does not correctly interpolate when using clamp.  Waiting on fix.
 // Both OCL and LevelZero have this issue.
 // CPU failing all linear interpolation at moment. Waiting on fix.
+// CUDA fails all linear interpolation. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/normalized-clamp-nearest.cpp
@@ -1,0 +1,164 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    CLAMP address_mode and NEAREST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_normalized_clamp_nearest_sampler(image_channel_order ChanOrder,
+                                           image_channel_type ChanType) {
+  int numTests = 7; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_Clamp_Nearest_sampler =
+        sampler(normalized, addressing_mode::clamp, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_nearest>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-3 read four pixels at low-boundary locations,  sample:   Normalized
+        // +  Clamp  + Nearest
+        test_acc[i++] =
+            image_acc.read(0.00f, Norm_Clamp_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_Clamp_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_Clamp_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_Clamp_Nearest_sampler); // {11,12,13,14}
+
+        // 4-6 read three pixels out of bounds,   sample:   Normalized + Clamp +
+        // Nearest
+        test_acc[i++] =
+            image_acc.read(-0.125f, Norm_Clamp_Nearest_sampler); // {0,0,0,0}
+        test_acc[i++] =
+            image_acc.read(1.0f, Norm_Clamp_Nearest_sampler); // {0,0,0,0}
+        test_acc[i++] =
+            image_acc.read(1.125f, Norm_Clamp_Nearest_sampler); // {0,0,0,0}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 0;
+        std::cout << "read four pixels at low-boundary locations,  sample:   "
+                     "Normalized +  Clamp  + Nearest"
+                  << std::endl;
+      }
+      if (i == 4) {
+        idx = -1;
+        std::cout << "read three pixels out of bounds,   sample:   Normalized "
+                     "+ Clamp + Nearest"
+                  << std::endl;
+      }
+      if (i == 5) {
+        idx = 4;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_clamp_nearest_sampler(image_channel_order::rgba,
+                                          image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read four pixels at low-boundary locations,  sample:   Normalized +  Clamp  + Nearest
+// CHECK-NEXT: 0 -- 0: {1,2,3,4} 
+// CHECK-NEXT: 1 -- 1: {49,48,47,46} 
+// CHECK-NEXT: 2 -- 2: {59,58,57,56} 
+// CHECK-NEXT: 3 -- 3: {11,12,13,14} 
+// CHECK-NEXT: read three pixels out of bounds,   sample:   Normalized + Clamp + Nearest
+// CHECK-NEXT: 4 -- -1: {0,0,0,0} 
+// CHECK-NEXT: 5 -- 4: {0,0,0,0} 
+// CHECK-NEXT: 6 -- 5: {0,0,0,0}
+// clang-format on

--- a/SYCL/Sampler/normalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/normalized-clamp-nearest.cpp
@@ -4,7 +4,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // XFAIL: level_zero
 
-// LevelZero has a bug wherein it always returns the first pixel value. Will re-enable once fixed.
+// LevelZero has a bug wherein it always returns the first pixel value.
+// Will re-enable once fixed.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/normalized-clamp-nearest.cpp
@@ -2,6 +2,9 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// XFAIL: level_zero
+
+// LevelZero has a bug wherein it always returns the first pixel value. Will re-enable once fixed.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/normalized-clamp-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/normalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/normalized-clamp-nearest.cpp
@@ -145,8 +145,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_clamp_nearest_sampler(image_channel_order::rgba,
-                                          image_channel_type::unsigned_int8);
+                                          image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear.cpp
@@ -1,0 +1,166 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+// CPU failing all linear interpolation at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    CLAMPEDGE address_mode and LINEAR filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto clamp_edge = addressing_mode::clamp_to_edge;
+constexpr auto linear = filtering_mode::linear;
+
+void test_normalized_clampedge_linear_sampler(image_channel_order ChanOrder,
+                                              image_channel_type ChanType) {
+  int numTests = 7; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_ClampEdge_Linear_sampler =
+        sampler(normalized, clamp_edge, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-2 read three pixels at inner boundary locations,  sample:
+        // Normalized +  ClampEdge  + Linear
+        test_acc[i++] = image_acc.read(
+            0.25f, Norm_ClampEdge_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] = image_acc.read(
+            0.50f, Norm_ClampEdge_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] = image_acc.read(
+            0.75f, Norm_ClampEdge_Linear_sampler); // {35,35,35,35}
+
+        // 3-6 read four pixels at either side of outer boundary with Normlized
+        // + ClampEdge + Linear
+        test_acc[i++] =
+            image_acc.read(-0.111f, Norm_ClampEdge_Linear_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.0f, Norm_ClampEdge_Linear_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            0.999f, Norm_ClampEdge_Linear_sampler); // {11,12,13,14}
+        test_acc[i++] = image_acc.read(
+            1.0f, Norm_ClampEdge_Linear_sampler); // {11,12,13,14}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 1;
+        std::cout << "read three pixels at inner boundary locations,  sample:  "
+                     " Normalized +  ClampEdge  + Linear"
+                  << std::endl;
+      }
+      if (i == 3) {
+        idx = -1;
+        std::cout << "read four pixels at either side of outer boundary with "
+                     "Normlized + ClampEdge + Linear"
+                  << std::endl;
+      }
+      if (i == 5) {
+        idx = 3;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_clampedge_linear_sampler(image_channel_order::rgba,
+                                             image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read three pixels at inner boundary locations,  sample:   Normalized +  ClampEdge  + Linear
+// CHECK-NEXT: 0 -- 1: {25,25,25,25} 
+// CHECK-NEXT: 1 -- 2: {54,53,52,51} 
+// CHECK-NEXT: 2 -- 3: {35,35,35,35} 
+// CHECK-NEXT: read four pixels at either side of outer boundary with Normlized + ClampEdge + Linear
+// CHECK-NEXT: 3 -- -1: {1,2,3,4} 
+// CHECK-NEXT: 4 -- 0: {1,2,3,4} 
+// CHECK-NEXT: 5 -- 3: {11,12,13,14} 
+// CHECK-NEXT: 6 -- 4: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/normalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear.cpp
@@ -3,8 +3,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
+// XFAIL: cuda
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
+// CUDA failing all linear interpolation at moment. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
 // CPU failing all linear interpolation at moment. Waiting on fix.

--- a/SYCL/Sampler/normalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// XFAIL: cpu
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 

--- a/SYCL/Sampler/normalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear.cpp
@@ -4,9 +4,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
 // XFAIL: cuda
+// UNSUPPORTED: level_zero && windows
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 // CUDA failing all linear interpolation at moment. Waiting on fix.
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear.cpp
@@ -146,8 +146,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
-    test_normalized_clampedge_linear_sampler(image_channel_order::rgba,
-                                             image_channel_type::unsigned_int8);
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
+    test_normalized_clampedge_linear_sampler(
+        image_channel_order::rgba, image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/normalized-clampedge-nearest.cpp
@@ -1,0 +1,164 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    CLAMPEDGE address_mode and NEAREST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto clamp_edge = addressing_mode::clamp_to_edge;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_normalized_clampedge_nearest_sampler(image_channel_order ChanOrder,
+                                               image_channel_type ChanType) {
+  int numTests = 7; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_ClampEdge_Nearest_sampler =
+        sampler(normalized, clamp_edge, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_nearest>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-3 read four pixels at low-boundary locations,  sample:   Normalized
+        // +  Clamp To Edge  + Nearest
+        test_acc[i++] =
+            image_acc.read(0.00f, Norm_ClampEdge_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            0.25f, Norm_ClampEdge_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] = image_acc.read(
+            0.50f, Norm_ClampEdge_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] = image_acc.read(
+            0.75f, Norm_ClampEdge_Nearest_sampler); // {11,12,13,14}
+
+        // 4-6 read three pixels out of buonds,   sample:   Normalized + Clamp
+        // To Edge + Nearest
+        test_acc[i++] = image_acc.read(
+            -0.125f, Norm_ClampEdge_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            1.0f, Norm_ClampEdge_Nearest_sampler); // {11,12,13,14}
+        test_acc[i++] = image_acc.read(
+            1.125f, Norm_ClampEdge_Nearest_sampler); // {11,12,13,14}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 0;
+        std::cout << "read four pixels at low-boundary locations,  sample:   "
+                     "Normalized +  Clamp To Edge  + Nearest"
+                  << std::endl;
+      }
+      if (i == 4) {
+        idx = -1;
+        std::cout << "read three pixels out of buonds,   sample:   Normalized "
+                     "+ Clamp To Edge + Nearest"
+                  << std::endl;
+      }
+      if (i == 5) {
+        idx = 4;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_clampedge_nearest_sampler(
+        image_channel_order::rgba, image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read four pixels at low-boundary locations,  sample:   Normalized +  Clamp To Edge  + Nearest
+// CHECK-NEXT: 0 -- 0: {1,2,3,4} 
+// CHECK-NEXT: 1 -- 1: {49,48,47,46} 
+// CHECK-NEXT: 2 -- 2: {59,58,57,56} 
+// CHECK-NEXT: 3 -- 3: {11,12,13,14} 
+// CHECK-NEXT: read three pixels out of buonds,   sample:   Normalized + Clamp To Edge + Nearest
+// CHECK-NEXT: 4 -- -1: {1,2,3,4} 
+// CHECK-NEXT: 5 -- 4: {11,12,13,14} 
+// CHECK-NEXT: 6 -- 5: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/normalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/normalized-clampedge-nearest.cpp
@@ -142,8 +142,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_clampedge_nearest_sampler(
-        image_channel_order::rgba, image_channel_type::unsigned_int8);
+        image_channel_order::rgba, image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/normalized-clampedge-nearest.cpp
@@ -2,6 +2,9 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// UNSUPPORTED: level_zero && windows
+
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/normalized-clampedge-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/normalized-mirror-linear.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear.cpp
@@ -1,0 +1,183 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+// CPU failing all linear interpolation at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    MIRROR_REPEAT address_mode and LINEAR filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto mirrored = addressing_mode::mirrored_repeat;
+constexpr auto linear = filtering_mode::linear;
+
+void test_normalized_mirrored_linear_sampler(image_channel_order ChanOrder,
+                                             image_channel_type ChanType) {
+  int numTests = 11; // drives the size of the testResults buffer, and the
+                     // number of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_Mirror_Linear_sampler = sampler(normalized, mirrored, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-2 read three pixels at inner boundary locations,  sample:
+        // Normalized +  Mirrored  + Linear
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_Mirror_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_Mirror_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_Mirror_Linear_sampler); // {35,35,35,35}
+
+        // 3-6 read four pixels above right bound,   sample: Normalized +
+        // Mirrored + Linear
+        test_acc[i++] =
+            image_acc.read(1.0f, Norm_Mirror_Linear_sampler); // {11,12,13,14}
+        test_acc[i++] =
+            image_acc.read(1.25f, Norm_Mirror_Linear_sampler); // {35,35,35,35}
+        test_acc[i++] =
+            image_acc.read(1.5f, Norm_Mirror_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(1.75f, Norm_Mirror_Linear_sampler); // {25,25,25,25}
+        // 7-10 read four pixels below left bound. sample: Normalized + Mirrored
+        // + Linear
+        test_acc[i++] =
+            image_acc.read(-0.75f, Norm_Mirror_Linear_sampler); // {35,35,35,35}
+        test_acc[i++] =
+            image_acc.read(-0.5f, Norm_Mirror_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(-0.25f, Norm_Mirror_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(0.0f, Norm_Mirror_Linear_sampler); // {1,2,3,4}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 1;
+        std::cout << "read three pixels at inner boundary locations,  sample:  "
+                     " Normalized +  Mirrored  + Linear"
+                  << std::endl;
+      }
+      if (i == 3) {
+        idx = 0;
+        std::cout << "read four pixels above right bound,   sample: Normalized "
+                     "+ Mirrored + Linear"
+                  << std::endl;
+      }
+      if (i == 7) {
+        idx = 0;
+        std::cout << "read four pixels below left bound. sample: Normalized + "
+                     "Mirrored + Linear"
+                  << std::endl;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_mirrored_linear_sampler(image_channel_order::rgba,
+                                            image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read three pixels at inner boundary locations,  sample:   Normalized +  Mirrored  + Linear
+// CHECK-NEXT: 0 -- 1: {25,25,25,25} 
+// CHECK-NEXT: 1 -- 2: {54,53,52,51} 
+// CHECK-NEXT: 2 -- 3: {35,35,35,35} 
+// CHECK-NEXT: read four pixels above right bound,   sample: Normalized + Mirrored + Linear
+// CHECK-NEXT: 3 -- 0: {11,12,13,14} 
+// CHECK-NEXT: 4 -- 1: {35,35,35,35} 
+// CHECK-NEXT: 5 -- 2: {54,53,52,51} 
+// CHECK-NEXT: 6 -- 3: {25,25,25,25} 
+// CHECK-NEXT: read four pixels below left bound. sample: Normalized + Mirrored + Linear
+// CHECK-NEXT: 7 -- 0: {35,35,35,35} 
+// CHECK-NEXT: 8 -- 1: {54,53,52,51} 
+// CHECK-NEXT: 9 -- 2: {25,25,25,25} 
+// CHECK-NEXT: 10 -- 3: {1,2,3,4}
+// clang-format on

--- a/SYCL/Sampler/normalized-mirror-linear.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear.cpp
@@ -3,8 +3,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
+// XFAIL: cuda
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
+// CUDA failing all linear interpolation at moment. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-mirror-linear.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
 // CPU failing all linear interpolation at moment. Waiting on fix.

--- a/SYCL/Sampler/normalized-mirror-linear.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// XFAIL: cpu
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 

--- a/SYCL/Sampler/normalized-mirror-linear.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear.cpp
@@ -4,9 +4,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
 // XFAIL: cuda
+// UNSUPPORTED: level_zero && windows
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 // CUDA failing all linear interpolation at moment. Waiting on fix.
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-mirror-linear.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear.cpp
@@ -158,8 +158,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_mirrored_linear_sampler(image_channel_order::rgba,
-                                            image_channel_type::unsigned_int8);
+                                            image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-mirror-nearest.cpp
+++ b/SYCL/Sampler/normalized-mirror-nearest.cpp
@@ -1,0 +1,185 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    MIRROR_REPEAT address_mode and NEAREST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto mirrored = addressing_mode::mirrored_repeat;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_normalized_mirrored_nearest_sampler(image_channel_order ChanOrder,
+                                              image_channel_type ChanType) {
+  int numTests = 12; // drives the size of the testResults buffer, and the
+                     // number of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_Mirror_Nearest_sampler = sampler(normalized, mirrored, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_nearest>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-3 read four pixels at low-boundary locations,  sample:   Normalized
+        // + Mirrored Repeat  + Nearest
+        test_acc[i++] =
+            image_acc.read(0.00f, Norm_Mirror_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_Mirror_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_Mirror_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_Mirror_Nearest_sampler); // {11,12,13,14}
+
+        // 4-7 read four pixels outside rightmost boundary,   sample: Normalized
+        // + Mirrored Repeat + Nearest
+        test_acc[i++] =
+            image_acc.read(1.875f, Norm_Mirror_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            1.625f, Norm_Mirror_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] = image_acc.read(
+            1.375f, Norm_Mirror_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] = image_acc.read(
+            1.125f, Norm_Mirror_Nearest_sampler); // {11,12,13,14}
+        // 8-11 read four pixels outside leftmost boundary,   sample: Normalized
+        // + Mirrored Repeat + Nearest
+        test_acc[i++] =
+            image_acc.read(-0.125f, Norm_Mirror_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            -0.375f, Norm_Mirror_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] = image_acc.read(
+            -0.625f, Norm_Mirror_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] = image_acc.read(
+            -0.875f, Norm_Mirror_Nearest_sampler); // {11,12,13,14}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 0;
+        std::cout << "read four pixels at low-boundary locations,  sample:   "
+                     "Normalized + Mirrored Repeat  + Nearest"
+                  << std::endl;
+      }
+      if (i == 4) {
+        idx = 0;
+        std::cout << "read four pixels outside rightmost boundary,   sample: "
+                     "Normalized + Mirrored Repeat + Nearest"
+                  << std::endl;
+      }
+      if (i == 8) {
+        idx = 0;
+        std::cout << "read four pixels outside leftmost boundary,   sample: "
+                     "Normalized + Mirrored Repeat + Nearest"
+                  << std::endl;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_mirrored_nearest_sampler(image_channel_order::rgba,
+                                             image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read four pixels at low-boundary locations,  sample:   Normalized + Mirrored Repeat  + Nearest
+// CHECK-NEXT: 0 -- 0: {1,2,3,4}
+// CHECK-NEXT: 1 -- 1: {49,48,47,46}
+// CHECK-NEXT: 2 -- 2: {59,58,57,56}
+// CHECK-NEXT: 3 -- 3: {11,12,13,14}
+// CHECK-NEXT: read four pixels outside rightmost boundary,   sample: Normalized + Mirrored Repeat + Nearest
+// CHECK-NEXT: 4 -- 0: {1,2,3,4}
+// CHECK-NEXT: 5 -- 1: {49,48,47,46}
+// CHECK-NEXT: 6 -- 2: {59,58,57,56}
+// CHECK-NEXT: 7 -- 3: {11,12,13,14}
+// CHECK-NEXT: read four pixels outside leftmost boundary,   sample: Normalized + Mirrored Repeat + Nearest
+// CHECK-NEXT: 8 -- 0: {1,2,3,4}
+// CHECK-NEXT: 9 -- 1: {49,48,47,46}
+// CHECK-NEXT: 10 -- 2: {59,58,57,56}
+// CHECK-NEXT: 11 -- 3: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/normalized-mirror-nearest.cpp
+++ b/SYCL/Sampler/normalized-mirror-nearest.cpp
@@ -3,9 +3,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // XFAIL: cuda
+// UNSUPPORTED: level_zero && windows
 
 // CUDA is not handling repeat or mirror correctly with normalized coordinates.
 // Waiting on a fix.
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-mirror-nearest.cpp
+++ b/SYCL/Sampler/normalized-mirror-nearest.cpp
@@ -2,6 +2,10 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// XFAIL: cuda
+
+// CUDA is not handling repeat or mirror correctly with normalized coordinates.
+// Waiting on a fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-mirror-nearest.cpp
+++ b/SYCL/Sampler/normalized-mirror-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/normalized-mirror-nearest.cpp
+++ b/SYCL/Sampler/normalized-mirror-nearest.cpp
@@ -157,8 +157,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
-    test_normalized_mirrored_nearest_sampler(image_channel_order::rgba,
-                                             image_channel_type::unsigned_int8);
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
+    test_normalized_mirrored_nearest_sampler(
+        image_channel_order::rgba, image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-none-linear.cpp
+++ b/SYCL/Sampler/normalized-none-linear.cpp
@@ -1,0 +1,163 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+// CPU failing at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    NONE address_mode and LINEAR filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto none = addressing_mode::none;
+constexpr auto linear = filtering_mode::linear;
+
+void test_normalized_none_linear_sampler(image_channel_order ChanOrder,
+                                         image_channel_type ChanType) {
+  int numTests = 7; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_None_Linear_sampler = sampler(normalized, none, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-2 read three pixels at inner boundary locations,  sample:
+        // Normalized +  None  + Linear
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_None_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_None_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_None_Linear_sampler); // {35,35,35,35}
+
+        // 3-6 read four pixels at exact center locations,  sample:   Normalized
+        // +  None  + Linear
+        test_acc[i++] =
+            image_acc.read(0.125f, Norm_None_Linear_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.375f, Norm_None_Linear_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(0.625f, Norm_None_Linear_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(0.875f, Norm_None_Linear_sampler); // {11,12,13,14}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 1;
+        std::cout << "read three pixels at inner boundary locations,  sample:  "
+                     " Normalized +  None  + Linear"
+                  << std::endl;
+      }
+      if (i == 3) {
+        idx = 0;
+        std::cout << "read four pixels at exact center locations,  sample:   "
+                     "Normalized +  None  + Linear"
+                  << std::endl;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_none_linear_sampler(image_channel_order::rgba,
+                                        image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read three pixels at inner boundary locations,  sample:   Normalized +  None  + Linear
+// CHECK-NEXT: 0 -- 1: {25,25,25,25}
+// CHECK-NEXT: 1 -- 2: {54,53,52,51}
+// CHECK-NEXT: 2 -- 3: {35,35,35,35}
+// CHECK-NEXT: read four pixels at exact center locations,  sample:   Normalized +  None  + Linear
+// CHECK-NEXT: 3 -- 0: {1,2,3,4}
+// CHECK-NEXT: 4 -- 1: {49,48,47,46}
+// CHECK-NEXT: 5 -- 2: {59,58,57,56}
+// CHECK-NEXT: 6 -- 3: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/normalized-none-linear.cpp
+++ b/SYCL/Sampler/normalized-none-linear.cpp
@@ -3,8 +3,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
+// XFAIL: cuda
 
 // CPU failing at moment. Waiting on fix.
+// CUDA failing all linear interpolation at moment. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-none-linear.cpp
+++ b/SYCL/Sampler/normalized-none-linear.cpp
@@ -143,8 +143,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_none_linear_sampler(image_channel_order::rgba,
-                                        image_channel_type::unsigned_int8);
+                                        image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-none-linear.cpp
+++ b/SYCL/Sampler/normalized-none-linear.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// XFAIL: cpu
 
 // CPU failing at moment. Waiting on fix.
 

--- a/SYCL/Sampler/normalized-none-linear.cpp
+++ b/SYCL/Sampler/normalized-none-linear.cpp
@@ -4,9 +4,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
 // XFAIL: cuda
+// UNSUPPORTED: level_zero && windows
 
 // CPU failing at moment. Waiting on fix.
 // CUDA failing all linear interpolation at moment. Waiting on fix.
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-none-linear.cpp
+++ b/SYCL/Sampler/normalized-none-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
 // CPU failing at moment. Waiting on fix.

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -1,0 +1,187 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    NONE address_mode and NEAREST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto none = addressing_mode::none;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_normalized_none_nearest_sampler(image_channel_order ChanOrder,
+                                          image_channel_type ChanType) {
+  int numTests = 12; // drives the size of the testResults buffer, and the
+                     // number of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_None_Nearest_sampler = sampler(normalized, none, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_nearest>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-3 read four pixels at low-boundary locations,  sample:   Normalized
+        // +  None  + Nearest
+        test_acc[i++] =
+            image_acc.read(0.00f, Norm_None_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_None_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_None_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_None_Nearest_sampler); // {11,12,13,14}
+
+        // 4-7 read four pixels at exact center locations,  sample:   Normalized
+        // +  None  + Nearest
+        test_acc[i++] =
+            image_acc.read(0.125f, Norm_None_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.375f, Norm_None_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(0.625f, Norm_None_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(0.875f, Norm_None_Nearest_sampler); // {11,12,13,14}
+
+        // 8-11 read four pixels at inexact upper boundary,  sample: Normalized
+        // +  None  + Nearest
+        test_acc[i++] =
+            image_acc.read(0.24999f, Norm_None_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            0.49999f, Norm_None_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] = image_acc.read(
+            0.74999f, Norm_None_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(0.9999f, Norm_None_Nearest_sampler); // {11,12,13,14}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 0;
+        std::cout << "read four pixels at low-boundary locations,  sample:   "
+                     "Normalized +  None  + Nearest"
+                  << std::endl;
+      }
+      if (i == 4) {
+        idx = 0;
+        std::cout << "read four pixels at exact center locations,  sample:   "
+                     "Normalized +  None  + Nearest"
+                  << std::endl;
+      }
+      if (i == 8) {
+        idx = 0;
+        std::cout << "read four pixels at inexact upper boundary,  sample:   "
+                     "Normalized +  None  + Nearest"
+                  << std::endl;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_none_nearest_sampler(image_channel_order::rgba,
+                                         image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read four pixels at low-boundary locations,  sample:   Normalized +  None  + Nearest
+// CHECK-NEXT: 0 -- 0: {1,2,3,4}
+// CHECK-NEXT: 1 -- 1: {49,48,47,46}
+// CHECK-NEXT: 2 -- 2: {59,58,57,56}
+// CHECK-NEXT: 3 -- 3: {11,12,13,14}
+// CHECK-NEXT: read four pixels at exact center locations,  sample:   Normalized +  None  + Nearest
+// CHECK-NEXT: 4 -- 0: {1,2,3,4}
+// CHECK-NEXT: 5 -- 1: {49,48,47,46}
+// CHECK-NEXT: 6 -- 2: {59,58,57,56}
+// CHECK-NEXT: 7 -- 3: {11,12,13,14}
+// CHECK-NEXT: read four pixels at inexact upper boundary,  sample:   Normalized +  None  + Nearest
+// CHECK-NEXT: 8 -- 0: {1,2,3,4}
+// CHECK-NEXT: 9 -- 1: {49,48,47,46}
+// CHECK-NEXT: 10 -- 2: {59,58,57,56}
+// CHECK-NEXT: 11 -- 3: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -2,6 +2,7 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// XFAIL: level_zero && windows
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -2,7 +2,9 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// XFAIL: level_zero && windows
+// UNSUPPORTED: level_zero && windows
+
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -159,8 +159,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_none_nearest_sampler(image_channel_order::rgba,
-                                         image_channel_type::unsigned_int8);
+                                         image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-repeat-linear.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear.cpp
@@ -1,0 +1,183 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+// CPU failing all linear interpolation at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    REPEAT address_mode and LINEAR filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto repeat = addressing_mode::repeat;
+constexpr auto linear = filtering_mode::linear;
+
+void test_normalized_repeat_linear_sampler(image_channel_order ChanOrder,
+                                           image_channel_type ChanType) {
+  int numTests = 11; // drives the size of the testResults buffer, and the
+                     // number of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_Repeat_Linear_sampler = sampler(normalized, repeat, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-2 read three pixels at inner boundary locations,  sample:
+        // Normalized +  Repeat  + Linear
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_Repeat_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_Repeat_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_Repeat_Linear_sampler); // {35,35,35,35}
+
+        // 3-6 read four pixels above right bound,   sample: Normalized + Repeat
+        // + Linear
+        test_acc[i++] =
+            image_acc.read(1.0f, Norm_Repeat_Linear_sampler); // {6,7,8,9}
+        test_acc[i++] =
+            image_acc.read(1.25f, Norm_Repeat_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(1.5f, Norm_Repeat_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(1.75f, Norm_Repeat_Linear_sampler); // {35,35,35,35}
+        // 7-10 read four pixels below left bound. sample: Normalized + Repeat +
+        // Linear
+        test_acc[i++] =
+            image_acc.read(-0.75f, Norm_Repeat_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(-0.5f, Norm_Repeat_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(-0.25f, Norm_Repeat_Linear_sampler); // {35,35,35,35}
+        test_acc[i++] =
+            image_acc.read(0.0f, Norm_Repeat_Linear_sampler); // {6,7,8,9}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 1;
+        std::cout << "read three pixels at inner boundary locations,  sample:  "
+                     " Normalized +  Repeat  + Linear"
+                  << std::endl;
+      }
+      if (i == 3) {
+        idx = 0;
+        std::cout << "read four pixels above right bound,   sample: Normalized "
+                     "+ Repeat + Linear"
+                  << std::endl;
+      }
+      if (i == 7) {
+        idx = 0;
+        std::cout << "read four pixels below left bound. sample: Normalized + "
+                     "Repeat + Linear"
+                  << std::endl;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_repeat_linear_sampler(image_channel_order::rgba,
+                                          image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read three pixels at inner boundary locations,  sample:   Normalized +  Repeat  + Linear
+// CHECK-NEXT: 0 -- 1: {25,25,25,25}
+// CHECK-NEXT: 1 -- 2: {54,53,52,51}
+// CHECK-NEXT: 2 -- 3: {35,35,35,35}
+// CHECK-NEXT: read four pixels above right bound,   sample: Normalized + Repeat + Linear
+// CHECK-NEXT: 3 -- 0: {6,7,8,9}
+// CHECK-NEXT: 4 -- 1: {25,25,25,25}
+// CHECK-NEXT: 5 -- 2: {54,53,52,51}
+// CHECK-NEXT: 6 -- 3: {35,35,35,35}
+// CHECK-NEXT: read four pixels below left bound. sample: Normalized + Repeat + Linear
+// CHECK-NEXT: 7 -- 0: {25,25,25,25}
+// CHECK-NEXT: 8 -- 1: {54,53,52,51}
+// CHECK-NEXT: 9 -- 2: {35,35,35,35}
+// CHECK-NEXT: 10 -- 3: {6,7,8,9}
+// clang-format on

--- a/SYCL/Sampler/normalized-repeat-linear.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear.cpp
@@ -3,8 +3,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
+// XFAIL: cuda
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
+// CUDA failing all linear interpolation at moment. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-repeat-linear.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
 // CPU failing all linear interpolation at moment. Waiting on fix.

--- a/SYCL/Sampler/normalized-repeat-linear.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// XFAIL: cpu
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 

--- a/SYCL/Sampler/normalized-repeat-linear.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear.cpp
@@ -4,9 +4,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
 // XFAIL: cuda
+// UNSUPPORTED: level_zero && windows
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 // CUDA failing all linear interpolation at moment. Waiting on fix.
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-repeat-linear.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear.cpp
@@ -158,8 +158,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_repeat_linear_sampler(image_channel_order::rgba,
-                                          image_channel_type::unsigned_int8);
+                                          image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-repeat-nearest.cpp
+++ b/SYCL/Sampler/normalized-repeat-nearest.cpp
@@ -1,0 +1,185 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured NORMALIZED coordinate_normalization_mode
+    REPEAT address_mode and NEAREST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto normalized = coordinate_normalization_mode::normalized;
+constexpr auto repeat = addressing_mode::repeat;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_normalized_repeat_nearest_sampler(image_channel_order ChanOrder,
+                                            image_channel_type ChanType) {
+  int numTests = 12; // drives the size of the testResults buffer, and the
+                     // number of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto Norm_Repeat_Nearest_sampler = sampler(normalized, repeat, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_norm_nearest>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // clang-format off
+        // Normalized Pixel Locations.  
+        //      .125        .375        .625        .875            <-- exact center
+        //  |-----^-----|-----^-----|-----^-----|-----^-----
+        //[0.0         .25         .50         .75          (1)     <-- low boundary (included in pixel)
+        //                                                              upper boundary inexact. (e.g. .2499999)
+        // clang-format on
+
+        // 0-3 read four pixels at low-boundary locations,  sample:   Normalized
+        // +  Repeat  + Nearest
+        test_acc[i++] =
+            image_acc.read(0.00f, Norm_Repeat_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.25f, Norm_Repeat_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(0.50f, Norm_Repeat_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(0.75f, Norm_Repeat_Nearest_sampler); // {11,12,13,14}
+
+        // 4-7 read four pixels above right bound,   sample: Normalized + Repeat
+        // + Nearest
+        test_acc[i++] =
+            image_acc.read(1.125f, Norm_Repeat_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            1.375f, Norm_Repeat_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] = image_acc.read(
+            1.625f, Norm_Repeat_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] = image_acc.read(
+            1.875f, Norm_Repeat_Nearest_sampler); // {11,12,13,14}
+        // 8-11 read four pixels below left bound. sample: Normalized + Repeat +
+        // Nearest
+        test_acc[i++] =
+            image_acc.read(-0.875f, Norm_Repeat_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            -0.625f, Norm_Repeat_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] = image_acc.read(
+            -0.375f, Norm_Repeat_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] = image_acc.read(
+            -0.125f, Norm_Repeat_Nearest_sampler); // {11,12,13,14}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 0;
+        std::cout << "read four pixels at low-boundary locations,  sample:   "
+                     "Normalized +  Repeat  + Nearest"
+                  << std::endl;
+      }
+      if (i == 4) {
+        idx = 0;
+        std::cout << "read four pixels above right bound,   sample: Normalized "
+                     "+ Repeat + Nearest"
+                  << std::endl;
+      }
+      if (i == 8) {
+        idx = 0;
+        std::cout << "read four pixels below left bound. sample: Normalized + "
+                     "Repeat + Nearest"
+                  << std::endl;
+      }
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_normalized_repeat_nearest_sampler(image_channel_order::rgba,
+                                           image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read four pixels at low-boundary locations,  sample:   Normalized +  Repeat  + Nearest
+// CHECK-NEXT: 0 -- 0: {1,2,3,4}
+// CHECK-NEXT: 1 -- 1: {49,48,47,46}
+// CHECK-NEXT: 2 -- 2: {59,58,57,56}
+// CHECK-NEXT: 3 -- 3: {11,12,13,14}
+// CHECK-NEXT: read four pixels above right bound,   sample: Normalized + Repeat + Nearest
+// CHECK-NEXT: 4 -- 0: {1,2,3,4}
+// CHECK-NEXT: 5 -- 1: {49,48,47,46}
+// CHECK-NEXT: 6 -- 2: {59,58,57,56}
+// CHECK-NEXT: 7 -- 3: {11,12,13,14}
+// CHECK-NEXT: read four pixels below left bound. sample: Normalized + Repeat + Nearest
+// CHECK-NEXT: 8 -- 0: {1,2,3,4}
+// CHECK-NEXT: 9 -- 1: {49,48,47,46}
+// CHECK-NEXT: 10 -- 2: {59,58,57,56}
+// CHECK-NEXT: 11 -- 3: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/normalized-repeat-nearest.cpp
+++ b/SYCL/Sampler/normalized-repeat-nearest.cpp
@@ -157,8 +157,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_normalized_repeat_nearest_sampler(image_channel_order::rgba,
-                                           image_channel_type::unsigned_int8);
+                                           image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/normalized-repeat-nearest.cpp
+++ b/SYCL/Sampler/normalized-repeat-nearest.cpp
@@ -3,9 +3,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // XFAIL: cuda
+// UNSUPPORTED: level_zero && windows
 
 // CUDA is not handling repeat or mirror correctly with normalized coordinates.
 // Waiting on a fix.
+// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-repeat-nearest.cpp
+++ b/SYCL/Sampler/normalized-repeat-nearest.cpp
@@ -2,6 +2,10 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// XFAIL: cuda
+
+// CUDA is not handling repeat or mirror correctly with normalized coordinates.
+// Waiting on a fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-repeat-nearest.cpp
+++ b/SYCL/Sampler/normalized-repeat-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/unnormalized-clamp-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-linear.cpp
@@ -1,0 +1,166 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+
+// GPU does not correctly interpolate when using clamp.  Waiting on fix.
+// Both OCL and LevelZero have this issue.
+// CPU failing all linear interpolation at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured UNNORMALIZED coordinate_normalization_mode
+    CLAMP address_mode and LINEAR filter_mode
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto unnormalized = coordinate_normalization_mode::unnormalized;
+constexpr auto linear = filtering_mode::linear;
+
+void test_unnormalized_clamp_linear_sampler(image_channel_order ChanOrder,
+                                            image_channel_type ChanType) {
+  int numTests = 8; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto UnNorm_Clamp_Linear_sampler =
+        sampler(unnormalized, addressing_mode::clamp, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_Unorm_Linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // UnNormalized Pixel Locations when using Linear Interpolation
+        // (0 -------- ](1 ---------- ](2 ----------- ](3---------- ](4)
+
+        // 0-5 read six pixels, float coordinates,   sample:   NonNormalized +
+        // Clamp + Linear
+        test_acc[i++] =
+            image_acc.read(-1.0f, UnNorm_Clamp_Linear_sampler); // {0,0,0,0}
+        test_acc[i++] =
+            image_acc.read(0.0f, UnNorm_Clamp_Linear_sampler); // {0,1,2,2}
+        test_acc[i++] =
+            image_acc.read(1.0f, UnNorm_Clamp_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(2.0f, UnNorm_Clamp_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(3.0f, UnNorm_Clamp_Linear_sampler); // {35,35,35,35}
+        test_acc[i++] = image_acc.read(
+            4.0f, UnNorm_Clamp_Linear_sampler); // {6,6,6,7}  // interpolated?
+
+        // 6-7 read two pixels on either side of first pixel. float coordinates.
+        // CLAMP
+        //  on GPU CLAMP is apparently stopping the interpolation. ( values on
+        //  right are expected value)
+        test_acc[i++] = image_acc.read(
+            0.9999f, UnNorm_Clamp_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] = image_acc.read(
+            1.0001f, UnNorm_Clamp_Linear_sampler); // {25,25,25,25}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = -1;
+        std::cout << "read six pixels, float coordinates,   sample:   "
+                     "NonNormalized + Clamp + Linear"
+                  << std::endl;
+      }
+      if (i == 6) {
+        idx = 1;
+        std::cout << "read two pixels on either side of 1. float coordinates. "
+                     "NonNormalized + Clamp + Linear"
+                  << std::endl;
+      }
+      if (i == 7) {
+        idx = 1;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_unnormalized_clamp_linear_sampler(image_channel_order::rgba,
+                                           image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read six pixels, float coordinates,   sample:   NonNormalized + Clamp + Linear
+// CHECK-NEXT: 0 -- -1: {0,0,0,0}
+// CHECK-NEXT: 1 -- 0: {0,1,2,2}
+// CHECK-NEXT: 2 -- 1: {25,25,25,25}
+// CHECK-NEXT: 3 -- 2: {54,53,52,51}
+// CHECK-NEXT: 4 -- 3: {35,35,35,35}
+// CHECK-NEXT: 5 -- 4: {6,6,6,7}
+// CHECK-NEXT: read two pixels on either side of 1. float coordinates. NonNormalized + Clamp + Linear
+// CHECK-NEXT: 6 -- 1: {25,25,25,25}
+// CHECK-NEXT: 7 -- 1: {25,25,25,25}
+// clang-format on

--- a/SYCL/Sampler/unnormalized-clamp-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-linear.cpp
@@ -2,12 +2,13 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// XFAIL: gpu && (level_zero || opencl)
+// XFAIL: gpu && (level_zero || opencl || cuda)
 // XFAIL: cpu
 
 // GPU does not correctly interpolate when using clamp.  Waiting on fix.
 // Both OCL and LevelZero have this issue.
 // CPU failing all linear interpolation at moment. Waiting on fix.
+// CUDA failing all linear interpolation at moment. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/unnormalized-clamp-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 
 // GPU does not correctly interpolate when using clamp.  Waiting on fix.
 // Both OCL and LevelZero have this issue.

--- a/SYCL/Sampler/unnormalized-clamp-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-linear.cpp
@@ -1,5 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// XFAIL: gpu && (level_zero || opencl)
+// XFAIL: cpu
 
 // GPU does not correctly interpolate when using clamp.  Waiting on fix.
 // Both OCL and LevelZero have this issue.

--- a/SYCL/Sampler/unnormalized-clamp-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-linear.cpp
@@ -147,8 +147,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_unnormalized_clamp_linear_sampler(image_channel_order::rgba,
-                                           image_channel_type::unsigned_int8);
+                                           image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/unnormalized-clamp-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-linear.cpp
@@ -2,7 +2,7 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// XFAIL: gpu && (level_zero || opencl || cuda)
+// XFAIL: gpu
 // XFAIL: cpu
 
 // GPU does not correctly interpolate when using clamp.  Waiting on fix.

--- a/SYCL/Sampler/unnormalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-nearest.cpp
@@ -1,0 +1,142 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured UNNORMALIZED coordinate_normalization_mode
+    CLAMP address_mode and NEAREAST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto unnormalized = coordinate_normalization_mode::unnormalized;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_unnormalized_clamp_nearest_sampler(image_channel_order ChanOrder,
+                                             image_channel_type ChanType) {
+  int numTests = 6; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto UnNorm_Clamp_Nearest_sampler =
+        sampler(unnormalized, addressing_mode::clamp, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_Unorm_Linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // 0-5 read six pixels,   sampler:   UnNormalized + Clamp + Nearest
+        test_acc[i++] =
+            image_acc.read(-1, UnNorm_Clamp_Nearest_sampler); // {0,0,0,0}
+        test_acc[i++] =
+            image_acc.read(0, UnNorm_Clamp_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(1, UnNorm_Clamp_Nearest_sampler); // {5,6,7,8}
+        test_acc[i++] =
+            image_acc.read(2, UnNorm_Clamp_Nearest_sampler); // {5,6,7,8}
+        test_acc[i++] =
+            image_acc.read(3, UnNorm_Clamp_Nearest_sampler); // {9,10,11,12}
+        test_acc[i++] =
+            image_acc.read(4, UnNorm_Clamp_Nearest_sampler); // {0,0,0,0}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = -1;
+        std::cout
+            << "read six pixels,   sampler:   UnNormalized + Clamp + Nearest"
+            << std::endl;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_unnormalized_clamp_nearest_sampler(image_channel_order::rgba,
+                                            image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// Clamp returns {0,0,0,0} for out-of-bound indeces.
+
+// clang-format off
+// CHECK: read six pixels,   sampler:   UnNormalized + Clamp + Nearest
+// CHECK-NEXT: -1: {0,0,0,0}
+// CHECK-NEXT: 0: {1,2,3,4}
+// CHECK-NEXT: 1: {49,48,47,46}
+// CHECK-NEXT: 2: {59,58,57,56}
+// CHECK-NEXT: 3: {11,12,13,14}
+// CHECK-NEXT: 4: {0,0,0,0}
+// clang-format on

--- a/SYCL/Sampler/unnormalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-nearest.cpp
@@ -120,8 +120,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_unnormalized_clamp_nearest_sampler(image_channel_order::rgba,
-                                            image_channel_type::unsigned_int8);
+                                            image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/unnormalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/unnormalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear.cpp
@@ -1,0 +1,165 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+// CPU failing all linear interpolation at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured UNNORMALIZED coordinate_normalization_mode
+    CLAMPEDGE address_mode and LINEAR filter_mode
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto unnormalized = coordinate_normalization_mode::unnormalized;
+constexpr auto clamp_edge = addressing_mode::clamp_to_edge;
+constexpr auto linear = filtering_mode::linear;
+
+void test_unnormalized_clampedge_linear_sampler(image_channel_order ChanOrder,
+                                                image_channel_type ChanType) {
+  int numTests = 8; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto UnNorm_ClampEdge_Linear_sampler =
+        sampler(unnormalized, clamp_edge, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_Unorm_Linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // UnNormalized Pixel Locations when using Linear Interpolation
+        // (0 -------- ](1 ---------- ](2 ----------- ](3---------- ](4)
+
+        // 0-5 read six pixels, float coordinates,   sample:   NonNormalized +
+        // ClampEDGE + Linear
+        test_acc[i++] =
+            image_acc.read(-1.0f, UnNorm_ClampEdge_Linear_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0.0f, UnNorm_ClampEdge_Linear_sampler); // {1,2,3,4}
+        test_acc[i++] = image_acc.read(
+            1.0f,
+            UnNorm_ClampEdge_Linear_sampler); // {25,25,25,25} //interpolated
+        test_acc[i++] = image_acc.read(
+            2.0f, UnNorm_ClampEdge_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] = image_acc.read(
+            3.0f, UnNorm_ClampEdge_Linear_sampler); // {35,35,35,35}
+        test_acc[i++] = image_acc.read(
+            4.0f, UnNorm_ClampEdge_Linear_sampler); // {11,12,13,14}
+
+        // 6-7 read two pixels on either side of 1. float coordinates. ClampEDGE
+        //  ClampEDGE correctly interpolates
+        test_acc[i++] = image_acc.read(
+            0.9999f, UnNorm_ClampEdge_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] = image_acc.read(
+            1.0001f, UnNorm_ClampEdge_Linear_sampler); // {25,25,25,25}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = -1;
+        std::cout << "read six pixels, float coordinates,   sample:   "
+                     "NonNormalized + ClampEDGE + Linear"
+                  << std::endl;
+      }
+      if (i == 6) {
+        idx = 1;
+        std::cout << "read two pixels on either side of 1. float coordinates. "
+                     "ClampEDGE"
+                  << std::endl;
+      }
+      if (i == 7) {
+        idx = 1;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_unnormalized_clampedge_linear_sampler(
+        image_channel_order::rgba, image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read six pixels, float coordinates,   sample:   NonNormalized + ClampEDGE + Linear
+// CHECK-NEXT: 0 -- -1: {1,2,3,4}
+// CHECK-NEXT: 1 -- 0: {1,2,3,4}
+// CHECK-NEXT: 2 -- 1: {25,25,25,25}
+// CHECK-NEXT: 3 -- 2: {54,53,52,51}
+// CHECK-NEXT: 4 -- 3: {35,35,35,35}
+// CHECK-NEXT: 5 -- 4: {11,12,13,14}
+// CHECK-NEXT: read two pixels on either side of 1. float coordinates. ClampEDGE
+// CHECK-NEXT: 6 -- 1: {25,25,25,25}
+// CHECK-NEXT: 7 -- 1: {25,25,25,25}
+// clang-format on

--- a/SYCL/Sampler/unnormalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear.cpp
@@ -3,8 +3,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
+// XFAIL: cuda
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
+// CUDA failing all linear interpolation at moment. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/unnormalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
 // CPU failing all linear interpolation at moment. Waiting on fix.

--- a/SYCL/Sampler/unnormalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// XFAIL: cpu
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 

--- a/SYCL/Sampler/unnormalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear.cpp
@@ -144,8 +144,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_unnormalized_clampedge_linear_sampler(
-        image_channel_order::rgba, image_channel_type::unsigned_int8);
+        image_channel_order::rgba, image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/unnormalized-clampedge-linear.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear.cpp
@@ -4,9 +4,12 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
 // XFAIL: cuda
+// XFAIL: level_zero && windows
 
 // CPU failing all linear interpolation at moment. Waiting on fix.
 // CUDA failing all linear interpolation at moment. Waiting on fix.
+// On Windows, LevelZero returns wrong value for clampedge
+// out of bounds. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
@@ -1,0 +1,141 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured UNNORMALIZED coordinate_normalization_mode
+    CLAMPEDGE address_mode and NEAREAST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto unnormalized = coordinate_normalization_mode::unnormalized;
+constexpr auto clamp_edge = addressing_mode::clamp_to_edge;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_unnormalized_clampedge_nearest_sampler(image_channel_order ChanOrder,
+                                                 image_channel_type ChanType) {
+  int numTests = 6; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto UnNorm_ClampEdge_Nearest_sampler =
+        sampler(unnormalized, clamp_edge, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_Unorm_Linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // 0-5 read six pixels,   sampler:   UnNormalized + ClampEdge + Nearest
+        test_acc[i++] =
+            image_acc.read(-1, UnNorm_ClampEdge_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(0, UnNorm_ClampEdge_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(1, UnNorm_ClampEdge_Nearest_sampler); // {5,6,7,8}
+        test_acc[i++] =
+            image_acc.read(2, UnNorm_ClampEdge_Nearest_sampler); // {5,6,7,8}
+        test_acc[i++] =
+            image_acc.read(3, UnNorm_ClampEdge_Nearest_sampler); // {9,10,11,12}
+        test_acc[i++] =
+            image_acc.read(4, UnNorm_ClampEdge_Nearest_sampler); // {9,10,11,12}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = -1;
+        std::cout << "read six pixels,   sampler:   UnNormalized + ClampEdge + "
+                     "Nearest"
+                  << std::endl;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_unnormalized_clampedge_nearest_sampler(
+        image_channel_order::rgba, image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: read six pixels,   sampler:   UnNormalized + ClampEdge + Nearest
+// CHECK-NEXT: -1: {1,2,3,4}
+// CHECK-NEXT: 0: {1,2,3,4}
+// CHECK-NEXT: 1: {49,48,47,46}
+// CHECK-NEXT: 2: {59,58,57,56}
+// CHECK-NEXT: 3: {11,12,13,14}
+// CHECK-NEXT: 4: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
@@ -2,6 +2,10 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// XFAIL: level_zero && windows
+
+// On Windows, LevelZero returns wrong value for clampedge
+// out of bounds. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
@@ -121,8 +121,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_unnormalized_clampedge_nearest_sampler(
-        image_channel_order::rgba, image_channel_type::unsigned_int8);
+        image_channel_order::rgba, image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/unnormalized-none-linear.cpp
+++ b/SYCL/Sampler/unnormalized-none-linear.cpp
@@ -1,0 +1,182 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+// CPU failing at moment. Waiting on fix.
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured UNNORMALIZED coordinate_normalization_mode
+    NONE address_mode and LINEAR filter_mode
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto unnormalized = coordinate_normalization_mode::unnormalized;
+constexpr auto none = addressing_mode::none;
+constexpr auto linear = filtering_mode::linear;
+
+void test_unnormalized_none_linear_sampler(image_channel_order ChanOrder,
+                                           image_channel_type ChanType) {
+  int numTests = 11; // drives the size of the testResults buffer, and the
+                     // number of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto UnNorm_None_Linear_sampler = sampler(unnormalized, none, linear);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_Unorm_Linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // UnNormalized Pixel Locations when using Linear Interpolation
+        // (0 -------- ](1 ---------- ](2 ----------- ](3---------- ](4)
+
+        // 0-2 read three pixels at inner boundary locations, float coordinates,
+        // sample:   UnNormalized +  None  + Linear
+        test_acc[i++] =
+            image_acc.read(1.0f, UnNorm_None_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] =
+            image_acc.read(2.0f, UnNorm_None_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] =
+            image_acc.read(3.0f, UnNorm_None_Linear_sampler); // {35,35,35,35}
+
+        // 3-6 read four pixels at exact center locations, float,  sample:
+        // Unnormalized +  None  + Linear
+        test_acc[i++] =
+            image_acc.read(0.5f, UnNorm_None_Linear_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(1.5f, UnNorm_None_Linear_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(2.5f, UnNorm_None_Linear_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(3.5f, UnNorm_None_Linear_sampler); // {11,12,13,14}
+
+        // 7-10 read four pixels at inexact upper boundary, float coord, sample:
+        // Unnormalized +  None  + Linear
+        test_acc[i++] = image_acc.read(
+            0.9999f, UnNorm_None_Linear_sampler); // {25,25,25,25}
+        test_acc[i++] = image_acc.read(
+            1.9999f, UnNorm_None_Linear_sampler); // {54,53,52,51}
+        test_acc[i++] = image_acc.read(
+            2.9999f, UnNorm_None_Linear_sampler); // {35,35,35,35}
+        test_acc[i++] = image_acc.read(
+            3.9999f,
+            UnNorm_None_Linear_sampler); // {6,6,7,7}  // <<--- should it be
+                                         // interpolating with the bg color?
+                                         // That doesn't seem right. But it is
+                                         // what it is.
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 1;
+        std::cout << "read three pixels at inner boundary locations, float "
+                     "coordinates,  sample:   UnNormalized +  None  + Linear"
+                  << std::endl;
+      }
+      if (i == 3) {
+        idx = 0;
+        std::cout << "read four pixels at exact center locations, float,  "
+                     "sample:   Unnormalized +  None  + Linear"
+                  << std::endl;
+      }
+      if (i == 7) {
+        idx = 0;
+        std::cout << "read four pixels at inexact upper boundary, float coord, "
+                     " sample:   Unnormalized +  None  + Linear"
+                  << std::endl;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << i << " -- " << idx << ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_unnormalized_none_linear_sampler(image_channel_order::rgba,
+                                          image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+// clang-format off
+// CHECK: read three pixels at inner boundary locations, float coordinates,  sample:   UnNormalized +  None  + Linear
+// CHECK-NEXT: 0 -- 1: {25,25,25,25}
+// CHECK-NEXT: 1 -- 2: {54,53,52,51}
+// CHECK-NEXT: 2 -- 3: {35,35,35,35}
+// CHECK-NEXT: read four pixels at exact center locations, float,  sample:   Unnormalized +  None  + Linear
+// CHECK-NEXT: 3 -- 0: {1,2,3,4}
+// CHECK-NEXT: 4 -- 1: {49,48,47,46}
+// CHECK-NEXT: 5 -- 2: {59,58,57,56}
+// CHECK-NEXT: 6 -- 3: {11,12,13,14}
+// CHECK-NEXT: read four pixels at inexact upper boundary, float coord,  sample:   Unnormalized +  None  + Linear
+// CHECK-NEXT: 7 -- 0: {25,25,25,25}
+// CHECK-NEXT: 8 -- 1: {54,53,52,51}
+// CHECK-NEXT: 9 -- 2: {35,35,35,35}
+// CHECK-NEXT: 10 -- 3: {6,6,7,7}
+// clang-format on

--- a/SYCL/Sampler/unnormalized-none-linear.cpp
+++ b/SYCL/Sampler/unnormalized-none-linear.cpp
@@ -3,8 +3,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cpu
+// XFAIL: cuda
 
 // CPU failing at moment. Waiting on fix.
+// CUDA failing all linear interpolation at moment. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/unnormalized-none-linear.cpp
+++ b/SYCL/Sampler/unnormalized-none-linear.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// XFAIL: cpu
 
 // CPU failing at moment. Waiting on fix.
 

--- a/SYCL/Sampler/unnormalized-none-linear.cpp
+++ b/SYCL/Sampler/unnormalized-none-linear.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
 // CPU failing at moment. Waiting on fix.

--- a/SYCL/Sampler/unnormalized-none-linear.cpp
+++ b/SYCL/Sampler/unnormalized-none-linear.cpp
@@ -158,8 +158,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_unnormalized_none_linear_sampler(image_channel_order::rgba,
-                                          image_channel_type::unsigned_int8);
+                                          image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }

--- a/SYCL/Sampler/unnormalized-none-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-none-nearest.cpp
@@ -1,0 +1,133 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+
+/*
+    This file sets up an image, initializes it with data,
+    and verifies that the data is sampled correctly with a
+    sampler configured UNNORMALIZED coordinate_normalization_mode
+    NONE address_mode and NEAREST filter_mode
+
+*/
+
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+// pixel data-type for RGBA operations (which is the minimum image type)
+using pixelT = sycl::uint4;
+
+// will output a pixel as {r,g,b,a}.  provide override if a different pixelT is
+// defined.
+void outputPixel(sycl::uint4 somePixel) {
+  std::cout << "{" << somePixel[0] << "," << somePixel[1] << "," << somePixel[2]
+            << "," << somePixel[3] << "} ";
+}
+
+// some constants.
+
+// 4 pixels on a side. 1D at the moment
+constexpr long width = 4;
+
+constexpr auto unnormalized = coordinate_normalization_mode::unnormalized;
+constexpr auto none = addressing_mode::none;
+constexpr auto nearest = filtering_mode::nearest;
+
+void test_unnormalized_none_nearest_sampler(image_channel_order ChanOrder,
+                                            image_channel_type ChanType) {
+  int numTests = 4; // drives the size of the testResults buffer, and the number
+                    // of report iterations. Kludge.
+
+  // we'll use these four pixels for our image. Makes it easy to measure
+  // interpolation and spot "off-by-one" probs.
+  pixelT leftEdge{1, 2, 3, 4};
+  pixelT body{49, 48, 47, 46};
+  pixelT bony{59, 58, 57, 56};
+  pixelT rightEdge{11, 12, 13, 14};
+
+  queue Q;
+  const sycl::range<1> ImgRange_1D(width);
+  { // closure
+    // - create an image
+    image<1> image_1D(ChanOrder, ChanType, ImgRange_1D);
+    event E_Setup = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::write>(cgh);
+      cgh.single_task<class setupUnormLinear>([=]() {
+        image_acc.write(0, leftEdge);
+        image_acc.write(1, body);
+        image_acc.write(2, bony);
+        image_acc.write(3, rightEdge);
+      });
+    });
+    E_Setup.wait();
+
+    // use a buffer to report back test results.
+    buffer<pixelT, 1> testResults((range<1>(numTests)));
+
+    // sampler
+    auto UnNorm_None_Nearest_sampler = sampler(unnormalized, none, nearest);
+
+    event E_Test = Q.submit([&](handler &cgh) {
+      auto image_acc = image_1D.get_access<pixelT, access::mode::read>(cgh);
+      auto test_acc = testResults.get_access<access::mode::write>(cgh);
+
+      cgh.single_task<class im1D_Unorm_Linear>([=]() {
+        int i = 0; // the index for writing into the testResult buffer.
+
+        // 0-3  read four pixels,  sample:   NonNormalized +  None  + Nearest
+        test_acc[i++] =
+            image_acc.read(0, UnNorm_None_Nearest_sampler); // {1,2,3,4}
+        test_acc[i++] =
+            image_acc.read(1, UnNorm_None_Nearest_sampler); // {49,48,47,46}
+        test_acc[i++] =
+            image_acc.read(2, UnNorm_None_Nearest_sampler); // {59,58,57,56}
+        test_acc[i++] =
+            image_acc.read(3, UnNorm_None_Nearest_sampler); // {11,12,13,14}
+      });
+    });
+    E_Test.wait();
+
+    // REPORT RESULTS
+    auto test_acc = testResults.get_access<access::mode::read>();
+    for (int i = 0, idx = 0; i < numTests; i++, idx++) {
+      if (i == 0) {
+        idx = 0;
+        std::cout
+            << "read four pixels,  sample:   NonNormalized +  None  + Nearest"
+            << std::endl;
+      }
+
+      pixelT testPixel = test_acc[i];
+      std::cout << i << /* " -- " << idx << */ ": ";
+      outputPixel(testPixel);
+      std::cout << std::endl;
+    }
+  } // ~image / ~buffer
+}
+
+int main() {
+
+  queue Q;
+  device D = Q.get_device();
+
+  if (D.has(aspect::image)) {
+    // the _int8 channels are one byte per channel, or four bytes per pixel (for
+    // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
+    // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
+    // channel, or sixteen bytes per pixel (for RGBA).
+    test_unnormalized_none_nearest_sampler(image_channel_order::rgba,
+                                           image_channel_type::unsigned_int8);
+  } else {
+    std::cout << "device does not support image operations" << std::endl;
+  }
+
+  return 0;
+}
+// clang-format off
+// CHECK: read four pixels,  sample:   NonNormalized +  None  + Nearest
+// CHECK-NEXT: 0: {1,2,3,4}
+// CHECK-NEXT: 1: {49,48,47,46}
+// CHECK-NEXT: 2: {59,58,57,56}
+// CHECK-NEXT: 3: {11,12,13,14}
+// clang-format on

--- a/SYCL/Sampler/unnormalized-none-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-none-nearest.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %RUN_ON_HOST %t.out %HOST_CHECK_PLACEHOLDER
+// RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/Sampler/unnormalized-none-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-none-nearest.cpp
@@ -116,8 +116,10 @@ int main() {
     // RGBA) the _int16/fp16 channels are two bytes per channel, or eight bytes
     // per pixel (for RGBA) the _int32/fp32  channels are four bytes per
     // channel, or sixteen bytes per pixel (for RGBA).
+    // CUDA has limited support for image_channel_type, so the tests use
+    // unsigned_int32
     test_unnormalized_none_nearest_sampler(image_channel_order::rgba,
-                                           image_channel_type::unsigned_int8);
+                                           image_channel_type::unsigned_int32);
   } else {
     std::cout << "device does not support image operations" << std::endl;
   }


### PR DESCRIPTION
Between the `coordinate_normalization_mode` , `addressing_mode` and `filtering_mode` there are 16 valid combinations that a sampler should support for RGBA images.  Here we are adding each combination as its own test.
Some of the devices do not support particular combinations. For example, the CPU device is not correctly supporting linear interpolation at this time. In those cases, I have simply skipped the `//RUN:` directive for the not-yet-supporting device and left a comment in its place.  Let me know if this is not the correct approach. 


Signed-off-by: Chris Perkins <chris.perkins@intel.com>