### PR TITLE
[SYCL] Adds test for building a simple SYCL program with -g and optimizations

### DIFF
--- a/SYCL/Regression/optimization_level_debug_info.cpp
+++ b/SYCL/Regression/optimization_level_debug_info.cpp
@@ -9,17 +9,17 @@
 // RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -O -o %t.out
 
 // NOTE: Tests that debugging information can be generated for all optimization
-// levels
+// levels.
 
 #include <CL/sycl.hpp>
 
 int main() {
-    sycl::queue q;
+  sycl::queue q;
 
-    q.submit([&](sycl::handler& cgh) {
-        cgh.parallel_for<class kernel_test>(100, [=](sycl::id<1> idx) { });
-    });
-    q.wait();
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for<class kernel_test>(100, [=](sycl::id<1> idx) {});
+  });
+  q.wait();
 
-    return 0;
+  return 0;
 }

--- a/SYCL/Regression/optimization_level_debug_info.cpp
+++ b/SYCL/Regression/optimization_level_debug_info.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -O0 -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -O1 -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -O2 -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -Ofast -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -Os -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -Oz -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -Og -o %t.out
+// RUN: %clangxx %debug_option -fsycl -fsycl-targets=%sycl_triple %s -O -o %t.out
+
+// NOTE: Tests that debugging information can be generated for all optimization
+// levels
+
+#include <CL/sycl.hpp>
+
+int main() {
+    sycl::queue q;
+
+    q.submit([&](sycl::handler& cgh) {
+        cgh.parallel_for<class kernel_test>(100, [=](sycl::id<1> idx) { });
+    });
+    q.wait();
+
+    return 0;
+}


### PR DESCRIPTION
Building a SYCL program with -g and -O0/1 currently fails due to missing debugging information. This is fixed with https://github.com/intel/llvm/pull/3736. Once that is merged, this will act as a regression test.