### PR TITLE
[ESIMD] Fix stencil tests timeouts

### DIFF
--- a/SYCL/ESIMD/Stencil.cpp
+++ b/SYCL/ESIMD/Stencil.cpp
@@ -8,8 +8,8 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %HOST_RUN_PLACEHOLDER %t.out 1024
-// RUN: %GPU_RUN_PLACEHOLDER %t.out 1024
+// RUN: %HOST_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"
 
@@ -34,8 +34,7 @@ void InitializeSquareMatrix(float *matrix, size_t const Dim,
   }
 }
 
-bool CheckResults(float *out, float *in, unsigned DIM_SIZE) {
-  unsigned int n = DIM_SIZE;
+bool CheckResults(float *out, float *in, unsigned n) {
   for (unsigned int i = 0; i < n; i++) {
     for (unsigned int j = 0; j < n; j++) {
       if ((5 <= i) && (i < n - 5) && (5 <= j) && (j < n - 5)) {
@@ -73,11 +72,12 @@ bool CheckResults(float *out, float *in, unsigned DIM_SIZE) {
 }
 
 int main(int argc, char *argv[]) {
-  if (argc != 2) {
-    std::cerr << "Usage: stencil.exe <dim_size>" << std::endl;
+  if (argc > 2) {
+    std::cerr << "Usage: stencil.exe [dim_size]" << std::endl;
     exit(1);
   }
-  const unsigned DIM_SIZE = atoi(argv[1]);
+  // Default dimension size is 1024
+  const unsigned DIM_SIZE = (argc == 2) ? atoi(argv[1]) : 1 << 10;
   const unsigned SQUARE_SZ = DIM_SIZE * DIM_SIZE + 16;
   uint range_width =
       (DIM_SIZE - 10) / WIDTH + (((DIM_SIZE - 10) % WIDTH == 0) ? 0 : 1);

--- a/SYCL/ESIMD/Stencil.cpp
+++ b/SYCL/ESIMD/Stencil.cpp
@@ -1,4 +1,4 @@
-//==---------------- stencil.cpp  - DPC++ ESIMD on-device test ------------==//
+//==---------------- Stencil.cpp  - DPC++ ESIMD on-device test ------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,21 +8,14 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %HOST_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %HOST_RUN_PLACEHOLDER %t.out 1024
+// RUN: %GPU_RUN_PLACEHOLDER %t.out 1024
 
 #include "esimd_test_utils.hpp"
 
 #include <CL/sycl.hpp>
 #include <CL/sycl/INTEL/esimd.hpp>
 #include <iostream>
-
-//
-// test smaller input size
-// test 8x16 block size
-//
-#define DIM_SIZE (1 << 13)
-#define SQUARE_SZ (DIM_SIZE * DIM_SIZE + 16)
 
 #define WIDTH 16
 #define HEIGHT 16
@@ -41,7 +34,7 @@ void InitializeSquareMatrix(float *matrix, size_t const Dim,
   }
 }
 
-bool CheckResults(float *out, float *in) {
+bool CheckResults(float *out, float *in, unsigned DIM_SIZE) {
   unsigned int n = DIM_SIZE;
   for (unsigned int i = 0; i < n; i++) {
     for (unsigned int j = 0; j < n; j++) {
@@ -79,7 +72,13 @@ bool CheckResults(float *out, float *in) {
   return true;
 }
 
-int main(void) {
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    std::cerr << "Usage: stencil.exe <dim_size>" << std::endl;
+    exit(1);
+  }
+  const unsigned DIM_SIZE = atoi(argv[1]);
+  const unsigned SQUARE_SZ = DIM_SIZE * DIM_SIZE + 16;
   uint range_width =
       (DIM_SIZE - 10) / WIDTH + (((DIM_SIZE - 10) % WIDTH == 0) ? 0 : 1);
   uint range_height =
@@ -182,7 +181,7 @@ int main(void) {
   }
 
   // check result
-  bool passed = CheckResults(outputMatrix, inputMatrix);
+  bool passed = CheckResults(outputMatrix, inputMatrix, DIM_SIZE);
   if (passed) {
     std::cout << "PASSED" << std::endl;
   } else {

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -8,8 +8,8 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %HOST_RUN_PLACEHOLDER %t.out 1024
-// RUN: %GPU_RUN_PLACEHOLDER %t.out 1024
+// RUN: %HOST_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 #include "esimd_test_utils.hpp"
 
@@ -36,8 +36,7 @@ void InitializeSquareMatrix(float *matrix, size_t const Dim,
   }
 }
 
-bool CheckResults(float *out, float *in, unsigned DIM_SIZE) {
-  unsigned int n = DIM_SIZE;
+bool CheckResults(float *out, float *in, unsigned n) {
   for (unsigned int i = 0; i < n; i++) {
     for (unsigned int j = 0; j < n; j++) {
       if ((5 <= i) && (i < n - 5) && (5 <= j) && (j < n - 5)) {
@@ -75,11 +74,12 @@ bool CheckResults(float *out, float *in, unsigned DIM_SIZE) {
 }
 
 int main(int argc, char *argv[]) {
-  if (argc != 2) {
-    std::cerr << "Usage: stencil.exe <dim_size>" << std::endl;
+  if (argc > 2) {
+    std::cerr << "Usage: stencil.exe [dim_size]" << std::endl;
     exit(1);
   }
-  const unsigned DIM_SIZE = atoi(argv[1]);
+  // Default dimension size is 1024
+  const unsigned DIM_SIZE = (argc == 2) ? atoi(argv[1]) : 1 << 10;
   const unsigned SQUARE_SZ = DIM_SIZE * DIM_SIZE + 16;
   uint range_width =
       (DIM_SIZE - 10) / WIDTH + (((DIM_SIZE - 10) % WIDTH == 0) ? 0 : 1);

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -8,21 +8,14 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %HOST_RUN_PLACEHOLDER %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %HOST_RUN_PLACEHOLDER %t.out 1024
+// RUN: %GPU_RUN_PLACEHOLDER %t.out 1024
 
 #include "esimd_test_utils.hpp"
 
 #include <CL/sycl.hpp>
 #include <CL/sycl/INTEL/esimd.hpp>
 #include <iostream>
-
-//
-// test smaller input size
-// test 8x16 block size
-//
-#define DIM_SIZE (1 << 13)
-#define SQUARE_SZ (DIM_SIZE * DIM_SIZE + 16)
 
 #define WIDTH 16
 #define HEIGHT 16
@@ -43,7 +36,7 @@ void InitializeSquareMatrix(float *matrix, size_t const Dim,
   }
 }
 
-bool CheckResults(float *out, float *in) {
+bool CheckResults(float *out, float *in, unsigned DIM_SIZE) {
   unsigned int n = DIM_SIZE;
   for (unsigned int i = 0; i < n; i++) {
     for (unsigned int j = 0; j < n; j++) {
@@ -81,7 +74,13 @@ bool CheckResults(float *out, float *in) {
   return true;
 }
 
-int main(void) {
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    std::cerr << "Usage: stencil.exe <dim_size>" << std::endl;
+    exit(1);
+  }
+  const unsigned DIM_SIZE = atoi(argv[1]);
+  const unsigned SQUARE_SZ = DIM_SIZE * DIM_SIZE + 16;
   uint range_width =
       (DIM_SIZE - 10) / WIDTH + (((DIM_SIZE - 10) % WIDTH == 0) ? 0 : 1);
   uint range_height =
@@ -184,7 +183,7 @@ int main(void) {
   }
 
   // check result
-  bool passed = CheckResults(outputMatrix, inputMatrix);
+  bool passed = CheckResults(outputMatrix, inputMatrix, DIM_SIZE);
   if (passed) {
     std::cout << "PASSED" << std::endl;
   } else {


### PR DESCRIPTION
I analyzed the history of ESIMD stencil tests in CI and found that
stencil tests are sensitive to the time limit. I.e. they are not
hanging but timing out before finishing the job.
Since #148 Stencil.cpp was failing several times per day.

This patch reduces back the working set for the two tests allowing
them to finish before in required time limit. Also, added a test
parameter to run with a bigger dimension size.