### PR TITLE
re-enable normalized sampler tests

### DIFF
--- a/SYCL/Sampler/normalized-clampedge-linear-float.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear-float.cpp
@@ -7,8 +7,6 @@
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)
 
-
-
 /*
     This file sets up an image, initializes it with data,
     and verifies that the data is sampled correctly with a

--- a/SYCL/Sampler/normalized-clampedge-linear-float.cpp
+++ b/SYCL/Sampler/normalized-clampedge-linear-float.cpp
@@ -3,12 +3,11 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // XFAIL: cuda
-// UNSUPPORTED: level_zero && windows
 
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)
 
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
+
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/normalized-clampedge-nearest.cpp
@@ -2,9 +2,7 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// UNSUPPORTED: level_zero && windows
 
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-mirror-linear-float.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear-float.cpp
@@ -4,12 +4,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 
 // XFAIL: cuda
-// UNSUPPORTED: level_zero && windows
 
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)
 
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-mirror-nearest.cpp
+++ b/SYCL/Sampler/normalized-mirror-nearest.cpp
@@ -3,11 +3,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // XFAIL: cuda
-// UNSUPPORTED: level_zero && windows
 
 // CUDA is not handling repeat or mirror correctly with normalized coordinates.
 // Waiting on a fix.
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-none-linear-float.cpp
+++ b/SYCL/Sampler/normalized-none-linear-float.cpp
@@ -4,12 +4,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 
 // XFAIL: cuda
-// UNSUPPORTED: level_zero && windows
 
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)
 
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -2,9 +2,7 @@
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
-// UNSUPPORTED: level_zero && windows
 
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-repeat-linear-float.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear-float.cpp
@@ -4,12 +4,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 
 // XFAIL: cuda
-// UNSUPPORTED: level_zero && windows
 
 // CUDA works with image_channel_type::fp32, but not with any 8-bit per channel
 // type (such as unorm_int8)
 
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,

--- a/SYCL/Sampler/normalized-repeat-nearest.cpp
+++ b/SYCL/Sampler/normalized-repeat-nearest.cpp
@@ -3,11 +3,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // XFAIL: cuda
-// UNSUPPORTED: level_zero && windows
 
 // CUDA is not handling repeat or mirror correctly with normalized coordinates.
 // Waiting on a fix.
-// LevelZero on Windows hangs with normalized coordinates. Waiting on fix.
 
 /*
     This file sets up an image, initializes it with data,


### PR DESCRIPTION
It seems normalization is now working correctly.  Should re-enable sampler tests to avoid future regressions.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>