### PR TITLE
Mark test as XFAIL

### DIFF
--- a/SYCL/Plugin/enqueue-arg-order-image.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-image.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
-
+// XFAIL: cuda
 #include <CL/sycl.hpp>
 #include <CL/sycl/accessor.hpp>
 #include <iostream>


### PR DESCRIPTION
The SYCL :: Plugin/enqueue-arg-order-image.cpp test start to fail on CUDA BE after intel/llvm#3294