### PR TITLE
[SYCL] Fix one of reduction tests failing if add sycl::reduction

### DIFF
--- a/SYCL/Reduction/reduction_reducer_op_eq.cpp
+++ b/SYCL/Reduction/reduction_reducer_op_eq.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 
 using namespace sycl;
-using namespace sycl::ONEAPI;
 
 struct XY {
   constexpr XY() : X(0), Y(0) {}
@@ -94,7 +93,7 @@ int test(T Identity) {
   }
 
   *Res = Identity;
-  auto Red = reduction(Res, Identity, BOp);
+  auto Red = ONEAPI::reduction(Res, Identity, BOp);
   nd_range<1> NDR{N, L};
   if constexpr (OpEq == PlusEq) {
     auto Lambda = [=](nd_item<1> ID, auto &Sum) {


### PR DESCRIPTION
This test failed due to usage of cl::sycl::ONEAPI and cl::sycl namespaces,
which caused error after adding sycl::reduction in https://github.com/intel/llvm/pull/3315

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>