### PR TITLE
Disable some SYCL/Reduction tests on Windows OpenCL

### DIFF
--- a/SYCL/Reduction/reduction_nd_s0_rw.cpp
+++ b/SYCL/Reduction/reduction_nd_s0_rw.cpp
@@ -6,6 +6,10 @@
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with 0-dimensional read_write accessor.
 
+// This test fails with exceeded time out on Windows with OpenCL, temporarily
+// disabling
+// UNSUPPORTED: windows && opencl
+
 #include "reduction_utils.hpp"
 #include <CL/sycl.hpp>
 #include <cassert>

--- a/SYCL/Reduction/reduction_nd_s1_rw.cpp
+++ b/SYCL/Reduction/reduction_nd_s1_rw.cpp
@@ -7,6 +7,10 @@
 // with reductions initialized with 1-dimensional read_write accessor
 // accessing 1 element buffer.
 
+// This test fails with exceeded time out on Windows with OpenCL, temporarily
+// disabling
+// UNSUPPORTED: windows && opencl
+
 #include "reduction_utils.hpp"
 #include <CL/sycl.hpp>
 #include <cassert>

--- a/SYCL/Reduction/reduction_usm.cpp
+++ b/SYCL/Reduction/reduction_usm.cpp
@@ -18,6 +18,10 @@
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with USM var.
 
+// This test fails with exceeded time out on Windows with OpenCL, temporarily
+// disabling
+// UNSUPPORTED: windows && opencl
+
 #include "reduction_utils.hpp"
 #include <CL/sycl.hpp>
 #include <cassert>


### PR DESCRIPTION
This patch disables some SYCL/Reduction tests because they fail
sporadically in CI on Windows with OpenCL with exceeded time out
(possible deadlock).