### PR TITLE
[SYCL] Adjust multiple tests to queue::wait() changes

### DIFF
--- a/SYCL/Basic/queue/release.cpp
+++ b/SYCL/Basic/queue/release.cpp
@@ -13,12 +13,12 @@ int main() {
   return 0;
 }
 
-//CHECK: ---> piEnqueueKernelLaunch(
+// CHECK: ---> piEnqueueKernelLaunch(
 // FIXME the order of these 2 varies between plugins due to a Level Zero
 // specific queue workaround.
-//CHECK-DAG: ---> piEventRelease(
-//CHECK-DAG: ---> piQueueRelease(
-//CHECK: ---> piContextRelease(
-//CHECK: ---> piKernelRelease(
-//CHECK: ---> piProgramRelease(
-//CHECK: ---> piDeviceRelease(
+// CHECK-DAG: ---> piEventRelease(
+// CHECK-DAG: ---> piQueueRelease(
+// CHECK: ---> piContextRelease(
+// CHECK: ---> piKernelRelease(
+// CHECK: ---> piProgramRelease(
+// CHECK: ---> piDeviceRelease(

--- a/SYCL/Basic/queue/release.cpp
+++ b/SYCL/Basic/queue/release.cpp
@@ -14,8 +14,10 @@ int main() {
 }
 
 //CHECK: ---> piEnqueueKernelLaunch(
-//CHECK: ---> piEventRelease(
-//CHECK: ---> piQueueRelease(
+// FIXME the order of these 2 varies between plugins due to a Level Zero
+// specific queue workaround.
+//CHECK-DAG: ---> piEventRelease(
+//CHECK-DAG: ---> piQueueRelease(
 //CHECK: ---> piContextRelease(
 //CHECK: ---> piKernelRelease(
 //CHECK: ---> piProgramRelease(

--- a/SYCL/Basic/queue/release.cpp
+++ b/SYCL/Basic/queue/release.cpp
@@ -14,8 +14,8 @@ int main() {
 }
 
 //CHECK: ---> piEnqueueKernelLaunch(
-//CHECK: ---> piQueueRelease(
 //CHECK: ---> piEventRelease(
+//CHECK: ---> piQueueRelease(
 //CHECK: ---> piContextRelease(
 //CHECK: ---> piKernelRelease(
 //CHECK: ---> piProgramRelease(

