### PR TITLE
[SYCL] update bit_cast for sycl namespace

### DIFF
--- a/SYCL/Basic/bit_cast/bit_cast.cpp
+++ b/SYCL/Basic/bit_cast/bit_cast.cpp
@@ -22,8 +22,7 @@ template <typename To, typename From> To doBitCast(const From &ValueToConvert) {
     Queue.submit([&](sycl::handler &cgh) {
       auto acc = Buf.template get_access<sycl_write>(cgh);
       cgh.single_task<class BitCastKernel<To, From>>([=]() {
-        // TODO: change to sycl::bit_cast in the future
-        acc[0] = sycl::detail::bit_cast<To>(ValueToConvert);
+        acc[0] = sycl::bit_cast<To>(ValueToConvert);
       });
     });
   }


### PR DESCRIPTION
for SYCL2020, bit_cast will be moved from sycl::detail:: to sycl:: namespace. The PR on intel/llvm is pending. This is a matching update to the tests here. This won't pass until https://github.com/intel/llvm/pull/3524 is merged.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>