### PR TITLE
[SYCL] Increase range so that this_item check becomes necessary.

### DIFF
--- a/SYCL/Basic/free_function_queries/free_function_queries.cpp
+++ b/SYCL/Basic/free_function_queries/free_function_queries.cpp
@@ -22,7 +22,7 @@
 #include <type_traits>
 
 int main() {
-  constexpr std::size_t n = 10;
+  constexpr std::size_t n = 1030;
 
   int data[n]{};
   int counter{0};


### PR DESCRIPTION
This change increases the range of parallel_for so that rounding would be done, except that it is then disabled owing to the use of this_item.
The original smaller range was making the check for usage of this_item in sycl/handler.hpp redundant, and thus this test was not actually checking range-rounding disabling for this_item in all cases.

Signed-off-by: rdeodhar <rajiv.deodhar@intel.com>