--- a/SYCL/Basic/subdevice_pi.cpp
+++ b/SYCL/Basic/subdevice_pi.cpp
@@ -61,7 +61,7 @@ static bool check_separate(device dev, buffer<int, 1> buf,
   // CHECK-SEPARATE: ---> piQueueCreate
   // CHECK-SEPARATE: ---> piMemBufferCreate
   // CHECK-SEPARATE: ---> piEnqueueKernelLaunch
-  // CHECK-SEPARATE: ---> piEventsWait
+  // CHECK-SEPARATE: ---> piQueueFinish
 
   log_pi("Test sub device 1");
   {
@@ -78,7 +78,7 @@ static bool check_separate(device dev, buffer<int, 1> buf,
   // CHECK-SEPARATE: ---> piEnqueueMemBufferWrite
   //
   // CHECK-SEPARATE: ---> piEnqueueKernelLaunch
-  // CHECK-SEPARATE: ---> piEventsWait
+  // CHECK-SEPARATE: ---> piQueueFinish
 
   return true;
 }
@@ -113,7 +113,7 @@ static bool check_shared_context(device dev, buffer<int, 1> buf,
   // see --implicit-check-not above.
   //
   // CHECK-SHARED: ---> piEnqueueKernelLaunch
-  // CHECK-SHARED: ---> piEventsWait
+  // CHECK-SHARED: ---> piQueueFinish
 
   log_pi("Test sub device 1");
   {
@@ -123,7 +123,7 @@ static bool check_shared_context(device dev, buffer<int, 1> buf,
   // CHECK-SHARED: Test sub device 1
   // CHECK-SHARED: ---> piQueueCreate
   // CHECK-SHARED: ---> piEnqueueKernelLaunch
-  // CHECK-SHARED: ---> piEventsWait
+  // CHECK-SHARED: ---> piQueueFinish
   // CHECK-SHARED: ---> piEnqueueMemBufferRead
 
   return true;
@@ -162,7 +162,7 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
   // *and* the root device): see --implicit-check-not above.
   //
   // CHECK-FUSED: ---> piEnqueueKernelLaunch
-  // CHECK-FUSED: ---> piEventsWait
+  // CHECK-FUSED: ---> piQueueFinish
 
   log_pi("Test sub device 0");
   {
@@ -172,7 +172,7 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
   // CHECK-FUSED: Test sub device 0
   // CHECK-FUSED: ---> piQueueCreate
   // CHECK-FUSED: ---> piEnqueueKernelLaunch
-  // CHECK-FUSED: ---> piEventsWait
+  // CHECK-FUSED: ---> piQueueFinish
 
   log_pi("Test sub device 1");
   {
@@ -182,7 +182,7 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
   // CHECK-FUSED: Test sub device 1
   // CHECK-FUSED: ---> piQueueCreate
   // CHECK-FUSED: ---> piEnqueueKernelLaunch
-  // CHECK-FUSED: ---> piEventsWait
+  // CHECK-FUSED: ---> piQueueFinish
   // CHECK-FUSED: ---> piEnqueueMemBufferRead
 
   return true;

--- a/SYCL/Plugin/enqueue-arg-order-image.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-image.cpp
@@ -282,6 +282,7 @@ int main() {
 
 // ----------- IMAGES
 
+// clang-format off
 //CHECK: start copyD2H-Image
 //CHECK: -- 1D
 //CHECK: ---> piMemImageCreate(
@@ -322,7 +323,8 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 1 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4340
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/1/1
-// The order of the following calls may vary since some of them are made by a host task (in a separate thread).
+// The order of the following calls may vary since some of them are made by a
+// host task (in a separate thread).
 //CHECK-DAG: ---> piMemImageCreate(
 //CHECK-DAG: image_desc w/h/d : 16 / 1 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4340
 //CHECK-DAG: ---> piEnqueueMemImageRead(
@@ -343,7 +345,8 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 5 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/1
-// The order of the following calls may vary since some of them are made by a host task (in a separate thread).
+// The order of the following calls may vary since some of them are made by a
+// host task (in a separate thread).
 //CHECK-DAG: ---> piMemImageCreate(
 //CHECK-DAG: image_desc w/h/d : 16 / 5 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
 //CHECK-DAG: ---> piEnqueueMemImageRead(
@@ -366,7 +369,8 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 5 / 3  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4338
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/3
-// The order of the following calls may vary since some of them are made by a host task (in a separate thread).
+// The order of the following calls may vary since some of them are made by a
+// host task (in a separate thread).
 //CHECK-DAG: ---> piMemImageCreate(
 //CHECK-DAG: image_desc w/h/d : 16 / 5 / 3  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4338
 //CHECK-DAG: ---> piEnqueueMemImageRead(
@@ -385,3 +389,4 @@ int main() {
 // CHECK-NEXT: <unknown> : 256
 // CHECK-NEXT: <unknown> : 1280
 //CHECK: end copyH2D-image
+// clang-format on

--- a/SYCL/Plugin/enqueue-arg-order-image.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-image.cpp
@@ -190,6 +190,7 @@ void testcopyH2DImage() {
             writeAcc.write(int(Item[0]), Data);
           });
     });
+    otherQueue.wait();
     std::cout << "about to destruct 1D" << std::endl;
   } // ~image 1D
 
@@ -224,6 +225,7 @@ void testcopyH2DImage() {
             writeAcc.write(sycl::int2{Item[0], Item[1]}, Data);
           });
     });
+    otherQueue.wait();
     std::cout << "about to destruct 2D" << std::endl;
   } // ~image 2D
 
@@ -260,6 +262,7 @@ void testcopyH2DImage() {
             writeAcc.write(sycl::int4{Item[0], Item[1], Item[2], 0}, Data);
           });
     });
