### PR TITLE
[SYCL] Add support for CL-style options

### DIFF
--- a/SYCL/Basic/accessor/device_accessor_deduction.cpp
+++ b/SYCL/Basic/accessor/device_accessor_deduction.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test -std=c++17 %S/Inputs/device_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test %S/Inputs/device_accessor.cpp -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/accessor/get_device_access_deduction.cpp
+++ b/SYCL/Basic/accessor/get_device_access_deduction.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test -std=c++17 %S/Inputs/device_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test %S/Inputs/device_accessor.cpp -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/accessor/get_host_access_deduction.cpp
+++ b/SYCL/Basic/accessor/get_host_access_deduction.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test -std=c++17 %S/Inputs/host_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test %S/Inputs/host_accessor.cpp -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/accessor/get_host_task_access_deduction.cpp
+++ b/SYCL/Basic/accessor/get_host_task_access_deduction.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test -std=c++17 %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/accessor/host_accessor_deduction.cpp
+++ b/SYCL/Basic/accessor/host_accessor_deduction.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test -std=c++17 %S/Inputs/host_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test %S/Inputs/host_accessor.cpp -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/accessor/host_task_accessor_deduction.cpp
+++ b/SYCL/Basic/accessor/host_task_accessor_deduction.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test -std=c++17 %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/buffer/buffer.cpp
+++ b/SYCL/Basic/buffer/buffer.cpp
@@ -1,11 +1,10 @@
-// RUN: %clangxx %s -o %t1.out -lsycl -I %sycl_include
+// RUN: %clangxx %s -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
-// UNSUPPORTED: cl_options
 
 //==------------------- buffer.cpp - SYCL buffer basic test ----------------==//
 //

--- a/SYCL/Basic/buffer/buffer_container.cpp
+++ b/SYCL/Basic/buffer/buffer_container.cpp
@@ -1,11 +1,10 @@
-// RUN: %clangxx %s -std=c++17 -o %t1.out -lsycl -I %sycl_include
+// RUN: %clangxx %s -std=c++17 -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
-// UNSUPPORTED: cl_options
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/Basic/buffer/buffer_container.cpp
+++ b/SYCL/Basic/buffer/buffer_container.cpp
@@ -1,6 +1,6 @@
-// RUN: %clangxx %s -std=c++17 -o %t1.out %sycl_options
+// RUN: %clangxx %s %cxx_std_optionc++17 -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
-// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
+// RUN: %clangxx %cxx_std_optionc++17 -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out

--- a/SYCL/Basic/buffer/buffer_full_copy.cpp
+++ b/SYCL/Basic/buffer/buffer_full_copy.cpp
@@ -1,11 +1,10 @@
-// RUN: %clangxx %s -o %t1.out -lsycl -I %sycl_include
+// RUN: %clangxx %s -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
-// UNSUPPORTED: cl_options
 
 //==------------- buffer_full_copy.cpp - SYCL buffer basic test ------------==//
 //

--- a/SYCL/Basic/device_code_dae.cpp
+++ b/SYCL/Basic/device_code_dae.cpp
@@ -3,7 +3,7 @@
 // UNSUPPORTED: cuda
 // CUDA does not support SPIR-V.
 // RUN: %clangxx -fsycl-device-only -Xclang -fenable-sycl-dae -Xclang -fsycl-int-header=int_header.h %s -c -o device_code.bc -Wno-sycl-strict
-// RUN: %clangxx -include int_header.h -g -c %s -o host_code.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx %include_option int_header.h %debug_option -c %s -o host_code.o %sycl_options -Wno-sycl-strict
 // RUN: llvm-link -o=linked_device_code.bc device_code.bc
 // RUN: sycl-post-link -emit-param-info linked_device_code.bc
 // RUN: llvm-spirv -o linked_device_code.spv linked_device_code.bc

