### PR TITLE
[SYCL] Fix tests for multi-tile devices

### DIFF
--- a/SYCL/Basic/query.cpp
+++ b/SYCL/Basic/query.cpp
@@ -1,43 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env CreateMultipleSubDevices=2 env EnableTimestampPacket=1 \
-// RUN: env NEOReadDebugKeys=1 env SYCL_DEVICE_FILTER="gpu" %t.out
-//
-// UNSUPPORTED: gpu-intel-dg1
+// RUN: env SYCL_DEVICE_FILTER="gpu" %t.out
 
-#include <CL/sycl.hpp>
-
-#include <iostream>
-using namespace sycl;
-
-int main() {
-  std::vector<device> devices = device::get_devices(info::device_type::gpu);
-  for (int i = 0; i < devices.size(); ++i) {
-    std::cout << std::endl;
-    std::cout << "Device " << i << ": "
-              << devices[i].get_info<info::device::name>() << std::endl;
-    std::cout << "  Platform: "
-              << devices[i].get_platform().get_info<info::platform::name>()
-              << std::endl;
-    std::cout << "  EUs: "
-              << devices[i].get_info<info::device::max_compute_units>()
-              << std::endl;
-    std::vector<device> subdevices;
-    try {
-      std::cout << "  Subdevices: ";
-      subdevices =
-          devices[i]
-              .create_sub_devices<
-                  info::partition_property::partition_by_affinity_domain>(
-                  info::partition_affinity_domain::numa);
-      std::cout << subdevices.size() << std::endl;
-    } catch (std::exception) {
-      std::cout << "Error -- cannot create subdevices" << std::endl;
-    }
-    for (int j = 0; j < subdevices.size(); ++j) {
-      std::cout << "  Subdevice " << j << std::endl;
-      std::cout << "    EUs: "
-                << subdevices[j].get_info<info::device::max_compute_units>()
-                << std::endl;
-    }
-  }
-}
+// REQUIRES: gpu-intel-dg1
+#include "query.hpp"

--- a/SYCL/Basic/query.hpp
+++ b/SYCL/Basic/query.hpp
@@ -1,0 +1,45 @@
+#include <CL/sycl.hpp>
+
+#include <iostream>
+using namespace sycl;
+
+int main() {
+  std::vector<device> devices = device::get_devices(info::device_type::gpu);
+  for (int i = 0; i < devices.size(); ++i) {
+    std::cout << std::endl;
+    std::cout << "Device " << i << ": "
+              << devices[i].get_info<info::device::name>() << std::endl;
+    std::cout << "  Platform: "
+              << devices[i].get_platform().get_info<info::platform::name>()
+              << std::endl;
+    std::cout << "  EUs: "
+              << devices[i].get_info<info::device::max_compute_units>()
+              << std::endl;
+    std::cout << "  Max sub-devices: "
+              << devices[i].get_info<info::device::partition_max_sub_devices>()
+              << std::endl;
+
+    std::vector<device> subdevices;
+    if (devices[i].get_info<info::device::partition_max_sub_devices>() > 0 &&
+        devices[i].get_info<info::device::max_compute_units>() > 0) {
+      try {
+        std::cout << "  Subdevices: ";
+        subdevices =
+            devices[i]
+                .create_sub_devices<
+                    info::partition_property::partition_by_affinity_domain>(
+                    info::partition_affinity_domain::numa);
+        std::cout << subdevices.size() << std::endl;
+      } catch (exception e) {
+        std::cout << "Error -- cannot create subdevices: " << e.what()
+                  << std::endl;
+      }
+      for (int j = 0; j < subdevices.size(); ++j) {
+        std::cout << "  Subdevice " << j << std::endl;
+        std::cout << "    EUs: "
+                  << subdevices[j].get_info<info::device::max_compute_units>()
+                  << std::endl;
+      }
+    }
+  }
+}

--- a/SYCL/Basic/query.hpp
+++ b/SYCL/Basic/query.hpp
@@ -33,7 +33,7 @@ int main() {
       } catch (exception e) {
         std::cout << "Error -- cannot create subdevices: " << e.what()
                   << std::endl;
-	return 1;
+        return 1;
       }
       for (int j = 0; j < subdevices.size(); ++j) {
         std::cout << "  Subdevice " << j << std::endl;

--- a/SYCL/Basic/query.hpp
+++ b/SYCL/Basic/query.hpp
@@ -33,6 +33,7 @@ int main() {
       } catch (exception e) {
         std::cout << "Error -- cannot create subdevices: " << e.what()
                   << std::endl;
+	return 1;
       }
       for (int j = 0; j < subdevices.size(); ++j) {
         std::cout << "  Subdevice " << j << std::endl;
@@ -42,4 +43,5 @@ int main() {
       }
     }
   }
+  return 0;
 }

--- a/SYCL/Basic/query_emulate_subdevice.cpp
+++ b/SYCL/Basic/query_emulate_subdevice.cpp
@@ -1,0 +1,6 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env CreateMultipleSubDevices=2 EnableTimestampPacket=1 \
+// RUN: NEOReadDebugKeys=1 SYCL_DEVICE_FILTER="gpu" %t.out
+
+// UNSUPPORTED: gpu-intel-dg1
+#include "query.hpp"


### PR DESCRIPTION
The test was split into two:
 - query_emulate_subdevice.cpp for GEN9 GPUs where subdevices should be emulated (this test will be executed when --param gpu-intel-dg1=1 LIT parameter is not set);
 - query.cpp the test for devices with multiple tiles (it is executed when --param gpu-intel-dg1=1 LIT parameter is set).