### PR TITLE
[SYCL] Add test for checking that context is destroyed after expected exception

### DIFF
--- a/SYCL/Regression/context_is_destroyed_after_exception.cpp
+++ b/SYCL/Regression/context_is_destroyed_after_exception.cpp
@@ -9,7 +9,7 @@ int main() {
   const auto GlobalRange = 1;
   const auto LocalRange = 2;
 
-  sycl::queue myQueue{sycl::cpu_selector{}, [](sycl::exception_list elist) {
+  sycl::queue myQueue{sycl::gpu_selector{}, [](sycl::exception_list elist) {
                         for (auto e : elist)
                           std::rethrow_exception(e);
                       }};
@@ -27,4 +27,4 @@ int main() {
   return 0;
 }
 
-// CHECK:---> piContextRelease
+// CHECK:---> piContextRelease(

--- a/SYCL/Regression/context_is_destroyed_after_exception.cpp
+++ b/SYCL/Regression/context_is_destroyed_after_exception.cpp
@@ -1,0 +1,30 @@
+// REQUIRES: gpu
+
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
+
+#include <CL/sycl.hpp>
+
+int main() {
+  const auto GlobalRange = 1;
+  const auto LocalRange = 2;
+
+  sycl::queue myQueue{sycl::cpu_selector{}, [](sycl::exception_list elist) {
+                        for (auto e : elist)
+                          std::rethrow_exception(e);
+                      }};
+
+  try {
+    myQueue.parallel_for<class myclass>(
+        sycl::nd_range<1>{sycl::range<1>(GlobalRange),
+                          sycl::range<1>(LocalRange)},
+        [=](sycl::nd_item<1> idx) {});
+    myQueue.wait_and_throw();
+    assert(false && "Expected exception was not caught");
+  } catch (sycl::exception &e) {
+  }
+
+  return 0;
+}
+
+// CHECK:---> piContextRelease

--- a/SYCL/Regression/context_is_destroyed_after_exception.cpp
+++ b/SYCL/Regression/context_is_destroyed_after_exception.cpp
@@ -15,7 +15,9 @@ int main() {
                       }};
 
   try {
-    myQueue.parallel_for<class myclass>(
+    // Generating an exception caused by the fact that LocalRange size (== 2)
+    // can't be greater than GlobalRange size (== 1)
+    myQueue.parallel_for<class TestKernel>(
         sycl::nd_range<1>{sycl::range<1>(GlobalRange),
                           sycl::range<1>(LocalRange)},
         [=](sycl::nd_item<1> idx) {});


### PR DESCRIPTION
This patch adds new regression test for checking that memory leak in
SYCL context is gone after throwing some expected exception