--- a/SYCL/Basic/device_code_dae.cpp
+++ b/SYCL/Basic/device_code_dae.cpp
@@ -10,7 +10,7 @@
 // RUN: echo -e -n "[Code|Properties]\nlinked_device_code.spv|linked_device_code_0.prop" > table.txt
 // RUN: clang-offload-wrapper -o wrapper.bc -host=x86_64 -kind=sycl -target=spir64 -batch table.txt
 // RUN: %clangxx -c wrapper.bc -o wrapper.o
-// RUN: %clangxx wrapper.o host_code.o -o app.exe -lsycl
+// RUN: %clangxx wrapper.o host_code.o -o app.exe %sycl_options
 // RUN: %BE_RUN_PLACEHOLDER ./app.exe
 
 //==---------device_code_dae.cpp - dead argument elimination test ----------==//

--- a/SYCL/Basic/device_code_dae.cpp
+++ b/SYCL/Basic/device_code_dae.cpp
@@ -1,9 +1,9 @@
 // NOTE A temporary test before this compilation flow is enabled by default in
 // driver
-// UNSUPPORTED: cuda,cl_options
+// UNSUPPORTED: cuda
 // CUDA does not support SPIR-V.
-// RUN: %clangxx -fsycl-device-only -Xclang -fenable-sycl-dae -Xclang -fsycl-int-header=int_header.h %s -c -o device_code.bc -I %sycl_include -Wno-sycl-strict
-// RUN: %clangxx -include int_header.h -g -c %s -o host_code.o -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -fsycl-device-only -Xclang -fenable-sycl-dae -Xclang -fsycl-int-header=int_header.h %s -c -o device_code.bc -Wno-sycl-strict
+// RUN: %clangxx -include int_header.h -g -c %s -o host_code.o %sycl_options -Wno-sycl-strict
 // RUN: llvm-link -o=linked_device_code.bc device_code.bc
 // RUN: sycl-post-link -emit-param-info linked_device_code.bc
 // RUN: llvm-spirv -o linked_device_code.spv linked_device_code.bc

--- a/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: aoc, accelerator
-// REQUIRES: system-windows, cl_options
+// REQUIRES: system-windows
 
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image. To avoid appending objects to

--- a/SYCL/Basic/fpga_tests/global_fpga_device_selector.cpp
+++ b/SYCL/Basic/fpga_tests/global_fpga_device_selector.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: aoc, accelerator
 
-// RUN: %clangxx -fsycl -fintelfpga -std=c++17 %s -o %t.out
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 #include <CL/sycl.hpp>

--- a/SYCL/Basic/image/image_constructors.cpp
+++ b/SYCL/Basic/image/image_constructors.cpp
@@ -1,11 +1,10 @@
-// RUN: %clangxx %s -o %t1.out -lsycl -I %sycl_include
+// RUN: %clangxx %s -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
-// UNSUPPORTED: cl_options
 //
 //==-------image_constructors.cpp - SYCL image constructors basic test------==//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/Basic/parallel_for_indexers.cpp
+++ b/SYCL/Basic/parallel_for_indexers.cpp
@@ -1,11 +1,10 @@
-// RUN: %clangxx %s -o %t1.out -lsycl -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx %s -o %t1.out %sycl_options -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
-// UNSUPPORTED: cl_options
 
 // TODO: Unexpected result
 // TODO: _indexers.cpp:37: int main(): Assertion `id == -1' failed.

--- a/SYCL/Config/config.cpp
+++ b/SYCL/Config/config.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %clangxx -g -O0 -fsycl %s -o %t.out
+// RUN: %clangxx %debug_option -O0 -fsycl %s -o %t.out
 // RUN: echo "SYCL_PRINT_EXECUTION_GRAPH=always" > %t.cfg
 // RUN: env SYCL_CONFIG_FILE_NAME=%t.cfg %t.out
 // RUN: ls | grep dot

