### PR TITLE
[SYCL] Disable two more failing tests

### DIFF
--- a/SYCL/ESIMD/private_memory/pm_access_2.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_2.cpp
@@ -8,6 +8,6 @@
 
 // REQUIRES: gpu
 // Sporadic failure in GPU RT 21.16.19610
-// UNSUPPORTED: cuda || (level_zero && linux)
+// UNSUPPORTED: cuda || (level_zero && linux) || (opencl && linux)
 // RUN: %clangxx -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 2

--- a/SYCL/ESIMD/private_memory/pm_access_3.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_3.cpp
@@ -8,6 +8,6 @@
 
 // REQUIRES: gpu
 // Sporadic failure in GPU RT 21.16.19610
-// UNSUPPORTED: cuda || (level_zero && linux)
+// UNSUPPORTED: cuda || (level_zero && linux) || (opencl && linux)
 // RUN: %clangxx -fsycl -I%S/.. %S/Inputs/pm_common.cpp -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 3


### PR DESCRIPTION
ESIMD private_memory tests sporadically fail with the following error:
"LLVM ERROR: Cannot find pointer replacement", because of regression in
VC backend.