### PR TITLE
[SYCL][ESIMD] Increase USM allocation size for Stencil test.

### DIFF
--- a/SYCL/ESIMD/Stencil.cpp
+++ b/SYCL/ESIMD/Stencil.cpp
@@ -22,7 +22,7 @@
 // test 8x16 block size
 //
 #define DIM_SIZE (1 << 13)
-#define SQUARE_SZ (DIM_SIZE * DIM_SIZE + 1)
+#define SQUARE_SZ (DIM_SIZE * DIM_SIZE + 16)
 
 #define WIDTH 16
 #define HEIGHT 16

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -22,7 +22,7 @@
 // test 8x16 block size
 //
 #define DIM_SIZE (1 << 13)
-#define SQUARE_SZ (DIM_SIZE * DIM_SIZE + 1)
+#define SQUARE_SZ (DIM_SIZE * DIM_SIZE + 16)
 
 #define WIDTH 16
 #define HEIGHT 16


### PR DESCRIPTION
The Stencil test showed sporadic failures before last change. Investigation shows it works fine on Linux. The problem only showed up on Windows and could be voided by adjusting SLM allocation size. The GPU assembly dump is the same in the passing and failing case. Semenov, Sergey helped look into USM allocation issue on Windows vs. Linux and didn't find anything suspicious. So the problem could be still due to out-of-order block access. As discussed, in this patch the kernel SLM allocation size is increased by +16 to avoid OOB access. 