--- a/SYCL/Config/env_vars.cpp
+++ b/SYCL/Config/env_vars.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl
 // Env vars are used to pass OpenCL-specific flags to PI compiling/linking.
 //
-// RUN: %clangxx -O0 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -lsycl
+// RUN: %clangxx -O0 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 //
 // RUN: %CPU_RUN_PLACEHOLDER SYCL_PROGRAM_COMPILE_OPTIONS="-g" %t.out
 // RUN: %GPU_RUN_PLACEHOLDER SYCL_PROGRAM_COMPILE_OPTIONS="-g" %t.out

--- a/SYCL/Config/kernel_from_file.cpp
+++ b/SYCL/Config/kernel_from_file.cpp
@@ -2,7 +2,7 @@
 // CUDA does not support SPIR-V.
 
 // RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
-// RUN: %clangxx -include %t.h %s -o %t.out %sycl_options -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx %include_option %t.h %s -o %t.out %sycl_options -Xclang -verify-ignore-unexpected=note,warning
 // RUN: %BE_RUN_PLACEHOLDER env SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
 // CHECK: Passed
 

--- a/SYCL/Config/kernel_from_file.cpp
+++ b/SYCL/Config/kernel_from_file.cpp
@@ -1,8 +1,8 @@
-// UNSUPPORTED: cuda,cl_options
+// UNSUPPORTED: cuda
 // CUDA does not support SPIR-V.
 
 // RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
-// RUN: %clangxx -include %t.h %s -o %t.out -lsycl -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -include %t.h %s -o %t.out %sycl_options -Xclang -verify-ignore-unexpected=note,warning
 // RUN: %BE_RUN_PLACEHOLDER env SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
 // CHECK: Passed
 

--- a/SYCL/DeviceLib/separate_compile_test.cpp
+++ b/SYCL/DeviceLib/separate_compile_test.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -include std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict
 // RUN: %clangxx %t_host.o %t_device.o -o %t.out -lsycl
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
@@ -9,7 +9,7 @@
 // RUN: %clangxx -fsycl -fsycl-link  %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -include std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict
 // RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -o %t_fp64.out %sycl_options
 // RUN: %CPU_RUN_PLACEHOLDER %t_fp64.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_fp64.out

--- a/SYCL/DeviceLib/separate_compile_test.cpp
+++ b/SYCL/DeviceLib/separate_compile_test.cpp
@@ -1,16 +1,15 @@
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o
-// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -include std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -include std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict
 // RUN: %clangxx %t_host.o %t_device.o -o %t.out -lsycl
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 // RUN: %clangxx -fsycl -fsycl-link  %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o
-// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -include std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o -I %sycl_include -Wno-sycl-strict
-// RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -o %t_fp64.out -lsycl
+// RUN: %clangxx -include std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -o %t_fp64.out %sycl_options
 // RUN: %CPU_RUN_PLACEHOLDER %t_fp64.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_fp64.out
-// UNSUPPORTED: cl_options

--- a/SYCL/DeviceLib/separate_compile_test.cpp
+++ b/SYCL/DeviceLib/separate_compile_test.cpp
@@ -2,7 +2,7 @@
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict
 // >> host compilation...
 // RUN: %clangxx %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict
-// RUN: %clangxx %t_host.o %t_device.o -o %t.out -lsycl
+// RUN: %clangxx %t_host.o %t_device.o -o %t.out %sycl_options
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
+++ b/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
@@ -1,8 +1,7 @@
-// UNSUPPORTED: windows
 // UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
 
-// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_optionc++14 -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
+++ b/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
@@ -1,8 +1,7 @@
-// UNSUPPORTED: windows
 // UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
 
-// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_optionc++14 -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/OnlineCompiler/online_compiler_L0.cpp
+++ b/SYCL/OnlineCompiler/online_compiler_L0.cpp
@@ -1,10 +1,9 @@
-// REQUIRES: level_zero, level_zero_headers
-// UNSUPPORTED: cl_options
+// REQUIRES: level_zero, level_zero_dev_kit
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DRUN_KERNELS -lze_loader %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DRUN_KERNELS %level_zero_options %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -lze_loader %s -o %th.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %level_zero_options %s -o %th.out
 // RUN: %HOST_RUN_PLACEHOLDER %th.out
 
 // This test checks INTEL feature class online_compiler for Level-Zero.

--- a/SYCL/Plugin/interop-level-zero-keep-ownership.cpp
+++ b/SYCL/Plugin/interop-level-zero-keep-ownership.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: level_zero,level_zero_headers
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out -lze_loader
+// REQUIRES: level_zero, level_zero_dev_kit
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %level_zero_options
 // RUN: env SYCL_BE=PI_LEVEL_ZERO %GPU_RUN_PLACEHOLDER %t.out
 
 // Test for Level Zero interop API where SYCL RT doesn't take ownership

--- a/SYCL/Plugin/interop-level-zero.cpp
+++ b/SYCL/Plugin/interop-level-zero.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: level_zero,level_zero_headers
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out -lze_loader
+// REQUIRES: level_zero, level_zero_dev_kit
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %level_zero_options %s -o %t.out
 // RUN: env SYCL_BE=PI_LEVEL_ZERO %GPU_RUN_PLACEHOLDER %t.out
 
 // Test for Level Zero interop API

--- a/SYCL/Plugin/interop-opencl.cpp
+++ b/SYCL/Plugin/interop-opencl.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_FILTER=opencl %CPU_RUN_PLACEHOLDER %t.out
 // RUN: env SYCL_DEVICE_FILTER=opencl %GPU_RUN_PLACEHOLDER %t.out
 // RUN: env SYCL_DEVICE_FILTER=opencl %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/README.md
+++ b/SYCL/README.md
@@ -94,6 +94,12 @@ to be linked with. Make sure OpenCL ICD loader library is available in the
 system or library with full path passed to CMake configuration using the
 variable.
 
+***LEVEL_ZERO_HEADERS*** - directory containing Level_Zero native headers,
+   can be also set by LIT parameter level_zero_headers.
+
+***LEVEL_ZERO_LIBS_DIR*** - directory containing Level_Zero native libraries,
+   can be also set by LIT parameter level_zero_libs_dir.
+
 It is asssumed that all required dependencies (OpenCL runtimes, CUDA SDK, AOT
 compilers, etc) are available in the system.
 
@@ -147,6 +153,10 @@ ninja check
  * **extra_environment** - comma-separated list of variables with values to be
    added to test environment. Can be also set by LIT_EXTRA_ENVIRONMENT variable
    in cmake.
+ * **level_zero_headers** - directory containing Level_Zero native headers,
+   can be also set by CMake variable LEVEL_ZERO_HEADERS.
+ * **level_zero_libs_dir** - directory containing Level_Zero native libraries,
+   can be also set by CMake variable LEVEL_ZERO_LIBS_DIR.
 
 # LIT features which can be used to configure test execution:
  * **windows**, **linux** - host OS;
@@ -158,7 +168,7 @@ ninja check
    OpenCL interoperability tests;
  * **aot_tool** - Ahead-of-time compilation tools are available, enables
    corresponding tests;
- * **level_zero_headers** - Level_Zero headers are available, the headers are
+ * **level_zero_dev_kit** - Level_Zero headers and library are available,
    needed for Level_Zero interoperability tests;
  * **gpu-intel-dg1** - Intel GPU DG1 is available for testing;
  * **dump_ir**: is set to true if compiler supports dumping IR. Can be also

--- a/SYCL/Regression/cache_test.cpp
+++ b/SYCL/Regression/cache_test.cpp
@@ -1,8 +1,7 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_include/.. -lze_loader %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %level_zero_options %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// REQUIRES: level_zero
-// UNSUPPORTED: cl_options
+// REQUIRES: level_zero, level_zero_dev_kit
 
 #include <algorithm>
 #include <level_zero/ze_api.h>