+    otherQueue.wait();
     std::cout << "about to destruct 3D" << std::endl;
   } // ~image 3D
 
@@ -319,15 +322,16 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 1 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4340
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/1/1
-//CHECK: ---> piMemImageCreate(
-//CHECK: image_desc w/h/d : 16 / 1 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4340
-//CHECK: ---> piEnqueueMemImageRead(
-//CHECK: pi_image_region width/height/depth : 16/1/1
+// The order of the following calls may vary since some of them are made by a host task (in a separate thread).
+//CHECK-DAG: ---> piMemImageCreate(
+//CHECK-DAG: image_desc w/h/d : 16 / 1 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4340
+//CHECK-DAG: ---> piEnqueueMemImageRead(
+//CHECK-DAG: pi_image_region width/height/depth : 16/1/1
+//CHECK-DAG: ---> piEnqueueMemImageWrite(
+//CHECK-DAG: pi_image_region width/height/depth : 16/1/1
+//CHECK-DAG: ---> piEnqueueMemImageWrite(
+//CHECK-DAG: pi_image_region width/height/depth : 16/1/1
 //CHECK: about to destruct 1D
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/1/1
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/1/1
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/1/1
 //CHECK: -- 2D
@@ -339,17 +343,18 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 5 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/1
-//CHECK: ---> piMemImageCreate(
-//CHECK: image_desc w/h/d : 16 / 5 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
-//CHECK: ---> piEnqueueMemImageRead(
-//CHECK: pi_image_region width/height/depth : 16/5/1
+// The order of the following calls may vary since some of them are made by a host task (in a separate thread).
+//CHECK-DAG: ---> piMemImageCreate(
+//CHECK-DAG: image_desc w/h/d : 16 / 5 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
+//CHECK-DAG: ---> piEnqueueMemImageRead(
+//CHECK-DAG: pi_image_region width/height/depth : 16/5/1
+//CHECK-DAG: ---> piEnqueueMemImageWrite(
+//CHECK-DAG: pi_image_region width/height/depth : 16/5/1
+//CHECK-DAG: <unknown> : 256
+//CHECK-DAG: ---> piEnqueueMemImageWrite(
+//CHECK-DAG: pi_image_region width/height/depth : 16/5/1
+//CHECK-DAG: <unknown> : 256
 //CHECK: about to destruct 2D
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/5/1
-// CHECK-NEXT: <unknown> : 256
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/5/1
-// CHECK-NEXT: <unknown> : 256
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/1
 //CHECK: -- 3D
@@ -361,19 +366,20 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 5 / 3  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4338
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/3
-//CHECK: ---> piMemImageCreate(
-//CHECK: image_desc w/h/d : 16 / 5 / 3  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4338
-//CHECK: ---> piEnqueueMemImageRead(
-//CHECK: pi_image_region width/height/depth : 16/5/3
+// The order of the following calls may vary since some of them are made by a host task (in a separate thread).
+//CHECK-DAG: ---> piMemImageCreate(
+//CHECK-DAG: image_desc w/h/d : 16 / 5 / 3  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4338
+//CHECK-DAG: ---> piEnqueueMemImageRead(
+//CHECK-DAG: pi_image_region width/height/depth : 16/5/3
+//CHECK-DAG: ---> piEnqueueMemImageWrite(
+//CHECK-DAG: pi_image_region width/height/depth : 16/5/3
+//CHECK-DAG: <unknown> : 256
+//CHECK-DAG: <unknown> : 1280
+//CHECK-DAG: ---> piEnqueueMemImageWrite(
+//CHECK-DAG: pi_image_region width/height/depth : 16/5/3
+//CHECK-DAG: <unknown> : 256
+//CHECK-DAG: <unknown> : 1280
 //CHECK: about to destruct 3D
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/5/3
-// CHECK-NEXT: <unknown> : 256
-// CHECK-NEXT: <unknown> : 1280
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/5/3
-// CHECK-NEXT: <unknown> : 256
-// CHECK-NEXT: <unknown> : 1280
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/3
 // CHECK-NEXT: <unknown> : 256

