### PR TITLE
[SYCL] Moved on-device tests from intel/llvm

### DIFF
--- a/SYCL/KernelAndProgram/basic.cpp
+++ b/SYCL/KernelAndProgram/basic.cpp
@@ -1,0 +1,18 @@
+// No JITing for host devices.
+// REQUIRES: opencl || level_zero
+// RUN: rm -rf %t/cache_dir
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-BUILD
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-CACHE
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-BUILD
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-CACHE
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER --check-prefixes=CHECK-BUILD
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER --check-prefixes=CHECK-CACHE
+//
+// The test checks that caching works properly.
+#include "basic.hpp"
+
+// CHECK-BUILD: piProgramBuild
+
+// CHECK-CACHE-NOT: piProgramBuild
+// CHECK-CACHE: piProgramCreateWithBinary

--- a/SYCL/KernelAndProgram/basic.hpp
+++ b/SYCL/KernelAndProgram/basic.hpp
@@ -1,0 +1,60 @@
+#include <CL/sycl.hpp>
+
+int main(int argc, char **argv) {
+  // Test program and kernel APIs when building a kernel.
+  {
+    cl::sycl::queue q;
+    int data = 0;
+    {
+      cl::sycl::buffer<int, 1> buf(&data, cl::sycl::range<1>(1));
+      cl::sycl::program prg1(q.get_context());
+      cl::sycl::program prg2(q.get_context());
+      cl::sycl::program prg3(q.get_context());
+      cl::sycl::program prg4(q.get_context());
+      cl::sycl::program prg5(q.get_context());
+
+      prg1.build_with_kernel_type<class BuiltKernel>(); // 1 cache item
+      prg2.build_with_kernel_type<class BuiltKernel>(
+          "-cl-fast-relaxed-math"); // +1 cache item due to build options
+      prg3.build_with_kernel_type<class BuiltKernel>();    // program binary is
+                                                           // equal to prg1
+      prg4.build_with_kernel_type<class CompiledKernel>(); // program binary is
+                                                           // equal to prg1
+      cl::sycl::kernel krn = prg2.get_kernel<class BuiltKernel>();
+
+      q.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.single_task<class BuiltKernel>(krn, [=]() { acc[0] = acc[0] + 1; });
+      });
+    }
+    assert(data == 1);
+  }
+
+  // Test program and kernel APIs when compiling / linking a kernel.
+  {
+    cl::sycl::queue q;
+    int data = 0;
+    {
+      cl::sycl::buffer<int, 1> buf(&data, cl::sycl::range<1>(1));
+      cl::sycl::program prg6(q.get_context());
+      cl::sycl::program prg7(q.get_context());
+      cl::sycl::program prg8(q.get_context());
+      prg6.compile_with_kernel_type<class CompiledKernel>();
+      prg6.link(); // The binary is not cached for separate compile/link
+      prg7.build_with_kernel_type<class CompiledKernel>(
+          "-cl-fast-relaxed-math"); // program binary is equal to prg2
+      prg8.build_with_kernel_type<class CompiledKernel>(
+          "-g"); // +1 cache item due to build options
+
+      cl::sycl::kernel krn = prg6.get_kernel<class CompiledKernel>();
+
+      q.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.single_task<class CompiledKernel>(krn,
+                                              [=]() { acc[0] = acc[0] + 1; });
+      });
+    }
+    assert(data == 1);
+  }
+  return 0;
+}