--- a/SYCL/Regression/implicit_offset_debug_info.cpp
+++ b/SYCL/Regression/implicit_offset_debug_info.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -g -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // REQUIRES: cuda
 

--- a/SYCL/Regression/long_kernel_name.cpp
+++ b/SYCL/Regression/long_kernel_name.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_include/.. -lze_loader %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %level_zero_options %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // REQUIRES: level_zero

--- a/SYCL/Scheduler/DataMovement.cpp
+++ b/SYCL/Scheduler/DataMovement.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -g
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %debug_option
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/SeparateCompile/test.cpp
+++ b/SYCL/SeparateCompile/test.cpp
@@ -36,7 +36,7 @@
 // RUN: %clangxx -c wrapper.bc -o wrapper.o
 //
 // >> ---- link the full hetero app
-// RUN: %clangxx wrapper.o a.o b.o -o app.exe -lsycl
+// RUN: %clangxx wrapper.o a.o b.o -o app.exe %sycl_options
 // RUN: %BE_RUN_PLACEHOLDER ./app.exe | FileCheck %s
 // CHECK: pass
 

--- a/SYCL/SeparateCompile/test.cpp
+++ b/SYCL/SeparateCompile/test.cpp
@@ -5,13 +5,13 @@
 // >> device compilation...
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -include sycl_ihdr_a.h -g -c %s -o a.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx %include_option sycl_ihdr_a.h %debug_option -c %s -o a.o %sycl_options -Wno-sycl-strict
 //
 // >> ---- compile src2
 // >> device compilation...
 // RUN: %clangxx -DB_CPP=1 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -DB_CPP=1 -include sycl_ihdr_b.h -g -c %s -o b.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx -DB_CPP=1 %include_option sycl_ihdr_b.h %debug_option -c %s -o b.o %sycl_options -Wno-sycl-strict
 //
 // >> ---- bundle .o with .spv
 // >> run bundler

--- a/SYCL/SeparateCompile/test.cpp
+++ b/SYCL/SeparateCompile/test.cpp
@@ -1,17 +1,17 @@
-// UNSUPPORTED: cuda,cl_options
+// UNSUPPORTED: cuda
 // CUDA does not support SPIR-V.
 //
 // >> ---- compile src1
 // >> device compilation...
-// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -include sycl_ihdr_a.h -g -c %s -o a.o -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -include sycl_ihdr_a.h -g -c %s -o a.o %sycl_options -Wno-sycl-strict
 //
 // >> ---- compile src2
 // >> device compilation...
-// RUN: %clangxx -DB_CPP=1 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -DB_CPP=1 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -DB_CPP=1 -include sycl_ihdr_b.h -g -c %s -o b.o -I %sycl_include -Wno-sycl-strict
+// RUN: %clangxx -DB_CPP=1 -include sycl_ihdr_b.h -g -c %s -o b.o %sycl_options -Wno-sycl-strict
 //
 // >> ---- bundle .o with .spv
 // >> run bundler

--- a/SYCL/SubGroup/generic_reduce.cpp
+++ b/SYCL/SubGroup/generic_reduce.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -std=c++14 %s -o %t.out
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple -std=c++14 -D SG_GPU %s -o %t_gpu.out
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple -D SG_GPU %s -o %t_gpu.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -137,10 +137,12 @@ if cl_options:
     config.substitutions.append( ('%sycl_options',  ' sycl.lib /I'+config.sycl_include ) )
     config.substitutions.append( ('%include_option',  '/FI' ) )
     config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
+    config.substitutions.append( ('%cxx_std_option',  '/std:' ) )
 else:
     config.substitutions.append( ('%sycl_options', ' -lsycl -I'+config.sycl_include ) )
     config.substitutions.append( ('%include_option',  '-include' ) )
     config.substitutions.append( ('%debug_option',  '-g' ) )
