### PR TITLE
[SYCL] Prepare FilterSelector tests for migrating to sycl::oneapi

### DIFF
--- a/SYCL/FilterSelector/reuse.cpp
+++ b/SYCL/FilterSelector/reuse.cpp
@@ -15,6 +15,8 @@
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;
+// change to 'using namespace cl::sycl::oneapi' after PR intel/llvm:4014 is
+// merged
 using namespace cl::sycl::ONEAPI;
 
 int main() {
@@ -25,15 +27,17 @@ int main() {
   std::cout << "# Devices found: " << Devs.size() << std::endl;
 
   if (Devs.size() > 1) {
-    filter_selector filter("1");
+    // change all occurrences of filter_selector to 'filter_selector' or
+    // 'oneapi::filter_selector' after PR intel/llvm:4014 is merged
+    ONEAPI::filter_selector filter("1");
 
     device d1(filter);
     device d2(filter);
 
     assert(d1 == d2);
 
-    filter_selector f1("0");
-    filter_selector f2("1");
+    ONEAPI::filter_selector f1("0");
+    ONEAPI::filter_selector f2("1");
     device d3(f1);
     device d4(f2);
 

--- a/SYCL/FilterSelector/reuse.cpp
+++ b/SYCL/FilterSelector/reuse.cpp
@@ -15,8 +15,8 @@
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;
-// change to 'using namespace cl::sycl::oneapi' after PR intel/llvm:4014 is
-// merged
+// TODO: change to 'using namespace cl::sycl::oneapi' after PR intel/llvm:4014
+// is merged
 using namespace cl::sycl::ONEAPI;
 
 int main() {
@@ -27,7 +27,7 @@ int main() {
   std::cout << "# Devices found: " << Devs.size() << std::endl;
 
   if (Devs.size() > 1) {
-    // change all occurrences of filter_selector to 'filter_selector' or
+    // TODO: change all occurrences of filter_selector to 'filter_selector' or
     // 'oneapi::filter_selector' after PR intel/llvm:4014 is merged
     ONEAPI::filter_selector filter("1");
 

--- a/SYCL/FilterSelector/select.cpp
+++ b/SYCL/FilterSelector/select.cpp
@@ -15,6 +15,8 @@
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;
+// change to 'using namespace cl::sycl::oneapi' after PR intel/llvm:4014 is
+// merged
 using namespace cl::sycl::ONEAPI;
 
 int main() {
@@ -67,52 +69,54 @@ int main() {
 
   if (!CPUs.empty()) {
     std::cout << "Test 'cpu'";
-    device d1(filter_selector("cpu"));
+    // change all occurrences of filter_selector to 'filter_selector' or
+    // 'oneapi::filter_selector' after PR intel/llvm:4014 is merged
+    device d1(ONEAPI::filter_selector("cpu"));
     assert(d1.is_cpu());
     std::cout << "...PASS" << std::endl;
   }
 
   if (!GPUs.empty()) {
     std::cout << "Test 'gpu'";
-    device d2(filter_selector("gpu"));
+    device d2(ONEAPI::filter_selector("gpu"));
     assert(d2.is_gpu());
     std::cout << "...PASS" << std::endl;
   }
 
   if (!CPUs.empty() || !GPUs.empty()) {
     std::cout << "Test 'cpu,gpu'";
-    device d3(filter_selector("cpu,gpu"));
+    device d3(ONEAPI::filter_selector("cpu,gpu"));
     assert((d3.is_gpu() || d3.is_cpu()));
     std::cout << "...PASS" << std::endl;
   }
 
   if (HasOpenCLDevices) {
     std::cout << "Test 'opencl'";
-    device d4(filter_selector("opencl"));
+    device d4(ONEAPI::filter_selector("opencl"));
     assert(d4.get_platform().get_backend() == backend::opencl);
     std::cout << "...PASS" << std::endl;
 
     if (!CPUs.empty()) {
       std::cout << "Test 'opencl:cpu'";
-      device d5(filter_selector("opencl:cpu"));
+      device d5(ONEAPI::filter_selector("opencl:cpu"));
       assert(d5.is_cpu() && d5.get_platform().get_backend() == backend::opencl);
       std::cout << "...PASS" << std::endl;
 
       std::cout << "Test 'opencl:cpu:0'";
-      device d6(filter_selector("opencl:cpu:0"));
+      device d6(ONEAPI::filter_selector("opencl:cpu:0"));
       assert(d6.is_cpu() && d6.get_platform().get_backend() == backend::opencl);
       std::cout << "...PASS" << std::endl;
     }
 
     if (HasOpenCLGPU) {
       std::cout << "Test 'opencl:gpu'" << std::endl;
-      device d7(filter_selector("opencl:gpu"));
+      device d7(ONEAPI::filter_selector("opencl:gpu"));
       assert(d7.is_gpu() && d7.get_platform().get_backend() == backend::opencl);
     }
   }
 
   std::cout << "Test '0'";
-  device d8(filter_selector("0"));
+  device d8(ONEAPI::filter_selector("0"));
   std::cout << "...PASS" << std::endl;
 
   std::string ErrorMesg(
@@ -120,7 +124,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d9(filter_selector("gpu:999"));
+    device d9(ONEAPI::filter_selector("gpu:999"));
     std::cout << "d9 = " << d9.get_info<info::device::name>() << std::endl;
   } catch (const sycl::runtime_error &e) {
     assert(ErrorMesg.find_first_of(e.what()) == 0);
@@ -129,7 +133,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d10(filter_selector("bob:gpu"));
+    device d10(ONEAPI::filter_selector("bob:gpu"));
     std::cout << "d10 = " << d10.get_info<info::device::name>() << std::endl;
   } catch (const sycl::runtime_error &e) {
     assert(ErrorMesg.find_first_of(e.what()) == 0);
@@ -138,7 +142,7 @@ int main() {
 
   try {
     // pick something crazy
-    device d11(filter_selector("opencl:bob"));
+    device d11(ONEAPI::filter_selector("opencl:bob"));
     std::cout << "d11 = " << d11.get_info<info::device::name>() << std::endl;
   } catch (const sycl::runtime_error &e) {
     assert(ErrorMesg.find_first_of(e.what()) == 0);
@@ -147,19 +151,19 @@ int main() {
 
   if (HasLevelZeroDevices && HasLevelZeroGPU) {
     std::cout << "Test 'level_zero'";
-    device d12(filter_selector("level_zero"));
+    device d12(ONEAPI::filter_selector("level_zero"));
     assert(d12.get_platform().get_backend() == backend::level_zero);
     std::cout << "...PASS" << std::endl;
 
     std::cout << "Test 'level_zero:gpu'";
-    device d13(filter_selector("level_zero:gpu"));
+    device d13(ONEAPI::filter_selector("level_zero:gpu"));
     assert(d13.is_gpu() &&
            d13.get_platform().get_backend() == backend::level_zero);
     std::cout << "...PASS" << std::endl;
 
     if (HasOpenCLDevices && !CPUs.empty()) {
       std::cout << "Test 'level_zero:gpu,cpu'";
-      device d14(filter_selector("level_zero:gpu,cpu"));
+      device d14(ONEAPI::filter_selector("level_zero:gpu,cpu"));
       assert((d14.is_gpu() || d14.is_cpu()));
       std::cout << "...PASS 1/2" << std::endl;
       if (d14.is_gpu()) {
@@ -171,25 +175,25 @@ int main() {
 
   if (Devs.size() > 1) {
     std::cout << "Test '1'";
-    device d15(filter_selector("1"));
+    device d15(ONEAPI::filter_selector("1"));
     std::cout << "...PASS" << std::endl;
   }
 
   if (HasCUDADevices) {
     std::cout << "Test 'cuda'";
-    device d16(filter_selector("cuda"));
+    device d16(ONEAPI::filter_selector("cuda"));
     assert(d16.get_platform().get_backend() == backend::cuda);
     std::cout << "...PASS" << std::endl;
 
     std::cout << "Test 'cuda:gpu'";
-    device d17(filter_selector("cuda:gpu"));
+    device d17(ONEAPI::filter_selector("cuda:gpu"));
     assert(d17.is_gpu() && d17.get_platform().get_backend() == backend::cuda);
     std::cout << "...PASS" << std::endl;
   }
 
   if (!Accels.empty()) {
     std::cout << "Test 'accelerator'";
-    device d18(filter_selector("accelerator"));
+    device d18(ONEAPI::filter_selector("accelerator"));
     assert(d18.is_accelerator());
     std::cout << "...PASS" << std::endl;
   }

--- a/SYCL/FilterSelector/select.cpp
+++ b/SYCL/FilterSelector/select.cpp
@@ -15,8 +15,8 @@
 #include <CL/sycl.hpp>
 
 using namespace cl::sycl;
-// change to 'using namespace cl::sycl::oneapi' after PR intel/llvm:4014 is
-// merged
+// TODO: change to 'using namespace cl::sycl::oneapi' after PR intel/llvm:4014
+// is merged
 using namespace cl::sycl::ONEAPI;
 
 int main() {
@@ -69,7 +69,7 @@ int main() {
 
   if (!CPUs.empty()) {
     std::cout << "Test 'cpu'";
-    // change all occurrences of filter_selector to 'filter_selector' or
+    // TODO: change all occurrences of filter_selector to 'filter_selector' or
     // 'oneapi::filter_selector' after PR intel/llvm:4014 is merged
     device d1(ONEAPI::filter_selector("cpu"));
     assert(d1.is_cpu());


### PR DESCRIPTION
This patch prepares FilterSelector tests for transitioning from
`sycl::ONEAPI` to `sycl::oneapi` namespace.