### PR TITLE
[SYCL] Remove test case using host accessor in interop_handle::get_na…

### DIFF
--- a/SYCL/HostInteropTask/interop-task.cpp
+++ b/SYCL/HostInteropTask/interop-task.cpp
@@ -221,35 +221,6 @@ void test5() {
   checkBufferValues(Buffer2, static_cast<int>(123));
 }
 
-// The test checks that an exception which is thrown from host_task body
-// is reported as asynchronous.
-void test6() {
-  queue Queue([](sycl::exception_list ExceptionList) {
-    if (ExceptionList.size() != 1) {
-      std::cerr << "Should be one exception in exception list" << std::endl;
-      std::abort();
-    }
-    std::rethrow_exception(*ExceptionList.begin());
-  });
-
-  try {
-    size_t size = 1;
-    buffer<int, 1> Buf{size};
-    Queue.submit([&](sycl::handler &CGH) {
-      auto acc = Buf.get_access<mode::write, target::host_buffer>(CGH);
-      CGH.codeplay_host_task(
-          [=](interop_handle IH) { (void)IH.get_native_mem(acc); });
-    });
-    Queue.wait_and_throw();
-    assert(!"Expected exception was not caught");
-  } catch (sycl::exception &ExpectedException) {
-    assert(std::string(ExpectedException.what())
-                   .find("memory object out of accessor for specified target "
-                         "is not allowed") != std::string::npos &&
-           "Unexpected error was caught!");
-  }
-}
-
 int main() {
   test1();
   test2();
@@ -257,7 +228,6 @@ int main() {
   test3();
   test4();
   test5();
-  test6();
   std::cout << "Test PASSED" << std::endl;
   return 0;
 }


### PR DESCRIPTION
…tive_mem()

This check verifies a situation that is always wrong and causing an exception
at runtime. The patch https://github.com/intel/llvm/pull/3685 removes
the method throwing exception at runtime and lets see the error at compile
time.

The temporarily removed test6() will be returned and improved in consequent
changes: https://github.com/intel/llvm-test-suite/pull/263
Removal of test6() is needed to have a clean CI run for #3685

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>