--- a/SYCL/Plugin/enqueue-arg-order-image.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-image.cpp
@@ -319,15 +319,15 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 1 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4340
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/1/1
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/1/1
 //CHECK: ---> piMemImageCreate(
 //CHECK: image_desc w/h/d : 16 / 1 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4340
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/1/1
+//CHECK: about to destruct 1D
 //CHECK: ---> piEnqueueMemImageWrite(
 //CHECK: pi_image_region width/height/depth : 16/1/1
-//CHECK: about to destruct 1D
+//CHECK: ---> piEnqueueMemImageWrite(
+//CHECK: pi_image_region width/height/depth : 16/1/1
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/1/1
 //CHECK: -- 2D
@@ -339,17 +339,17 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 5 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/1
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/5/1
-// CHECK-NEXT: <unknown> : 256
 //CHECK: ---> piMemImageCreate(
 //CHECK: image_desc w/h/d : 16 / 5 / 1  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/1
+//CHECK: about to destruct 2D
 //CHECK: ---> piEnqueueMemImageWrite(
 //CHECK: pi_image_region width/height/depth : 16/5/1
 // CHECK-NEXT: <unknown> : 256
-//CHECK: about to destruct 2D
+//CHECK: ---> piEnqueueMemImageWrite(
+//CHECK: pi_image_region width/height/depth : 16/5/1
+// CHECK-NEXT: <unknown> : 256
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/1
 //CHECK: -- 3D
@@ -361,19 +361,19 @@ int main() {
 //CHECK: image_desc w/h/d : 16 / 5 / 3  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4338
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/3
-//CHECK: ---> piEnqueueMemImageWrite(
-//CHECK: pi_image_region width/height/depth : 16/5/3
-// CHECK-NEXT: <unknown> : 256
-// CHECK-NEXT: <unknown> : 1280
 //CHECK: ---> piMemImageCreate(
 //CHECK: image_desc w/h/d : 16 / 5 / 3  --  arrSz/row/slice : 0 / 0 / 0  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4338
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/3
+//CHECK: about to destruct 3D
 //CHECK: ---> piEnqueueMemImageWrite(
 //CHECK: pi_image_region width/height/depth : 16/5/3
 // CHECK-NEXT: <unknown> : 256
 // CHECK-NEXT: <unknown> : 1280
-//CHECK: about to destruct 3D
+//CHECK: ---> piEnqueueMemImageWrite(
+//CHECK: pi_image_region width/height/depth : 16/5/3
+// CHECK-NEXT: <unknown> : 256
+// CHECK-NEXT: <unknown> : 1280
 //CHECK: ---> piEnqueueMemImageRead(
 //CHECK: pi_image_region width/height/depth : 16/5/3
 // CHECK-NEXT: <unknown> : 256

--- a/SYCL/Tracing/pi_tracing_test.cpp
+++ b/SYCL/Tracing/pi_tracing_test.cpp
@@ -46,12 +46,12 @@
 int main() {
   cl::sycl::queue Queue;
   cl::sycl::buffer<int, 1> Buf(10);
-  Queue.submit([&](cl::sycl::handler &cgh) {
+  cl::sycl::event E = Queue.submit([&](cl::sycl::handler &cgh) {
     auto Acc = Buf.template get_access<cl::sycl::access::mode::read_write>(cgh);
 
     cgh.parallel_for<class CheckTraces>(
         10, [=](cl::sycl::id<1> ID) { Acc[ID] = 5; });
   });
-  Queue.wait();
+  E.wait();
   return 0;
 }


### PR DESCRIPTION
Adjust tests to expect a call to piQueueFinish rather than piEventsWait
as part of queue::wait(), as well as release of events for queue USM
operations or non-host commands with no implicit dependencies right after
their submission.

Additionally, blocked commands are no longer always waited for before enqueueing
of their users. This introduces more cases where host tasks are used to "glue"
events from different contexts, which makes it so that the order of some calls in the
enqueue-arg-order-image test may vary from run to run.