+    config.substitutions.append( ('%cxx_std_option',  '-std=' ) )
 
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -61,12 +61,12 @@ llvm_config.with_environment('PATH', config.lit_tools_dir, append_path=True)
 # Configure LD_LIBRARY_PATH or corresponding os-specific alternatives
 if platform.system() == "Linux":
     config.available_features.add('linux')
-    llvm_config.with_system_environment('LD_LIBRARY_PATH')
+    llvm_config.with_system_environment(['LD_LIBRARY_PATH','LIBRARY_PATH','CPATH'])
     llvm_config.with_environment('LD_LIBRARY_PATH', config.sycl_libs_dir, append_path=True)
 
 elif platform.system() == "Windows":
     config.available_features.add('windows')
-    llvm_config.with_system_environment('LIB')
+    llvm_config.with_system_environment(['LIB','CPATH','INCLUDE'])
     llvm_config.with_environment('LIB', config.sycl_libs_dir, append_path=True)
     llvm_config.with_environment('PATH', config.sycl_libs_dir, append_path=True)
     llvm_config.with_environment('LIB', os.path.join(config.dpcpp_root_dir, 'lib'), append_path=True)
@@ -106,11 +106,25 @@ if sp[0] == 0:
 
 check_l0_file='l0_include.cpp'
 with open(check_l0_file, 'w') as fp:
-    fp.write("#include<level_zero/ze_api.h>")
+    fp.write('#include<level_zero/ze_api.h>\n')
+    fp.write('int main() { uint32_t t; zeDriverGet(&t,nullptr); return t; }')
 
-sp = subprocess.getstatusoutput(config.dpcpp_compiler+' -fsycl -c '+check_l0_file)
+config.level_zero_libs_dir=lit_config.params.get("level_zero_libs_dir", config.level_zero_libs_dir)
+config.level_zero_include=lit_config.params.get("level_zero_include", (config.level_zero_include if config.level_zero_include else os.path.join(config.sycl_include, '..')))
+
+level_zero_options=level_zero_options = ' -L'+config.level_zero_libs_dir+' -lze_loader '+' -I'+config.level_zero_include
+if cl_options:
+    level_zero_options = ' '+config.level_zero_libs_dir+'/ze_loader.lib '+' /I'+config.level_zero_include
+
+config.substitutions.append( ('%level_zero_options', level_zero_options) )
+
+sp = subprocess.getstatusoutput('echo '+config.dpcpp_compiler+' -fsycl  ' + check_l0_file + level_zero_options)
+print (sp[1])
 if sp[0] == 0:
-    config.available_features.add('level_zero_headers')
+    config.available_features.add('level_zero_dev_kit')
+    config.substitutions.append( ('%level_zero_options', level_zero_options) )
+else:
+    config.substitutions.append( ('%level_zero_options', '') )
 
 if config.opencl_libs_dir:
     if cl_options:
@@ -119,6 +133,11 @@ if config.opencl_libs_dir:
         config.substitutions.append( ('%opencl_lib',  '-L'+config.opencl_libs_dir+' -lOpenCL') )
     config.available_features.add('opencl_icd')
 config.substitutions.append( ('%opencl_include_dir',  config.opencl_include_dir) )
+
+if cl_options:
+    config.substitutions.append( ('%sycl_options',  ' '+config.sycl_libs_dir+'/sycl.lib /I'+config.sycl_include ) )
+else:
+    config.substitutions.append( ('%sycl_options', '-lsycl -I'+config.sycl_include ) )
 
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -112,14 +112,13 @@ with open(check_l0_file, 'w') as fp:
 config.level_zero_libs_dir=lit_config.params.get("level_zero_libs_dir", config.level_zero_libs_dir)
 config.level_zero_include=lit_config.params.get("level_zero_include", (config.level_zero_include if config.level_zero_include else os.path.join(config.sycl_include, '..')))
 
