### PR TITLE
[SYCL] Remove -std=c++14 from tests as new SYCL 2020 features require C++17

### DIFF
--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_call_from_func.cpp
+++ b/SYCL/ESIMD/fp_call_from_func.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: gpu
 // Issue #162 Test timeouts on Windows
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 //

--- a/SYCL/ESIMD/fp_call_recursive.cpp
+++ b/SYCL/ESIMD/fp_call_recursive.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // The test checks that ESIMD kernels support use of function pointers

--- a/SYCL/ESIMD/fp_in_phi.cpp
+++ b/SYCL/ESIMD/fp_in_phi.cpp
@@ -10,7 +10,7 @@
 // based spirv translator. This test should start working on Windows when the
 // llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 //

--- a/SYCL/ESIMD/fp_in_select.cpp
+++ b/SYCL/ESIMD/fp_in_select.cpp
@@ -10,7 +10,7 @@
 // based spirv translator. This test should start working on Windows when the
 // llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -std=c++14 -fsycl %s -o %t.out
+// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 // The test fails on JITing due to use of too many registers

--- a/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
+++ b/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
 
-// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_optionc++14 -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_option -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
+++ b/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
 
-// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_option -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
+++ b/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
 
-// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_optionc++14 -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_option -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
+++ b/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda
 // CUDA does not support the function pointer as kernel argument extension.
 
-// RUN: %clangxx -Xclang -fsycl-allow-func-ptr %cxx_std_option -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Sampler/normalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/normalized-clamp-nearest.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // XFAIL: level_zero
 
+// TODO: enable this test after flaky bug is gone on Windows
+// UNSUPPORTED: windows
+
 // LevelZero has a bug wherein it always returns the first pixel value.
 // Will re-enable once fixed.
 

--- a/SYCL/Sampler/normalized-none-linear-float.cpp
+++ b/SYCL/Sampler/normalized-none-linear-float.cpp
@@ -6,9 +6,6 @@
 // XFAIL: cuda
 // UNSUPPORTED: level_zero && windows
 
-// TODO: enable this test after flaky bug is gone
-// UNSUPPORTED: opencl && linux
-
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)
 

--- a/SYCL/Sampler/normalized-none-linear-float.cpp
+++ b/SYCL/Sampler/normalized-none-linear-float.cpp
@@ -6,6 +6,9 @@
 // XFAIL: cuda
 // UNSUPPORTED: level_zero && windows
 
+// TODO: enable this test after flaky bug is gone
+// UNSUPPORTED: opencl & linux
+
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)
 

--- a/SYCL/Sampler/normalized-none-linear-float.cpp
+++ b/SYCL/Sampler/normalized-none-linear-float.cpp
@@ -7,7 +7,7 @@
 // UNSUPPORTED: level_zero && windows
 
 // TODO: enable this test after flaky bug is gone
-// UNSUPPORTED: opencl & linux
+// UNSUPPORTED: opencl && linux
 
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)


### PR DESCRIPTION
This patch removes -std=c++14 from SYCL tests because some of the SYCL
2020 features require C++17 features and syntax