### PR TITLE
[ESIMD] Remove -fsycl-explicit-simd flag

### DIFF
--- a/SYCL/ESIMD/BitonicSortK.cpp
+++ b/SYCL/ESIMD/BitonicSortK.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/BitonicSortKv2.cpp
+++ b/SYCL/ESIMD/BitonicSortKv2.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/PrefixSum.cpp
+++ b/SYCL/ESIMD/PrefixSum.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out 20
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20
 

--- a/SYCL/ESIMD/Prefix_Local_sum1.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum1.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out 20
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20
 

--- a/SYCL/ESIMD/Prefix_Local_sum2.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum2.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out 20
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20
 

--- a/SYCL/ESIMD/Prefix_Local_sum3.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum3.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/Stencil.cpp
+++ b/SYCL/ESIMD/Stencil.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/accessor.cpp
+++ b/SYCL/ESIMD/accessor.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -D_CRT_SECURE_NO_WARNINGS=1 %s -o %t.out
+// RUN: %clangxx -fsycl -D_CRT_SECURE_NO_WARNINGS=1 %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // This test checks that accessor-based memory accesses work correctly in ESIMD.

--- a/SYCL/ESIMD/accessor_gather_scatter.cpp
+++ b/SYCL/ESIMD/accessor_gather_scatter.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // The test checks functionality of the gather/scatter accessor-based ESIMD

--- a/SYCL/ESIMD/accessor_load_store.cpp
+++ b/SYCL/ESIMD/accessor_load_store.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // The test checks functionality of the scalar load/store accessor-based ESIMD

--- a/SYCL/ESIMD/dp4a.cpp
+++ b/SYCL/ESIMD/dp4a.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // TODO enable on Windows
 // REQUIRES: linux && gpu
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // TODO : Enable test for new GPU device
 // XFAIL: *

--- a/SYCL/ESIMD/ext_math.cpp
+++ b/SYCL/ESIMD/ext_math.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // This test checks extended math operations.

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/fp_call_from_func.cpp
+++ b/SYCL/ESIMD/fp_call_from_func.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: gpu
 // Issue #162 Test timeouts on Windows
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 //

--- a/SYCL/ESIMD/fp_call_recursive.cpp
+++ b/SYCL/ESIMD/fp_call_recursive.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // The test checks that ESIMD kernels support use of function pointers

--- a/SYCL/ESIMD/fp_in_phi.cpp
+++ b/SYCL/ESIMD/fp_in_phi.cpp
@@ -10,7 +10,7 @@
 // based spirv translator. This test should start working on Windows when the
 // llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 //

--- a/SYCL/ESIMD/fp_in_select.cpp
+++ b/SYCL/ESIMD/fp_in_select.cpp
@@ -10,7 +10,7 @@
 // based spirv translator. This test should start working on Windows when the
 // llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
+// RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 // The test fails on JITing due to use of too many registers

--- a/SYCL/ESIMD/histogram.cpp
+++ b/SYCL/ESIMD/histogram.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/histogram_256_slm.cpp
+++ b/SYCL/ESIMD/histogram_256_slm.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/histogram_256_slm_spec.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec.cpp
@@ -8,7 +8,7 @@
 // TODO enable on Windows
 // REQUIRES: linux && gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 16
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/histogram_2d.cpp
+++ b/SYCL/ESIMD/histogram_2d.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/kmeans/kmeans.cpp
+++ b/SYCL/ESIMD/kmeans/kmeans.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
+// RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %S/points.csv
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %S/points.csv
 //

--- a/SYCL/ESIMD/linear/linear.cpp
+++ b/SYCL/ESIMD/linear/linear.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
+// RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp
 

--- a/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
+// RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %T/output.ppm %S/golden_hw.ppm
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -8,7 +8,7 @@
 // TODO enable on Windows
 // REQUIRES: linux && gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
+// RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %T/output_spec.ppm %S/golden_hw.ppm 512 -2.09798 -1.19798 0.004 4.0
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/matrix_transpose.cpp
+++ b/SYCL/ESIMD/matrix_transpose.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/matrix_transpose_glb.cpp
+++ b/SYCL/ESIMD/matrix_transpose_glb.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/matrix_transpose_usm.cpp
+++ b/SYCL/ESIMD/matrix_transpose_usm.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_192.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_192.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_256.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_256.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_512.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_512.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_64.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_64.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_96.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_96.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_192.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_192.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_256.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_256.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_512.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_512.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_64.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_64.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_96.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_96.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 
 #include <cstdint>

--- a/SYCL/ESIMD/noinline_call_from_func.cpp
+++ b/SYCL/ESIMD/noinline_call_from_func.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: gpu
 // Test currently timeouts on Windows Level Zero and OpenCL
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 //

--- a/SYCL/ESIMD/noinline_call_recursive.cpp
+++ b/SYCL/ESIMD/noinline_call_recursive.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 //

--- a/SYCL/ESIMD/private_memory/pm_access_1.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_1.cpp
@@ -8,5 +8,5 @@
 
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 1

--- a/SYCL/ESIMD/private_memory/pm_access_2.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_2.cpp
@@ -8,5 +8,5 @@
 
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 2

--- a/SYCL/ESIMD/private_memory/pm_access_3.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_3.cpp
@@ -8,5 +8,5 @@
 
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 3

