### PR TITLE
Fix enqueue-arg-order-image test on CUDA

### DIFF
--- a/SYCL/Plugin/enqueue-arg-order-image.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-image.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
-// Native iamges are created with host pointers only with host unified memory
+// Native images are created with host pointers only with host unified memory
 // support, enforce it for this test.
 // RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Plugin/enqueue-arg-order-image.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-image.cpp
@@ -1,6 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
-// RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
+// Native iamges are created with host pointers only with host unified memory
+// support, enforce it for this test.
+// RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
+// RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 
 #include <CL/sycl.hpp>
 #include <CL/sycl/accessor.hpp>


### PR DESCRIPTION
The test checks the arguments passed to piMemImageCreate, several of
which are only set if a host pointer is passed. Since whether or not
that pointer is passed depends on host unified memory support, enforce
it for this test.