### PR TITLE
[SYCL][CUDA] Corrected a missing triple and set an XFAIL: cuda.

### DIFF
--- a/SYCL/DeviceLib/built-ins/nan.cpp
+++ b/SYCL/DeviceLib/built-ins/nan.cpp
@@ -5,6 +5,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: cuda
+
 #include <CL/sycl.hpp>
 
 #include <cassert>

--- a/SYCL/Regression/fp16-with-unnamed-lambda.cpp
+++ b/SYCL/Regression/fp16-with-unnamed-lambda.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-unnamed-lambda %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Now that the fp16 aspect is connected to the cuda PI (https://github.com/intel/llvm/pull/4029/files) one test case (fp16-with-unnamed-lambda.cpp) that now runs for cuda if the device has the fp16 aspect failed because it was missing the triple for ptx.  The triple has been added.
nan.cpp fails for the fp64 case that was switched on by (https://github.com/intel/llvm/pull/3950).

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>