-level_zero_options=level_zero_options = ' -L'+config.level_zero_libs_dir+' -lze_loader '+' -I'+config.level_zero_include
+level_zero_options=level_zero_options = (' -L'+config.level_zero_libs_dir if config.level_zero_libs_dir else '')+' -lze_loader '+' -I'+config.level_zero_include
 if cl_options:
-    level_zero_options = ' '+config.level_zero_libs_dir+'/ze_loader.lib '+' /I'+config.level_zero_include
+    level_zero_options = ' '+( config.level_zero_libs_dir+'/ze_loader.lib ' if config.level_zero_libs_dir else 'ze_loader.lib')+' /I'+config.level_zero_include
 
 config.substitutions.append( ('%level_zero_options', level_zero_options) )
 
-sp = subprocess.getstatusoutput('echo '+config.dpcpp_compiler+' -fsycl  ' + check_l0_file + level_zero_options)
-print (sp[1])
+sp = subprocess.getstatusoutput(config.dpcpp_compiler+' -fsycl  ' + check_l0_file + level_zero_options)
 if sp[0] == 0:
     config.available_features.add('level_zero_dev_kit')
     config.substitutions.append( ('%level_zero_options', level_zero_options) )
@@ -135,9 +134,13 @@ if config.opencl_libs_dir:
 config.substitutions.append( ('%opencl_include_dir',  config.opencl_include_dir) )
 
 if cl_options:
-    config.substitutions.append( ('%sycl_options',  ' '+config.sycl_libs_dir+'/sycl.lib /I'+config.sycl_include ) )
+    config.substitutions.append( ('%sycl_options',  ' sycl.lib /I'+config.sycl_include ) )
+    config.substitutions.append( ('%include_option',  '/FI' ) )
+    config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
 else:
     config.substitutions.append( ('%sycl_options', '-lsycl -I'+config.sycl_include ) )
+    config.substitutions.append( ('%include_option',  '/FI' ) )
+    config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
 
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -138,9 +138,9 @@ if cl_options:
     config.substitutions.append( ('%include_option',  '/FI' ) )
     config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
 else:
-    config.substitutions.append( ('%sycl_options', '-lsycl -I'+config.sycl_include ) )
-    config.substitutions.append( ('%include_option',  '/FI' ) )
-    config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
+    config.substitutions.append( ('%sycl_options', ' -lsycl -I'+config.sycl_include ) )
+    config.substitutions.append( ('%include_option',  '-include' ) )
+    config.substitutions.append( ('%debug_option',  '-g' ) )
 
 llvm_config.add_tool_substitutions(['llvm-spirv'], [config.sycl_tools_dir])
 

--- a/SYCL/lit.site.cfg.py.in
+++ b/SYCL/lit.site.cfg.py.in
@@ -18,6 +18,8 @@ config.target_triple = "x86_64-unknown-unknown-gnu"
 config.host_triple = "x86_64-unknown-unknown-gnu" 
 
 config.opencl_libs_dir = (os.path.dirname("@OpenCL_LIBRARY@") if "@OpenCL_LIBRARY@" else "")
+config.level_zero_libs_dir = "@LEVEL_ZERO_LIBS_DIR@"
+config.level_zero_include = "@LEVEL_ZERO_INCLUDE@"
 
 config.opencl_include_dir = config.sycl_include
 config.target_devices = lit_config.params.get("target_devices", "@SYCL_TARGET_DEVICES@")


### PR DESCRIPTION
 - Adopt tests to use CL-style options when clang-cl compiler is used;
 - Add possibility for setting Level Zero headers and loader location in LIT parameters or CMake variables;
 - Rename level_zero_header feature to level_zero_dev_kit to identify that both Level Zero headers and loader are available;
 - Search for Level Zero headers and loader in environment;
 - Inherit LIBRARY_PATH, CPATH, INCLUDE environment variables to LIT infrastructure.