### PR TITLE
[SYCL] Mark several FPGA tests as XFAIL

### DIFF
--- a/SYCL/Basic/context-with-multiple-devices.cpp
+++ b/SYCL/Basic/context-with-multiple-devices.cpp
@@ -2,6 +2,7 @@
 
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-unnamed-lambda %s -o %t2.out
 // RUN: env CL_CONFIG_CPU_EMULATE_DEVICES=2 %t2.out
+// XFAIL: *
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/Basic/fpga_tests/fpga_aocx.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx.cpp
@@ -23,3 +23,5 @@
 //
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_src.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_obj.out
+
+// XFAIL: *

--- a/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -24,3 +24,5 @@
 //
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_src.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_obj.out
+
+// XFAIL: *

--- a/SYCL/Basic/fpga_tests/global_fpga_device_selector.cpp
+++ b/SYCL/Basic/fpga_tests/global_fpga_device_selector.cpp
@@ -3,6 +3,8 @@
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: *
+
 #include <CL/sycl.hpp>
 #include <CL/sycl/INTEL/fpga_extensions.hpp>
 

--- a/SYCL/DeviceLib/complex-fpga.cpp
+++ b/SYCL/DeviceLib/complex-fpga.cpp
@@ -13,3 +13,5 @@
 
 // RUN: %clangxx -fsycl -fintelfpga %S/std_complex_math_test.cpp -o %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// XFAIL: *

--- a/SYCL/Scheduler/DataMovement.cpp
+++ b/SYCL/Scheduler/DataMovement.cpp
@@ -4,6 +4,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
+// XFAIL: accelerator
+//
 //==-------------------------- DataMovement.cpp ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
The following tests have started to fail after https://github.com/intel/llvm/pull/3312:
  SYCL :: Basic/context-with-multiple-devices.cpp
  SYCL :: Basic/fpga_tests/fpga_aocx.cpp
  SYCL :: Basic/fpga_tests/global_fpga_device_selector.cpp
  SYCL :: DeviceLib/complex-fpga.cpp
  SYCL :: Scheduler/DataMovement.cpp

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>