### PR TITLE
[SYCL] Update allowlist and select_device tests

### DIFF
--- a/SYCL/Config/allowlist.cpp
+++ b/SYCL/Config/allowlist.cpp
@@ -93,10 +93,22 @@ int main() {
     try {
       sycl::platform::get_platforms();
     } catch (sycl::runtime_error &E) {
-      const std::string ExpectedMsg("Unrecognized key in device allowlist");
+      // Workaround to make CI pass.
+      // TODO: after the submission of PR intel/llvm:3826, create PR to
+      // intel/llvm-test-suite with removal of 1st parameter of the vector,
+      // and transformation of std::vector<std::string> to std::string
+      const std::vector<std::string> ExpectedMsgs{
+          "Unrecognized key in device allowlist",
+          "Unrecognized key in SYCL_DEVICE_ALLOWLIST"};
       const std::string GotMessage(E.what());
-      const bool CorrectMeg = GotMessage.find(ExpectedMsg) != std::string::npos;
-      return CorrectMeg ? 0 : 1;
+      const bool CorrectMsg = false;
+      for (const auto &ExpectedMsg : ExpectedMsgs) {
+        if (GotMessage.find(ExpectedMsg) != std::string::npos) {
+          CorrectMsg = true;
+          break;
+        }
+      }
+      return CorrectMsg ? 0 : 1;
     }
   }
 

--- a/SYCL/Config/allowlist.cpp
+++ b/SYCL/Config/allowlist.cpp
@@ -101,7 +101,7 @@ int main() {
           "Unrecognized key in device allowlist",
           "Unrecognized key in SYCL_DEVICE_ALLOWLIST"};
       const std::string GotMessage(E.what());
-      const bool CorrectMsg = false;
+      bool CorrectMsg = false;
       for (const auto &ExpectedMsg : ExpectedMsgs) {
         if (GotMessage.find(ExpectedMsg) != std::string::npos) {
           CorrectMsg = true;

--- a/SYCL/Config/select_device.cpp
+++ b/SYCL/Config/select_device.cpp
@@ -682,12 +682,20 @@ int main() {
           device dev = deviceQueue.get_device();
           const auto &plt = dev.get_platform();
         } catch (sycl::runtime_error &E) {
-          const std::string expectedMsg(
-              "Malformed syntax in SYCL_DEVICE_ALLOWLIST");
+          // Workaround to make CI pass.
+          // TODO: after the submission of PR intel/llvm:3826, create PR to
+          // intel/llvm-test-suite with removal of 1st parameter of the vector,
+          // and transformation of std::vector<std::string> to std::string
+          const std::vector<std::string> expectedMsgs{
+              "Malformed syntax in SYCL_DEVICE_ALLOWLIST",
+              "Key DeviceName of SYCL_DEVICE_ALLOWLIST should have value which "
+              "starts with {{"};
           const std::string gotMessage(E.what());
-          if (gotMessage.find(expectedMsg) != std::string::npos) {
-            passed = true;
-          } else {
+          for (const auto &expectedMsg : expectedMsgs) {
+            if (gotMessage.find(expectedMsg) != std::string::npos) {
+              passed = true;
+              break;
+            }
             passed = false;
           }
         }
@@ -733,12 +741,20 @@ int main() {
           device dev = deviceQueue.get_device();
           const auto &plt = dev.get_platform();
         } catch (sycl::runtime_error &E) {
-          const std::string expectedMsg(
-              "Malformed syntax in SYCL_DEVICE_ALLOWLIST");
+          // Workaround to make CI pass.
+          // TODO: after the submission of PR intel/llvm:3826, create PR to
+          // intel/llvm-test-suite with removal of 1st parameter of the vector,
+          // and transformation of std::vector<std::string> to std::string
+          const std::vector<std::string> expectedMsgs{
+              "Malformed syntax in SYCL_DEVICE_ALLOWLIST",
+              "Key PlatformName of SYCL_DEVICE_ALLOWLIST should have value "
+              "which starts with {{"};
           const std::string gotMessage(E.what());
-          if (gotMessage.find(expectedMsg) != std::string::npos) {
-            passed = true;
-          } else {
+          for (const auto &expectedMsg : expectedMsgs) {
+            if (gotMessage.find(expectedMsg) != std::string::npos) {
+              passed = true;
+              break;
+            }
             passed = false;
           }
         }
@@ -790,12 +806,20 @@ int main() {
           device dev = deviceQueue.get_device();
           const auto &plt = dev.get_platform();
         } catch (sycl::runtime_error &E) {
-          const std::string expectedMsg(
-              "Malformed syntax in SYCL_DEVICE_ALLOWLIST");
+          // Workaround to make CI pass.
+          // TODO: after the submission of PR intel/llvm:3826, create PR to
+          // intel/llvm-test-suite with removal of 1st parameter of the vector,
+          // and transformation of std::vector<std::string> to std::string
+          const std::vector<std::string> expectedMsgs{
+              "Malformed syntax in SYCL_DEVICE_ALLOWLIST",
+              "Key DriverVersion of SYCL_DEVICE_ALLOWLIST should have value "
+              "which starts with {{"};
           const std::string gotMessage(E.what());
-          if (gotMessage.find(expectedMsg) != std::string::npos) {
-            passed = true;
-          } else {
+          for (const auto &expectedMsg : expectedMsgs) {
+            if (gotMessage.find(expectedMsg) != std::string::npos) {
+              passed = true;
+              break;
+            }
             passed = false;
           }
         }
@@ -843,12 +867,20 @@ int main() {
           device dev = deviceQueue.get_device();
           const auto &plt = dev.get_platform();
         } catch (sycl::runtime_error &E) {
-          const std::string expectedMsg(
-              "Malformed syntax in SYCL_DEVICE_ALLOWLIST");
+          // Workaround to make CI pass.
+          // TODO: after the submission of PR intel/llvm:3826, create PR to
+          // intel/llvm-test-suite with removal of 1st parameter of the vector,
+          // and transformation of std::vector<std::string> to std::string
+          const std::vector<std::string> expectedMsgs{
+              "Malformed syntax in SYCL_DEVICE_ALLOWLIST",
+              "Key PlatformVersion of SYCL_DEVICE_ALLOWLIST should have value "
+              "which starts with {{"};
           const std::string gotMessage(E.what());
-          if (gotMessage.find(expectedMsg) != std::string::npos) {
-            passed = true;
-          } else {
+          for (const auto &expectedMsg : expectedMsgs) {
+            if (gotMessage.find(expectedMsg) != std::string::npos) {
+              passed = true;
+              break;
+            }
             passed = false;
           }
         }


### PR DESCRIPTION
This patch adds checking of new exception messages for
SYCL_DEVICE_ALLOWLIST. Old messages weren't removed here for
compatibility reasons, and should be removed in separate PR merged after
PR intel/llvm:3826.