### PR TITLE
[SYCL] Fix SYCL_DEVICE_FILTER setting

### DIFF
--- a/SYCL/Basic/host_always_works.cpp
+++ b/SYCL/Basic/host_always_works.cpp
@@ -2,7 +2,7 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
-// RUN: SYCL_DEVICE_FILTER=acc,host %t1.out
+// RUN: env SYCL_DEVICE_FILTER=acc,host %t1.out
 
 //==------ host_always_works.cpp - Host Device Availability test -----------==//
 //

--- a/SYCL/Basic/host_always_works.cpp
+++ b/SYCL/Basic/host_always_works.cpp
@@ -2,7 +2,7 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
-// RUN: %ACC_RUN_PLACEHOLDER %t1.out
+// RUN: SYCL_DEVICE_FILTER=acc,host %t1.out
 
 //==------ host_always_works.cpp - Host Device Availability test -----------==//
 //

--- a/SYCL/FilterSelector/select_device.cpp
+++ b/SYCL/FilterSelector/select_device.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_FILTER="*" %t.out
-// RUN: env SYCL_DEVICE_FILTER=cpu %t.out
+// RUN: env SYCL_DEVICE_FILTER=cpu,host %t.out
 // RUN: env SYCL_DEVICE_FILTER=level_zero:gpu %t.out
 // RUN: env SYCL_DEVICE_FILTER=opencl:gpu %t.out
 // RUN: env SYCL_DEVICE_FILTER=cpu,level_zero:gpu %t.out
@@ -11,7 +11,7 @@
 // Checks that no device is selected when no device of desired type is
 // available.
 //
-// REQUIRES: cpu,gpu,accelerator
+// REQUIRES: cpu,gpu,accelerator,host
 
 #include <CL/sycl.hpp>
 #include <iostream>
@@ -50,8 +50,8 @@ int main() {
     device d = cs.select_device();
     std::cout << "CPU device is found: " << d.is_cpu() << std::endl;
   }
-  // HOST device is always available regardless of SYCL_DEVICE_FILTER
-  {
+  if (!envVal || forcedPIs == "*" ||
+      forcedPIs.find("host") != std::string::npos) {
     host_selector hs;
     device d = hs.select_device();
     std::cout << "HOST device is found: " << d.is_host() << std::endl;

--- a/SYCL/FilterSelector/select_device_cpu.cpp
+++ b/SYCL/FilterSelector/select_device_cpu.cpp
@@ -45,6 +45,8 @@ int main() {
     device d = cs.select_device();
     std::cout << "CPU device is found: " << d.is_cpu() << std::endl;
   }
+  /*
+  // TODO: enable this once SYCL_DEVICE_FILTER PR is merged.
   {
     host_selector hs;
     try {
@@ -55,6 +57,7 @@ int main() {
       std::cout << "Expectedly, HOST device is not found";
     }
   }
+  */
   {
     accelerator_selector as;
     try {

--- a/SYCL/FilterSelector/select_device_cpu.cpp
+++ b/SYCL/FilterSelector/select_device_cpu.cpp
@@ -45,11 +45,15 @@ int main() {
     device d = cs.select_device();
     std::cout << "CPU device is found: " << d.is_cpu() << std::endl;
   }
-  // HOST device is always available regardless of SYCL_DEVICE_FILTER
   {
     host_selector hs;
-    device d = hs.select_device();
-    std::cout << "HOST device is found: " << d.is_host() << std::endl;
+    try {
+      device d = hs.select_device();
+      std::cerr << "HOST device is found: " << d.is_host() << std::endl;
+      return -1;
+    } catch (...) {
+      std::cout << "Expectedly, HOST device is not found";
+    }
   }
   {
     accelerator_selector as;

--- a/SYCL/FilterSelector/select_device_level_zero.cpp
+++ b/SYCL/FilterSelector/select_device_level_zero.cpp
@@ -1,12 +1,12 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_DEVICE_FILTER=level_zero:gpu %t.out
+// RUN: env SYCL_DEVICE_FILTER=level_zero:gpu,host %t.out
 //
 // Checks if only specified device types can be acquired from select_device
 // when SYCL_DEVICE_FILTER is set
 // Checks that no device is selected when no device of desired type is
 // available.
 //
-// REQUIRES: level_zero,gpu
+// REQUIRES: level_zero,gpu,host
 
 #include <CL/sycl.hpp>
 #include <iostream>


### PR DESCRIPTION
HOST device is not automatically available when SYCL_DEVICE_FILTER is set.
SYCL_DEVICE_FILTER has to list 'host' explicitly if a test needs it.

Signed-off-by: Byoungro So <byoungro.so@intel.com>