### PR TITLE
[SYCL] Fix lit.cfg.py to set SYCL_DEVICE_FILTER correctly.

### DIFF
--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -198,11 +198,11 @@ for target_device in config.target_devices.split(','):
 if 'host' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Test HOST device")
-    host_run_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:host ".format(SYCL_PLUGIN=config.sycl_be)
+    host_run_substitute = "env SYCL_DEVICE_FILTER=host "
     host_check_substitute = "| FileCheck %s"
     config.available_features.add('host')
     if platform.system() == "Linux":
-        host_run_on_linux_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:host ".format(SYCL_PLUGIN=config.sycl_be)
+        host_run_on_linux_substitute = "env SYCL_DEVICE_FILTER=host "
         host_check_on_linux_substitute = "| FileCheck %s"
 else:
     lit_config.warning("HOST device not used")
@@ -220,11 +220,11 @@ cpu_check_on_linux_substitute = ""
 if 'cpu' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Test CPU device")
-    cpu_run_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:cpu ".format(SYCL_PLUGIN=config.sycl_be)
+    cpu_run_substitute = "env SYCL_DEVICE_FILTER=cpu "
     cpu_check_substitute = "| FileCheck %s"
     config.available_features.add('cpu')
     if platform.system() == "Linux":
-        cpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:cpu ".format(SYCL_PLUGIN=config.sycl_be)
+        cpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER=cpu "
         cpu_check_on_linux_substitute = "| FileCheck %s"
 else:
     lit_config.warning("CPU device not used")
@@ -269,7 +269,7 @@ acc_check_substitute = ""
 if 'acc' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Tests accelerator device")
-    acc_run_substitute = " env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:acc ".format(SYCL_PLUGIN=config.sycl_be)
+    acc_run_substitute = " env SYCL_DEVICE_FILTER=acc ".format(SYCL_PLUGIN=config.sycl_be)
     acc_check_substitute = "| FileCheck %s"
     config.available_features.add('accelerator')
 else:

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -220,11 +220,11 @@ cpu_check_on_linux_substitute = ""
 if 'cpu' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Test CPU device")
-    cpu_run_substitute = "env SYCL_DEVICE_FILTER=cpu "
+    cpu_run_substitute = "env SYCL_DEVICE_FILTER=cpu,host "
     cpu_check_substitute = "| FileCheck %s"
     config.available_features.add('cpu')
     if platform.system() == "Linux":
-        cpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER=cpu "
+        cpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER=cpu,host "
         cpu_check_on_linux_substitute = "| FileCheck %s"
 else:
     lit_config.warning("CPU device not used")
@@ -244,7 +244,7 @@ gpu_check_on_linux_substitute = ""
 if 'gpu' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Test GPU device")
-    gpu_run_substitute = " env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:gpu ".format(SYCL_PLUGIN=config.sycl_be)
+    gpu_run_substitute = " env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:gpu,host ".format(SYCL_PLUGIN=config.sycl_be)
     gpu_check_substitute = "| FileCheck %s"
     config.available_features.add('gpu')
 
@@ -252,7 +252,7 @@ if 'gpu' in config.target_devices.split(','):
         gpu_l0_check_substitute = "| FileCheck %s"
 
     if platform.system() == "Linux":
-        gpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:gpu ".format(SYCL_PLUGIN=config.sycl_be)
+        gpu_run_on_linux_substitute = "env SYCL_DEVICE_FILTER={SYCL_PLUGIN}:gpu,host ".format(SYCL_PLUGIN=config.sycl_be)
         gpu_check_on_linux_substitute = "| FileCheck %s"
 
 else:
@@ -269,7 +269,7 @@ acc_check_substitute = ""
 if 'acc' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Tests accelerator device")
-    acc_run_substitute = " env SYCL_DEVICE_FILTER=acc ".format(SYCL_PLUGIN=config.sycl_be)
+    acc_run_substitute = " env SYCL_DEVICE_FILTER=acc,host "
     acc_check_substitute = "| FileCheck %s"
     config.available_features.add('accelerator')
 else:

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -269,7 +269,7 @@ acc_check_substitute = ""
 if 'acc' in config.target_devices.split(','):
     found_at_least_one_device = True
     lit_config.note("Tests accelerator device")
-    acc_run_substitute = " env SYCL_DEVICE_FILTER=acc,host "
+    acc_run_substitute = " env SYCL_DEVICE_FILTER=acc "
     acc_check_substitute = "| FileCheck %s"
     config.available_features.add('accelerator')
 else:


### PR DESCRIPTION
We should not use {SYCL_PLUGIN}: prefix for HOST/CPU/ACC_RUN_PLACEHOLDERs.
These are incorrect combination of BE:DEV_TYPE, and it will cause
device_selectors to return no device because they cannot find any device
that can satisfy that invalid combination.

Also, added host for CPU/GPU_RUN_PLACEHOLDERs because the new implementation of SYCL_DEVICE_FILTER will not add the host device automatically. https://github.com/intel/llvm/pull/3397

Signed-off-by: Byoungro So <byoungro.so@intel.com>