### PR TITLE
[SYCL] Change in macro name.

### DIFF
--- a/SYCL/Basic/parallel_for_disable_range_roundup.cpp
+++ b/SYCL/Basic/parallel_for_disable_range_roundup.cpp
@@ -1,4 +1,6 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ -DSYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING %s -o %t.out
+// TODO: Remove -DSYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING after runtime change.
+
 // RUN: %GPU_RUN_PLACEHOLDER SYCL_PARALLEL_FOR_RANGE_ROUNDING_TRACE=1 %t.out %GPU_CHECK_PLACEHOLDER --check-prefix CHECK-DISABLED
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -sycl-std=2017 %s -o %t.out


### PR DESCRIPTION
This change is the first step in migrating from using a macro without underscores around, it to one with the underscores.

Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>