### PR TITLE
[SYCL] Fix host device check

### DIFF
--- a/SYCL/FilterSelector/select_device_cuda.cpp
+++ b/SYCL/FilterSelector/select_device_cuda.cpp
@@ -47,11 +47,15 @@ int main() {
       cout << "Expectedly, cpu device is not found." << std::endl;
     }
   }
-  // HOST device is always available regardless of SYCL_DEVICE_FILTER
   {
     host_selector hs;
-    device d = hs.select_device();
-    cout << "HOST device is found: " << d.is_host() << std::endl;
+    try {
+      device d = hs.select_device();
+      cerr << "CPU device is found in error: " << d.is_host() << std::endl;
+      return -1;
+    } catch (...) {
+      cout << "Expectedly, HOST device is not found." << std::endl;
+    }
   }
   {
     accelerator_selector as;

--- a/SYCL/FilterSelector/select_device_cuda.cpp
+++ b/SYCL/FilterSelector/select_device_cuda.cpp
@@ -51,7 +51,7 @@ int main() {
     host_selector hs;
     try {
       device d = hs.select_device();
-      cerr << "CPU device is found in error: " << d.is_host() << std::endl;
+      cerr << "HOST device is found in error: " << d.is_host() << std::endl;
       return -1;
     } catch (...) {
       cout << "Expectedly, HOST device is not found." << std::endl;


### PR DESCRIPTION
Now, the host device is not automatically available when SYCL_DEVICE_FILTER is set.

Signed-off-by: Byoungro So <byoungro.so@intel.com>