--- a/SYCL/KernelAndProgram/cache_env_vars.cpp
+++ b/SYCL/KernelAndProgram/cache_env_vars.cpp
@@ -1,0 +1,129 @@
+// No JITing for host devices.
+// REQUIRES: opencl || level_zero
+// RUN: rm -rf %t/cache_dir
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -DTARGET_IMAGE=INC100
+// Build program and add item to cache
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %t.out | FileCheck %s --check-prefixes=CHECK-BUILD
+// Ignore caching because image size is less than threshold
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 SYCL_CACHE_MIN_DEVICE_IMAGE_SIZE=100000 %t.out | FileCheck %s --check-prefixes=CHECK-BUILD
+// Ignore caching because image size is more than threshold
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 SYCL_CACHE_MAX_DEVICE_IMAGE_SIZE=1000 %t.out | FileCheck %s --check-prefixes=CHECK-BUILD
+// Use cache
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %t.out | FileCheck %s --check-prefixes=CHECK-CACHE
+// Ignore cache because of environment variable
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 SYCL_CACHE_DISABLE_PERSISTENT=1 %t.out | FileCheck %s --check-prefixes=CHECK-BUILD
+//
+// The test checks environment variables which may disable caching.
+// Also it can be used for benchmarking cache:
+// Rough data collected on 32 core machine.
+// Number of lines    1      10    100    1000   10000
+// Image Size(kB)     2       2	    20	   165    1700
+// Device code build time in seconds
+// CPU OCL JIT       0.12    0.12  0.16     1.1     16
+// CPU OCL Cache     0.01    0.01  0.01	   0.02   0.08
+
+// CHECK-BUILD: piProgramBuild
+// CHECK-BUILD-NOT: piProgramCreateWithBinary
+
+// CHECK-CACHE-NOT: piProgramBuild
+// CHECK-CACHE: piProgramCreateWithBinary
+
+#define INC1(x) ((x) = (x) + 1);
+
+#define INC10(x)                                                               \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)                                                                      \
+  INC1(x)
+
+#define INC100(x)                                                              \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)                                                                     \
+  INC10(x)
+
+#define INC1000(x)                                                             \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)                                                                    \
+  INC100(x)
+
+#define INC10000(x)                                                            \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)                                                                   \
+  INC1000(x)
+
+#define INC100000(x)                                                           \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)                                                                  \
+  INC10000(x)
+
+#include <CL/sycl.hpp>
+#include <chrono>
+#include <iostream>
+class Inc;
+template <class Kernel> void check_build_time(cl::sycl::queue &q) {
+  cl::sycl::program program(q.get_context());
+  auto start = std::chrono::steady_clock::now();
+  program.build_with_kernel_type<Kernel>();
+  auto end = std::chrono::steady_clock::now();
+
+  std::chrono::duration<double> elapsed_seconds = end - start;
+  std::cout << "elapsed build time: " << elapsed_seconds.count() << "s\n";
+}
+int main(int argc, char **argv) {
+  auto start = std::chrono::steady_clock::now();
+  // Test program and kernel APIs when building a kernel.
+  {
+    cl::sycl::queue q;
+    check_build_time<Inc>(q);
+
+    int data = 0;
+    {
+      cl::sycl::buffer<int, 1> buf(&data, cl::sycl::range<1>(1));
+      cl::sycl::range<1> NumOfWorkItems{buf.get_count()};
+
+      q.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::read_write>(cgh);
+        cgh.parallel_for<class Inc>(
+            NumOfWorkItems, [=](cl::sycl::id<1> WIid) { TARGET_IMAGE(acc[0]) });
+      });
+    }
+    // check_build_time<Inc>(q);
+    auto end = std::chrono::steady_clock::now();
+    std::chrono::duration<double> elapsed_seconds = end - start;
+    std::cout << "elapsed kernel time: " << elapsed_seconds.count() << "s\n";
+  }
+}

--- a/SYCL/KernelAndProgram/spec_consts.cpp
+++ b/SYCL/KernelAndProgram/spec_consts.cpp
@@ -1,0 +1,21 @@
+// No JITing for host devices.
+// Specialization constant values are not supported on CUDA
+// REQUIRES: opencl || level_zero
+// RUN: rm -rf %t/cache_dir
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-BUILD
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-CACHE
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-BUILD
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER --check-prefixes=CHECK-CACHE
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER --check-prefixes=CHECK-BUILD
+// RUN: env SYCL_CACHE_DIR=%t/cache_dir SYCL_PI_TRACE=-1 %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER --check-prefixes=CHECK-CACHE
+//
+// The test checks that caching works properly for SYCL application containing
+// specialization constant values.
+#include "spec_consts.hpp"
+
+// CHECK-BUILD: piProgramBuild
+// CHECK-BUILD-NOT: piProgramCreateWithBinary
+
+// CHECK-CACHE-NOT: piProgramBuild
+// CHECK-CACHE: piProgramCreateWithBinary

