### PR TITLE
[SYCL][CUDA] Removes XFAILs ignored by subsequent REQUIRES

### DIFF
--- a/SYCL/USM/dmem_varied.cpp
+++ b/SYCL/USM/dmem_varied.cpp
@@ -1,4 +1,3 @@
-// XFAIL: cuda
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/SYCL/USM/math.cpp
+++ b/SYCL/USM/math.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 
 // REQUIRES: cpu
-// XFAIL: cuda
-// TODO: ptxas fatal   : Unresolved extern function
-// '_Z20__spirv_ocl_lgamma_rfPi'
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/USM/smem_concurrent.cpp
+++ b/SYCL/USM/smem_concurrent.cpp
@@ -1,4 +1,3 @@
-// XFAIL: cuda
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out

--- a/SYCL/USM/smem_varied.cpp
+++ b/SYCL/USM/smem_varied.cpp
@@ -1,4 +1,3 @@
-// XFAIL: cuda
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t1.out -DTEST_SHARED
 // RUN: %HOST_RUN_PLACEHOLDER %t1.out
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out


### PR DESCRIPTION
Some `XFAIL: cuda` are ignored due to subsequent `REQUIRES:` that do not overlap. This removes the `XFAIL: cuda` from these tests.