### PR TITLE
[SYCL][CUDA] Enables reqd_work_group_test for CUDA

### DIFF
--- a/SYCL/Basic/reqd_work_group_size.cpp
+++ b/SYCL/Basic/reqd_work_group_size.cpp
@@ -1,7 +1,3 @@
-// XFAIL: cuda
-// The negative test fails on CUDA.  It's not clear whether the CUDA backend
-// respects the reqd_work_group_size attribute.
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
SYCL/Basic/reqd_work_group_size.cpp will pass for CUDA after https://github.com/intel/llvm/pull/3735 is merged.