### PR TITLE
[SYCL][CUDA] Disable image_sample test for CUDA

### DIFF
--- a/SYCL/Basic/image/image_sample.cpp
+++ b/SYCL/Basic/image/image_sample.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
+// UNSUPPORTED: cuda
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
Newer CUDA versions break the current implementation of image samplers
in DPC++ CUDA. This patch disables the failing test temporarily.