### PR TITLE
Revert "[SYCL] Remove 6 ESIMD and InlineAsm tests' XFAIL when GPU uplift"

### DIFF
--- a/SYCL/ESIMD/spec_const/spec_const_char.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_char.cpp
@@ -14,6 +14,7 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
+// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/ESIMD/spec_const/spec_const_short.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_short.cpp
@@ -14,6 +14,7 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
+// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
@@ -14,6 +14,7 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
+// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
@@ -14,6 +14,7 @@
 // UNSUPPORTED: windows
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
+// XFAIL: level_zero
 // RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda

--- a/SYCL/InlineAsm/asm_loop.cpp
+++ b/SYCL/InlineAsm/asm_loop.cpp
@@ -3,6 +3,7 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// XFAIL:*
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
 #include <cmath>

--- a/SYCL/InlineAsm/asm_switch.cpp
+++ b/SYCL/InlineAsm/asm_switch.cpp
@@ -3,6 +3,7 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// XFAIL:*
 #include "include/asmhelper.h"
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
Reverts intel/llvm-test-suite#193