### PR TITLE
[SYCL] Remove "UNSUPPORTED" for a fixed test

### DIFF
--- a/SYCL/Basic/parallel_for_range_roundup.cpp
+++ b/SYCL/Basic/parallel_for_range_roundup.cpp
@@ -1,8 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_TRACE=1 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
-// Issue #164 The test is failing sporadically on Windows
-// UNSUPPORTED: windows
 #include <CL/sycl.hpp>
 
 using namespace sycl;


### PR DESCRIPTION
After MinRange was introduced in the compiler implementation, the original test stopped range rounding. It was re-enabled in the previous commit, after adjusting the ranges to sizes greater than MinRange.