### PR TITLE
[SYCL][CUDA] Add triple to build step and remove XFAIL: cuda

### DIFF
--- a/SYCL/Regression/atomic_load.cpp
+++ b/SYCL/Regression/atomic_load.cpp
@@ -1,9 +1,8 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// XFAIL: cuda
 #include <CL/sycl.hpp>
 using namespace cl::sycl;
 

--- a/SYCL/Scheduler/MemObjRemapping.cpp
+++ b/SYCL/Scheduler/MemObjRemapping.cpp
@@ -1,7 +1,6 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
-// XFAIL: cuda
 #include <CL/sycl.hpp>
 #include <cassert>
 #include <cstddef>


### PR DESCRIPTION
SYCL/Regression/atomic_load.cpp and SYCL/Scheduler/MemObjRemapping.cpp should pass for the PI CUDA backend, but are missing the corresponding triple in the build step. These changes add the -fsycl-targets with the triple to these tests and reenable them for CUDA.