### PR TITLE
[SYCL] Add tests for types mentioned in SYCL-2020 as implicitly copyable

### DIFF
--- a/SYCL/Basic/is_device_copyable/array.cpp
+++ b/SYCL/Basic/is_device_copyable/array.cpp
@@ -1,0 +1,97 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// This test performs basic check of std::array type mentioned
+// in SYCL-2020 SPEC as one of implicitly device copyable types.
+// That means that std::array can be passed between the host
+// and device or between devices.
+
+#include <CL/sycl.hpp>
+
+#include <array>
+#include <iostream>
+#include <numeric>
+
+using namespace cl::sycl;
+
+template <typename T, size_t N, size_t TestType = 0> class Names;
+
+template <typename T, size_t N> int testBasic(queue &Q) {
+  buffer<int, 1> OutBuf(range<1>{1});
+  Q.submit([&](handler &CGH) {
+    std::array<T, N> Arr;
+    if constexpr (N > 0)
+      std::iota(Arr.begin(), Arr.end(), 0);
+
+    auto OutAcc = OutBuf.template get_access<access::mode::discard_write>(CGH);
+    CGH.single_task<Names<T, N>>([=]() {
+      int Score = 0;
+      if constexpr (N > 0) {
+        for (int I = 0; I < N; I++)
+          Score += Arr[I] == I ? 1 : 0;
+      }
+      Score += Arr.size() == N ? 1 : 0;
+      OutAcc[0] = Score;
+    });
+  });
+  int Score = (OutBuf.template get_access<access::mode::read>())[0];
+  if (Score != N + 1) {
+    std::cerr << "ArrayN test case failed." << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+template <typename T> int testAcc(queue &Q) {
+  buffer<T, 1> OutBuf1(range<1>{1});
+  buffer<T, 1> OutBuf2(range<1>{1});
+  buffer<T, 1> OutBuf3(range<1>{1});
+
+  Q.submit([&](handler &CGH) {
+    using AccType = accessor<T, 1, access::mode::discard_write,
+                             access::target::global_buffer>;
+    std::array<AccType, 3> Arr = {AccType(OutBuf1, CGH), AccType(OutBuf2, CGH),
+                                  AccType(OutBuf3, CGH)};
+
+    CGH.single_task<Names<T, 3, 1>>([=]() {
+      Arr[0][0] = 1001;
+      Arr[1][0] = 1002;
+      Arr[2][0] = 1003;
+    });
+  });
+  int Res1 = (OutBuf1.template get_access<access::mode::read>())[0];
+  int Res2 = (OutBuf2.template get_access<access::mode::read>())[0];
+  int Res3 = (OutBuf3.template get_access<access::mode::read>())[0];
+  int Score = Res1 == 1001 && Res2 == 1002 && Res3 == 1003;
+  if (!Score) {
+    std::cerr << "ArrayN test case failed." << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int main() {
+  int NumErrors = 0;
+
+  queue Q;
+  NumErrors += testBasic<int, 0>(Q);
+  NumErrors += testBasic<int, 1>(Q);
+  NumErrors += testBasic<float, 8>(Q);
+
+  // TODO: enable this test case when compiler can pass std::arrays
+  // more efficiently. Right now it passes each of std::array elements
+  // as 4 separate parameters and thus quickly exceeds the maximum
+  // possible number of kernel parameters.
+  // NumErrors += testBasic<float, 1024 * 8>(Q);
+
+  NumErrors += testAcc<float>(Q);
+
+  if (NumErrors)
+    std::cerr << NumErrors << " test cases failed" << std::endl;
+  else
+    std::cout << "Test PASSED." << std::endl;
+
+  return 0;
+}

--- a/SYCL/Basic/is_device_copyable/basic_string_view.cpp
+++ b/SYCL/Basic/is_device_copyable/basic_string_view.cpp
@@ -1,0 +1,100 @@
+#include <CL/sycl.hpp>
+
+#include <iostream>
+#include <string_view>
+
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// This test performs basic check of std::basic_string_view type mentioned
+// in SYCL-2020 SPEC as one of implicitly device copyable types.
+// std::basic_string_view is device copyable as a viewer/container only,
+// i.e. the content must be allocated as USM memory in order to be
+// accessible on device.
+
+using namespace cl::sycl;
+
+template <typename T> class Names;
+
+template <typename Name, typename T>
+int test(size_t NSyms, usm::alloc AllocType, queue &Q) {
+  auto Dev = Q.get_device();
+
+  if (AllocType == usm::alloc::shared &&
+      !Dev.get_info<info::device::usm_shared_allocations>())
+    return 0;
+  if (AllocType == usm::alloc::host &&
+      !Dev.get_info<info::device::usm_host_allocations>())
+    return 0;
+  if (AllocType == usm::alloc::device &&
+      !Dev.get_info<info::device::usm_device_allocations>())
+    return 0;
+
+  T *StrPtr =
+      (T *)malloc(sizeof(T) * 2 * NSyms, Dev, Q.get_context(), AllocType);
+  if (StrPtr == nullptr)
+    return 0;
+  if (AllocType == usm::alloc::device) {
+    Q.submit([&](handler &CGH) {
+       CGH.single_task<Names<Name>>([=]() {
+         for (int I = 0; I < NSyms; I++) {
+           StrPtr[I * 2] = StrPtr[I * 2 + 1] = 'a' + I;
+         }
+       });
+     }).wait();
+  } else {
+    for (int I = 0; I < NSyms; I++) {
+      StrPtr[I * 2] = StrPtr[I * 2 + 1] = 'a' + I;
+    }
+  }
+
+  buffer<T, 1> StrBuf(NSyms);
+  std::basic_string_view View(StrPtr, 2 * NSyms);
+
+  // Compute.
+  Q.submit([&](handler &CGH) {
+     auto StrAcc = StrBuf.template get_access<access::mode::discard_write>(CGH);
+     CGH.parallel_for<Name>(range<1>{NSyms}, [=](id<1> Id) {
+       size_t I = Id.get(0);
+       StrAcc[I] = View[I * 2];
+     });
+   }).wait();
+
+  // Check correctness.
+  auto StrAcc = StrBuf.template get_access<access::mode::read>();
+  for (int I = 0; I < NSyms; I++) {
+    T ExpectedSym = 'a' + I;
+    if (StrAcc[I] != ExpectedSym) {
+      std::cerr << "Wrong result at index = " << I
+                << ", expected = " << ExpectedSym
+                << ", computed = " << StrAcc[I] << std::endl;
+      return 1;
+    }
+  }
+
+  free(StrPtr, Q.get_context());
+  return 0;
+}
+
+template <typename Name, typename T> int testUSM(size_t NSyms, queue &Q) {
+  int Errors = 0;
+  Errors += test<Name, T>(NSyms, usm::alloc::shared, Q);
+  Errors += test<Name, T>(NSyms, usm::alloc::host, Q);
+  Errors += test<Name, T>(NSyms, usm::alloc::device, Q);
+  return Errors;
+}
+
+int main() {
+  int NumErrors = 0;
+  queue Q;
+  NumErrors += testUSM<class A, char>(26, Q);
+
+  if (NumErrors)
+    std::cerr << NumErrors << " test cases failed" << std::endl;
+  else
+    std::cout << "Test PASSED." << std::endl;
+
+  return NumErrors;
+}

--- a/SYCL/Basic/is_device_copyable/optional.cpp
+++ b/SYCL/Basic/is_device_copyable/optional.cpp
@@ -1,0 +1,61 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// This test performs basic check of std::optional type mentioned
+// in SYCL-2020 SPEC as one of implicitly device copyable types.
+
+#include <CL/sycl.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <optional>
+
+using namespace cl::sycl;
+
+struct CustomStruct {
+  int A;
+  double B;
+  bool operator==(const CustomStruct &RHS) const {
+    return A == RHS.A && B == RHS.B;
+  }
+};
+
+int testBasic(queue &Q) {
+  buffer<int, 1> OutBuf(range<1>{1});
+  Q.submit([&](handler &CGH) {
+    std::optional<uint64_t> OptInt(0xCAFEF00D);
+    std::optional<uint64_t> OptEmpty{};
+    std::optional<CustomStruct> OptCustom{CustomStruct{0x12345678, 123.456}};
+
+    auto OutAcc = OutBuf.template get_access<access::mode::discard_write>(CGH);
+    CGH.single_task<class A>([=]() {
+      uint64_t GoodFood = OptInt.value_or(0xBAADF00D);
+      uint64_t BaadFood = OptEmpty.value_or(0xBAADF00D);
+      auto Custom = OptCustom.value_or(CustomStruct{0, 0.0});
+      OutAcc[0] = GoodFood == 0xCAFEF00D && BaadFood == 0xBAADF00D &&
+                  Custom == CustomStruct{0x12345678, 123.456};
+    });
+  });
+  int Score = (OutBuf.template get_access<access::mode::read>())[0];
+  if (!Score) {
+    std::cerr << "optional basic test case failed." << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int main() {
+  int NumErrors = 0;
+
+  queue Q;
+  NumErrors += testBasic(Q);
+
+  if (NumErrors)
+    std::cerr << NumErrors << " test cases failed" << std::endl;
+  else
+    std::cout << "Test PASSED." << std::endl;
+
+  return 0;
+}

--- a/SYCL/Basic/is_device_copyable/pair.cpp
+++ b/SYCL/Basic/is_device_copyable/pair.cpp
@@ -1,0 +1,93 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// This test performs basic check of std::pair type mentioned
+// in SYCL-2020 SPEC as one of implicitly device copyable types.
+// It is device copyable if the template arguments of std::pair class
+// are device copyable.
+
+#include <CL/sycl.hpp>
+
+#include <iostream>
+#include <utility>
+
+using namespace cl::sycl;
+
+struct CustomStruct {
+  int A;
+  double B;
+  bool operator==(const CustomStruct &RHS) const {
+    return A == RHS.A && B == RHS.B;
+  }
+};
+
+int testBasic(queue &Q) {
+  buffer<int, 1> OutBuf(range<1>{1});
+  Q.submit([&](handler &CGH) {
+    std::pair<int, float> Pair1(7, 3.14);
+    std::pair<double, CustomStruct> Pair2(123.456, CustomStruct{2, 55.1});
+
+    auto OutAcc = OutBuf.get_access<access::mode::discard_write>(CGH);
+    CGH.single_task<class A>([=]() {
+      int Score = 0;
+      Score += (Pair1.first == 7) ? 1 : 0;
+      Score += (Pair1.second == static_cast<float>(3.14)) ? 1 : 0;
+      Score += (Pair2.first == static_cast<double>(123.456)) ? 1 : 0;
+      Score += (Pair2.second == CustomStruct{2, 55.1}) ? 1 : 0;
+      OutAcc[0] = Score;
+    });
+  });
+  int Score = (OutBuf.template get_access<access::mode::read>())[0];
+  if (Score != 4) {
+    std::cerr << "Tuple basic test case failed." << std::endl;
+    std::cerr << "Expected score = 5, computed = " << Score << std::endl;
+    return 1;
+  }
+  return 0;
+}
+#if 0
+// TODO: support of accessors passed in std::pair does not work yet.
+int testAcc(queue &Q) {
+  buffer<int, 1> OutBuf1(range<1>{1});
+  buffer<double, 1> OutBuf2(range<1>{1});
+
+  Q.submit([&](handler &CGH) {
+    using AccType1 = accessor<int, 1, access::mode::discard_write,
+                              access::target::global_buffer>;
+    using AccType2 = accessor<double, 1, access::mode::discard_write,
+                              access::target::global_buffer>;
+    std::pair<AccType1, AccType2> Pair(AccType1(OutBuf1, CGH),
+                                       AccType2(OutBuf2, CGH));
+
+    CGH.single_task<class B>([=]() {
+      Pair.first[0] = 1001;
+      Pair.second[0] = 123.456;
+    });
+  });
+  int Res1 = (OutBuf1.get_access<access::mode::read>())[0];
+  float Res2 = (OutBuf2.get_access<access::mode::read>())[0];
+  int Score = Res1 == 1001 && Res2 == static_cast<float>(123.456);
+  if (!Score) {
+    std::cerr << "Tuple acc test case failed." << std::endl;
+    return 1;
+  }
+  return 0;
+}
+#endif
+
+int main() {
+  int NumErrors = 0;
+
+  queue Q;
+  NumErrors += testBasic(Q);
+  //  NumErrors += testAcc(Q);
+
+  if (NumErrors)
+    std::cerr << NumErrors << " test cases failed" << std::endl;
+  else
+    std::cout << "Test PASSED." << std::endl;
+
+  return 0;
+}

--- a/SYCL/Basic/is_device_copyable/tuple.cpp
+++ b/SYCL/Basic/is_device_copyable/tuple.cpp
@@ -1,0 +1,104 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// TODO: enable the type when it gets support on Windows. Right now it is
+// reported as not trivially copyable and thus cannot be passed to device.
+// UNSUPPORTED: windows || level_zero
+
+// This test performs basic check of std::tuple type mentioned
+// in SYCL-2020 SPEC as one of implicitly device copyable types.
+// It is device copyable if the template arguments of std::tuple class
+// are device copyable.
+
+#include <CL/sycl.hpp>
+
+#include <iostream>
+#include <tuple>
+
+using namespace cl::sycl;
+
+struct CustomStruct {
+  int A;
+  double B;
+  bool operator==(const CustomStruct &RHS) const {
+    return A == RHS.A && B == RHS.B;
+  }
+};
+
+int testBasic(queue &Q) {
+  buffer<int, 1> OutBuf(range<1>{1});
+  Q.submit([&](handler &CGH) {
+    std::tuple<int, float, double, CustomStruct> Tuple(7, 3.14, 123.456,
+                                                       CustomStruct{2, 55.1});
+    std::tuple<> EmptyTuple1;
+    std::tuple<> EmptyTuple2;
+
+    auto OutAcc = OutBuf.get_access<access::mode::discard_write>(CGH);
+    CGH.single_task<class A>([=]() {
+      int Score = 0;
+      Score += (std::get<0>(Tuple) == 7) ? 1 : 0;
+      Score += (std::get<1>(Tuple) == static_cast<float>(3.14)) ? 1 : 0;
+      Score += (std::get<2>(Tuple) == static_cast<double>(123.456)) ? 1 : 0;
+      Score += (std::get<3>(Tuple) == CustomStruct{2, 55.1}) ? 1 : 0;
+      Score += EmptyTuple1 == EmptyTuple2;
+      OutAcc[0] = Score;
+    });
+  });
+  int Score = (OutBuf.template get_access<access::mode::read>())[0];
+  if (Score != 5) {
+    std::cerr << "Tuple basic test case failed." << std::endl;
+    std::cerr << "Expected score = 5, computed = " << Score << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int testAcc(queue &Q) {
+  buffer<int, 1> OutBuf1(range<1>{1});
+  buffer<float, 1> OutBuf2(range<1>{1});
+  buffer<double, 1> OutBuf3(range<1>{1});
+
+  Q.submit([&](handler &CGH) {
+    using AccType1 = accessor<int, 1, access::mode::discard_write,
+                              access::target::global_buffer>;
+    using AccType2 = accessor<float, 1, access::mode::discard_write,
+                              access::target::global_buffer>;
+    using AccType3 = accessor<double, 1, access::mode::discard_write,
+                              access::target::global_buffer>;
+    auto Tuple = std::make_tuple(AccType1(OutBuf1, CGH), AccType2(OutBuf2, CGH),
+                                 AccType3(OutBuf3, CGH));
+
+    CGH.single_task<class B>([=]() {
+      std::get<0>(Tuple)[0] = 1001;
+      std::get<1>(Tuple)[0] = 123.456;
+      std::get<2>(Tuple)[0] = 789.001;
+    });
+  });
+  int Res1 = (OutBuf1.get_access<access::mode::read>())[0];
+  float Res2 = (OutBuf2.get_access<access::mode::read>())[0];
+  double Res3 = (OutBuf3.get_access<access::mode::read>())[0];
+  int Score = Res1 == 1001 && Res2 == static_cast<float>(123.456) &&
+              Res3 == static_cast<double>(789.001);
+  if (!Score) {
+    std::cerr << "Tuple acc test case failed." << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int main() {
+  int NumErrors = 0;
+
+  queue Q;
+  NumErrors += testBasic(Q);
+  NumErrors += testAcc(Q);
+
+  if (NumErrors)
+    std::cerr << NumErrors << " test cases failed" << std::endl;
+  else
+    std::cout << "Test PASSED." << std::endl;
+
+  return 0;
+}

--- a/SYCL/Basic/is_device_copyable/variant.cpp
+++ b/SYCL/Basic/is_device_copyable/variant.cpp
@@ -1,0 +1,67 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// This test performs basic check of std::variant<> and std::variant<Ts...>
+// types mentioned in SYCL-2020 SPEC as implicitly device copyable types.
+// It is device copyable if all template arguments of std::variant class
+// are device copyable.
+
+#include <CL/sycl.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <variant>
+
+using namespace cl::sycl;
+
+struct CustomStruct {
+  uint16_t A;
+  uint16_t B;
+  bool operator==(const CustomStruct &RHS) const {
+    return A == RHS.A && B == RHS.B;
+  }
+};
+
+int testBasic(queue &Q) {
+  buffer<int, 1> OutBuf(range<1>{1});
+  Q.submit([&](handler &CGH) {
+    std::variant<uint64_t, double> Var1 =
+        static_cast<uint64_t>(0x3FF0000000000000LL);
+    std::variant<uint64_t, double> Var2 = static_cast<double>(3.14);
+    std::variant<uint32_t, int32_t, float> Var3 = static_cast<float>(123.456);
+    std::variant<std::monostate> VarEmpty{};
+
+    auto OutAcc = OutBuf.template get_access<access::mode::discard_write>(CGH);
+    CGH.single_task<class A>([=]() {
+      // The code has to be trivial because std::get<>() method cannot be
+      // used on DEVICE as it throws exception, not supported on DEVICE.
+      OutAcc[0] = Var1.index() + Var2.index() * 10 + Var3.index() * 100 +
+                  VarEmpty.index() * 1000;
+      ;
+    });
+  });
+  int ComputedRes = (OutBuf.template get_access<access::mode::read>())[0];
+  int ExpectedRes = 210;
+  if (ComputedRes != ExpectedRes) {
+    std::cerr << "std::variant - basic test case failed. Expected = "
+              << ExpectedRes << ", Computed = " << ComputedRes << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int main() {
+  int NumErrors = 0;
+
+  queue Q;
+  NumErrors += testBasic(Q);
+
+  if (NumErrors)
+    std::cerr << NumErrors << " test cases failed" << std::endl;
+  else
+    std::cout << "Test PASSED." << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
The following types have basic tests: std::array, std::basic_string_view,
std::optional, std::pair, std::tuple, std::variant

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>