--- a/SYCL/KernelAndProgram/spec_consts.hpp
+++ b/SYCL/KernelAndProgram/spec_consts.hpp
@@ -1,0 +1,170 @@
+#include <CL/sycl.hpp>
+
+#include <iostream>
+#include <vector>
+
+class MyInt32Const;
+class MyFloatConst;
+class MyConst;
+
+using namespace sycl;
+
+class KernelAAAi;
+class KernelBBBf;
+
+int global_val = 10;
+
+// Fetch a value at runtime.
+int get_value() { return global_val; }
+
+float foo(
+    const cl::sycl::ONEAPI::experimental::spec_constant<float, MyFloatConst>
+        &f32) {
+  return f32;
+}
+
+struct SCWrapper {
+  SCWrapper(cl::sycl::program &p)
+      : SC1(p.set_spec_constant<class sc_name1, int>(4)),
+        SC2(p.set_spec_constant<class sc_name2, int>(2)) {}
+
+  cl::sycl::ONEAPI::experimental::spec_constant<int, class sc_name1> SC1;
+  cl::sycl::ONEAPI::experimental::spec_constant<int, class sc_name2> SC2;
+};
+
+// MyKernel is used to test default constructor
+using AccT = sycl::accessor<int, 1, sycl::access::mode::write>;
+using ScT = sycl::ONEAPI::experimental::spec_constant<int, MyConst>;
+
+struct MyKernel {
+  MyKernel(AccT &Acc) : Acc(Acc) {}
+
+  void setConst(ScT Sc) { this->Sc = Sc; }
+
+  void operator()() const { Acc[0] = Sc.get(); }
+  AccT Acc;
+  ScT Sc;
+};
+
+int main(int argc, char **argv) {
+  global_val = argc + 16;
+
+  cl::sycl::queue q(default_selector{}, [](exception_list l) {
+    for (auto ep : l) {
+      try {
+        std::rethrow_exception(ep);
+      } catch (cl::sycl::exception &e0) {
+        std::cout << e0.what();
+      } catch (std::exception &e1) {
+        std::cout << e1.what();
+      } catch (...) {
+        std::cout << "*** catch (...)\n";
+      }
+    }
+  });
+
+  std::cout << "Running on " << q.get_device().get_info<info::device::name>()
+            << "\n";
+  std::cout << "global_val = " << global_val << "\n";
+  cl::sycl::program program1(q.get_context());
+  cl::sycl::program program2(q.get_context());
+  cl::sycl::program program3(q.get_context());
+  cl::sycl::program program4(q.get_context());
+
+  int goldi = (int)get_value();
+  // TODO make this floating point once supported by the compiler
+  float goldf = (float)get_value();
+
+  cl::sycl::ONEAPI::experimental::spec_constant<int32_t, MyInt32Const> i32 =
+      program1.set_spec_constant<MyInt32Const>(goldi);
+
+  cl::sycl::ONEAPI::experimental::spec_constant<float, MyFloatConst> f32 =
+      program2.set_spec_constant<MyFloatConst>(goldf);
+
+  cl::sycl::ONEAPI::experimental::spec_constant<int, MyConst> sc =
+      program4.set_spec_constant<MyConst>(goldi);
+
+  program1.build_with_kernel_type<KernelAAAi>();
+  // Use an option (does not matter which exactly) to test different internal
+  // SYCL RT execution path
+  program2.build_with_kernel_type<KernelBBBf>("-cl-fast-relaxed-math");
+
+  SCWrapper W(program3);
+  program3.build_with_kernel_type<class KernelWrappedSC>();
+
+  program4.build_with_kernel_type<MyKernel>();
+
+  int goldw = 6;
+
+  std::vector<int> veci(1);
+  std::vector<float> vecf(1);
+  std::vector<int> vecw(1);
+  std::vector<int> vec(1);
+  try {
+    cl::sycl::buffer<int, 1> bufi(veci.data(), veci.size());
+    cl::sycl::buffer<float, 1> buff(vecf.data(), vecf.size());
+    cl::sycl::buffer<int, 1> bufw(vecw.data(), vecw.size());
+    cl::sycl::buffer<int, 1> buf(vec.data(), vec.size());
+
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto acci = bufi.get_access<cl::sycl::access::mode::write>(cgh);
+      cgh.single_task<KernelAAAi>(program1.get_kernel<KernelAAAi>(),
+                                  [=]() { acci[0] = i32.get(); });
+    });
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto accf = buff.get_access<cl::sycl::access::mode::write>(cgh);
+      cgh.single_task<KernelBBBf>(program2.get_kernel<KernelBBBf>(),
+                                  [=]() { accf[0] = foo(f32); });
+    });
+
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto accw = bufw.get_access<cl::sycl::access::mode::write>(cgh);
+      cgh.single_task<KernelWrappedSC>(
+          program3.get_kernel<KernelWrappedSC>(),
+          [=]() { accw[0] = W.SC1.get() + W.SC2.get(); });
+    });
+    // Check spec_constant default construction with subsequent initialization
+    q.submit([&](cl::sycl::handler &cgh) {
+      auto acc = buf.get_access<cl::sycl::access::mode::write>(cgh);
+      // Specialization constants specification says:
+      //   cl::sycl::experimental::spec_constant is default constructible,
+      //   although the object is not considered initialized until the result of
+      //   the call to cl::sycl::program::set_spec_constant is assigned to it.
+      MyKernel Kernel(acc); // default construct inside MyKernel instance
+      Kernel.setConst(sc);  // initialize to sc, returned by set_spec_constant
+
+      cgh.single_task<MyKernel>(program4.get_kernel<MyKernel>(), Kernel);
+    });
+
+  } catch (cl::sycl::exception &e) {
+    std::cout << "*** Exception caught: " << e.what() << "\n";
+    return 1;
+  }
+  bool passed = true;
+  int vali = veci[0];
+
+  if (vali != goldi) {
+    std::cout << "*** ERROR: " << vali << " != " << goldi << "(gold)\n";
+    passed = false;
+  }
+  int valf = vecf[0];
+
+  if (valf != goldf) {
+    std::cout << "*** ERROR: " << valf << " != " << goldf << "(gold)\n";
+    passed = false;
+  }
+  int valw = vecw[0];
+
+  if (valw != goldw) {
+    std::cout << "*** ERROR: " << valw << " != " << goldw << "(gold)\n";
+    passed = false;
+  }
+  int val = vec[0];
+
+  if (val != goldi) {
+    std::cout << "*** ERROR: " << val << " != " << goldi << "(gold)\n";
+    passed = false;
+  }
+  std::cout << (passed ? "passed\n" : "FAILED\n");
+  return passed ? 0 : 1;
+}

