### PR TITLE
[SYCL] Allow default selected GPU to be from any available platform

### DIFF
--- a/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
@@ -4,7 +4,9 @@
 // RUN: FileCheck %s --check-prefixes=CHECK-GPU-BUILTIN,CHECK-GPU-CUSTOM --input-file %t.default.out
 
 // CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}{{Level-Zero|CUDA|OpenCL}}
+// clang-format off
 // CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}GPU : {{.*}}{{Level-Zero|CUDA|OpenCL}}
+// clang-format on
 
 //==--------------------- sycl-ls-gpu-default-any.cpp ----------------------==//
 //

--- a/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
@@ -1,15 +1,18 @@
-// REQUIRES: gpu, level-zero
+// REQUIRES: gpu
 
 // RUN: env --unset=SYCL_DEVICE_FILTER sycl-ls --verbose >%t.default.out
 // RUN: FileCheck %s --check-prefixes=CHECK-GPU-BUILTIN,CHECK-GPU-CUSTOM --input-file %t.default.out
 
-// CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}Level-Zero
-// CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}GPU : {{.*}}Level-Zero
+// CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}{{Level-Zero|CUDA|OpenCL}}
+// CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}GPU : {{.*}}{{Level-Zero|CUDA|OpenCL}}
 
-//==-- sycl-ls-gpu-default.cpp - SYCL test for default selected gpu device -==//
+//==--------------------- sycl-ls-gpu-default-any.cpp ----------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// This test checks that a valid GPU is returned by sycl-ls by default if one
+// is present.

--- a/SYCL/Plugin/sycl-ls-gpu-default-level-zero.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-default-level-zero.cpp
@@ -6,10 +6,13 @@
 // CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}Level-Zero
 // CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}GPU : {{.*}}Level-Zero
 
-//==-- sycl-ls-gpu-default.cpp - SYCL test for default selected gpu device -==//
+//==------------------ sycl-ls-gpu-default-level-zero.cpp ------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// This test checks that, if available, a Level-Zero GPU will be selected by
+// the default GPU selector.

--- a/SYCL/Plugin/sycl-ls-gpu-default.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-default.cpp
@@ -3,8 +3,8 @@
 // RUN: env --unset=SYCL_DEVICE_FILTER sycl-ls --verbose >%t.default.out
 // RUN: FileCheck %s --check-prefixes=CHECK-GPU-BUILTIN,CHECK-GPU-CUSTOM --input-file %t.default.out
 
-// CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}Level-Zero
-// CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}GPU : {{.*}}Level-Zero
+// CHECK-GPU-BUILTIN: gpu_selector(){{.*}}GPU : {{.*}}{{Level-Zero|CUDA|OpenCL}}
+// CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}GPU : {{.*}}{{Level-Zero|CUDA|OpenCL}}
 
 //==-- sycl-ls-gpu-default.cpp - SYCL test for default selected gpu device -==//
 //


### PR DESCRIPTION
Removes the assumption that level-zero is available and the default on the system, allowing the default GPU to be from either the OpenCL backend, the CUDA backend, or the L0 backend.