### PR TITLE
[SYCL] -std=c++17 added to some of the tests.

### DIFF
--- a/SYCL/Basic/buffer/buffer.cpp
+++ b/SYCL/Basic/buffer/buffer.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %s -o %t1.out %sycl_options
+// RUN: %clangxx -std=c++17 %s -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out

--- a/SYCL/Basic/buffer/buffer_full_copy.cpp
+++ b/SYCL/Basic/buffer/buffer_full_copy.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %s -o %t1.out %sycl_options
+// RUN: %clangxx -std=c++17 %s -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out

--- a/SYCL/Basic/device_code_dae.cpp
+++ b/SYCL/Basic/device_code_dae.cpp
@@ -3,7 +3,7 @@
 // UNSUPPORTED: cuda
 // CUDA does not support SPIR-V.
 // RUN: %clangxx -fsycl-device-only -Xclang -fenable-sycl-dae -Xclang -fsycl-int-header=int_header.h %s -c -o device_code.bc -Wno-sycl-strict
-// RUN: %clangxx %include_option int_header.h %debug_option -c %s -o host_code.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx -std=c++17 %include_option int_header.h %debug_option -c %s -o host_code.o %sycl_options -Wno-sycl-strict
 // RUN: llvm-link -o=linked_device_code.bc device_code.bc
 // RUN: sycl-post-link -emit-param-info linked_device_code.bc
 // RUN: llvm-spirv -o linked_device_code.spv linked_device_code.bc

--- a/SYCL/Basic/image/image_constructors.cpp
+++ b/SYCL/Basic/image/image_constructors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %s -o %t1.out %sycl_options
+// RUN: %clangxx %s -std=c++17 -o %t1.out %sycl_options
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out

--- a/SYCL/Basic/parallel_for_indexers.cpp
+++ b/SYCL/Basic/parallel_for_indexers.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %s -o %t1.out %sycl_options -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -std=c++17 %s -o %t1.out %sycl_options -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t2.out
 // RUN: %HOST_RUN_PLACEHOLDER %t2.out

--- a/SYCL/Config/kernel_from_file.cpp
+++ b/SYCL/Config/kernel_from_file.cpp
@@ -1,8 +1,8 @@
 // UNSUPPORTED: cuda
 // CUDA does not support SPIR-V.
 
-// RUN: %clangxx -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
-// RUN: %clangxx %include_option %t.h %s -o %t.out %sycl_options -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -std=c++17 -fsycl-device-only -fno-sycl-use-bitcode -Xclang -fsycl-int-header=%t.h -c %s -o %t.spv -I %sycl_include -Xclang -verify-ignore-unexpected=note,warning -Wno-sycl-strict
+// RUN: %clangxx -std=c++17 %include_option %t.h %s -o %t.out %sycl_options -Xclang -verify-ignore-unexpected=note,warning
 // RUN: %BE_RUN_PLACEHOLDER env SYCL_USE_KERNEL_SPV=%t.spv %t.out | FileCheck %s
 // CHECK: Passed
 

--- a/SYCL/DeviceLib/separate_compile_test.cpp
+++ b/SYCL/DeviceLib/separate_compile_test.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx -std=c++17 %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict
 // RUN: %clangxx %t_host.o %t_device.o -o %t.out %sycl_options
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
@@ -9,7 +9,7 @@
 // RUN: %clangxx -fsycl -fsycl-link  %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx -std=c++17 %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict
 // RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -o %t_fp64.out %sycl_options
 // RUN: %CPU_RUN_PLACEHOLDER %t_fp64.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_fp64.out

--- a/SYCL/SeparateCompile/test.cpp
+++ b/SYCL/SeparateCompile/test.cpp
@@ -5,13 +5,13 @@
 // >> device compilation...
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -c -o a_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx %include_option sycl_ihdr_a.h %debug_option -c %s -o a.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx -std=c++17 %include_option sycl_ihdr_a.h %debug_option -c %s -o a.o %sycl_options -Wno-sycl-strict
 //
 // >> ---- compile src2
 // >> device compilation...
 // RUN: %clangxx -DB_CPP=1 -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -c -o b_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -DB_CPP=1 %include_option sycl_ihdr_b.h %debug_option -c %s -o b.o %sycl_options -Wno-sycl-strict
+// RUN: %clangxx -DB_CPP=1 -std=c++17 %include_option sycl_ihdr_b.h %debug_option -c %s -o b.o %sycl_options -Wno-sycl-strict
 //
 // >> ---- bundle .o with .spv
 // >> run bundler


### PR DESCRIPTION
Some of the test invocations don't pass the -fsycl flag, but do include the SYCL headers. We need to make sure these are compiled with C++17, or the upcoming `span` headers will trigger test failures. 

Signed-off-by: Chris Perkins <chris.perkins@intel.com>