--- a/SYCL/KernelAndProgram/spec_consts.hpp
+++ b/SYCL/KernelAndProgram/spec_consts.hpp
@@ -71,9 +71,9 @@ int main(int argc, char **argv) {
   cl::sycl::program program3(q.get_context());
   cl::sycl::program program4(q.get_context());
 
-  int goldi = (int)get_value();
+  const int goldi = get_value();
   // TODO make this floating point once supported by the compiler
-  float goldf = (float)get_value();
+  const float goldf = get_value();
 
   cl::sycl::ONEAPI::experimental::spec_constant<int32_t, MyInt32Const> i32 =
       program1.set_spec_constant<MyInt32Const>(goldi);
@@ -147,10 +147,9 @@ int main(int argc, char **argv) {
     std::cout << "*** ERROR: " << vali << " != " << goldi << "(gold)\n";
     passed = false;
   }
-  int valf = vecf[0];
 
-  if (valf != goldf) {
-    std::cout << "*** ERROR: " << valf << " != " << goldf << "(gold)\n";
+  if (std::fabs(vecf[0] - goldf) > std::numeric_limits<float>::epsilon()) {
+    std::cout << "*** ERROR: " << vecf[0] << " != " << goldf << "(gold)\n";
     passed = false;
   }
   int valw = vecw[0];

--- a/SYCL/Regression/implicit_offset_debug_info.cpp
+++ b/SYCL/Regression/implicit_offset_debug_info.cpp
@@ -2,6 +2,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // REQUIRES: cuda
 
+// The test fail after LLVM pulldown intel/llvm#3573
+// XFAIL: cuda
+
 // NOTE: Tests that the implicit global offset pass copies debug information
 
 #include <CL/sycl.hpp>


### PR DESCRIPTION
 - The on-device tests for persistent cache moved;
 - Marked implicit_offset_debug_info.cpp XFAIl to avoid false alarms in
   CI.