### PR TITLE
Remove 2 Sampler's XFAIL when Windows GPURT uplift to 27.20.100.9466

### DIFF
--- a/SYCL/Sampler/unnormalized-clampedge-linear-float.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear-float.cpp
@@ -3,7 +3,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cuda
-// XFAIL: level_zero && windows
 
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)

--- a/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
@@ -2,7 +2,6 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// XFAIL: level_zero && windows
 
 // On Windows, LevelZero returns wrong value for clampedge
 // out of bounds. Waiting on fix.


### PR DESCRIPTION
The following 2 tests begin to PASS after https://github.com/intel/llvm/pull/3594:
SYCL::Sampler/unnormalized-clampedge-linear-float.cpp
SYCL::Sampler/unnormalized-clampedge-nearest.cpp
Need to remove "XFAIL: level_zero && windows"
