### PR TITLE
[SYCL] Remove 6 ESIMD and InlineAsm tests' XFAIL when GPU uplift

### DIFF
--- a/SYCL/ESIMD/spec_const/spec_const_char.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_char.cpp
@@ -14,7 +14,6 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
-// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/ESIMD/spec_const/spec_const_short.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_short.cpp
@@ -14,7 +14,6 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
-// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
@@ -14,7 +14,6 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
-// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
@@ -14,7 +14,6 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
-// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/InlineAsm/asm_loop.cpp
+++ b/SYCL/InlineAsm/asm_loop.cpp
@@ -3,7 +3,6 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// XFAIL:*
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
 #include <cmath>

--- a/SYCL/InlineAsm/asm_switch.cpp
+++ b/SYCL/InlineAsm/asm_switch.cpp
@@ -3,7 +3,6 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// XFAIL:*
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
The following 6 tests begin to PASS after https://github.com/intel/llvm/pull/3386
4 tests unexpected pass on level_zero:gpu
SYCL :: ESIMD/spec_const/spec_const_char.cpp
SYCL :: ESIMD/spec_const/spec_const_short.cpp
SYCL :: ESIMD/spec_const/spec_const_uchar.cpp
SYCL :: ESIMD/spec_const/spec_const_ushort.cpp
2 tests unexpected pass on level_zero:gpu/opencl:gpu
SYCL :: InlineAsm/asm_loop.cpp
SYCL :: InlineAsm/asm_switch.cpp

Remove llvm-test-suite "//XFAIL: level_zero" for ESIMD test, and "//XFAIL:*" for InlineAsm test.