--- a/SYCL/ESIMD/reduction.cpp
+++ b/SYCL/ESIMD/reduction.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/regression/big_const_initializer.cpp
+++ b/SYCL/ESIMD/regression/big_const_initializer.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // This test checks that ESIMD program with big constant initializer list can

--- a/SYCL/ESIMD/regression/dgetrf.cpp
+++ b/SYCL/ESIMD/regression/dgetrf.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -DUSE_REF %s -I%S/.. -o %t.ref.out
-// RUN: %clangxx-esimd -fsycl %s -I%S/.. -o %t.out
+// RUN: %clangxx -fsycl -DUSE_REF %s -I%S/.. -o %t.ref.out
+// RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.ref.out 3 2 1
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 3 2 1
 //

--- a/SYCL/ESIMD/regression/unused_load.cpp
+++ b/SYCL/ESIMD/regression/unused_load.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // This test checks that ESIMD JIT compilation does not crash on unused

--- a/SYCL/ESIMD/slm_barrier.cpp
+++ b/SYCL/ESIMD/slm_barrier.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/slm_split_barrier.cpp
+++ b/SYCL/ESIMD/slm_split_barrier.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_bool.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_bool.cpp
@@ -12,7 +12,7 @@
 // driver is disabled at all. This feature will start working on Windows when
 // the llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_char.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_char.cpp
@@ -15,7 +15,7 @@
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
 // XFAIL: level_zero
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_double.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_double.cpp
@@ -12,7 +12,7 @@
 // driver is disabled at all. This feature will start working on Windows when
 // the llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_float.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_float.cpp
@@ -12,7 +12,7 @@
 // driver is disabled at all. This feature will start working on Windows when
 // the llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_int.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_int.cpp
@@ -12,7 +12,7 @@
 // driver is disabled at all. This feature will start working on Windows when
 // the llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_int64.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_int64.cpp
@@ -12,7 +12,7 @@
 // driver is disabled at all. This feature will start working on Windows when
 // the llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_short.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_short.cpp
@@ -15,7 +15,7 @@
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
 // XFAIL: level_zero
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
@@ -15,7 +15,7 @@
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
 // XFAIL: level_zero
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_uint.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uint.cpp
@@ -12,7 +12,7 @@
 // driver is disabled at all. This feature will start working on Windows when
 // the llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_uint64.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uint64.cpp
@@ -12,7 +12,7 @@
 // driver is disabled at all. This feature will start working on Windows when
 // the llvm version is switched to 9.
 // UNSUPPORTED: windows
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
@@ -15,7 +15,7 @@
 // Linux Level Zero fail with assertion in SPIRV about specialization constant
 // type size.
 // XFAIL: level_zero
-// RUN: %clangxx-esimd -fsycl -I%S/.. %s -o %t.out
+// RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/spec_const_redefine_esimd.cpp
+++ b/SYCL/ESIMD/spec_const_redefine_esimd.cpp
@@ -1,6 +1,6 @@
 // TODO enable on Windows
 // REQUIRES: linux && gpu
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // UNSUPPORTED: cuda
 

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/sycl_esimd_mix.cpp
+++ b/SYCL/ESIMD/sycl_esimd_mix.cpp
@@ -10,7 +10,7 @@
 
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/test_id_3d.cpp
+++ b/SYCL/ESIMD/test_id_3d.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/vadd_1d.cpp
+++ b/SYCL/ESIMD/vadd_1d.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/vadd_2d.cpp
+++ b/SYCL/ESIMD/vadd_2d.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/vadd_2d_acc.cpp
+++ b/SYCL/ESIMD/vadd_2d_acc.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // UNSUPPORTED: cuda

--- a/SYCL/ESIMD/vadd_raw_send.cpp
+++ b/SYCL/ESIMD/vadd_raw_send.cpp
@@ -8,7 +8,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"

--- a/SYCL/ESIMD/vadd_usm.cpp
+++ b/SYCL/ESIMD/vadd_usm.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
-// RUN: %clangxx-esimd -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -171,9 +171,6 @@ if config.sycl_be not in ['host', 'opencl','cuda', 'level_zero']:
                      config.sycl_be +
                      "' supported values are opencl, cuda, level_zero")
 
-config.substitutions.append( ('%clangxx-esimd',  config.dpcpp_compiler +
-                              ' ' + '-fsycl-explicit-simd' + ' ' +
-                              config.cxx_flags ) )
 config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags ) )
 config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags ) )
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
@@ -234,7 +231,6 @@ config.substitutions.append( ('%CPU_RUN_ON_LINUX_PLACEHOLDER',  cpu_run_on_linux
 config.substitutions.append( ('%CPU_CHECK_PLACEHOLDER',  cpu_check_substitute) )
 config.substitutions.append( ('%CPU_CHECK_ON_LINUX_PLACEHOLDER',  cpu_check_on_linux_substitute) )
 
-esimd_run_substitute = "true"
 gpu_run_substitute = "true"
 gpu_run_on_linux_substitute = "true "
 gpu_check_substitute = ""


### PR DESCRIPTION
SYCL and ESIMD code now have a unified compilation flow, so ESIMD code does not depend on `-fsycl-explicit-simd` flag anymore.