### PR TITLE
[SYCL][ESIMD] Removing warning messages from deprecated definitions

### DIFF
--- a/SYCL/ESIMD/BitonicSortK.cpp
+++ b/SYCL/ESIMD/BitonicSortK.cpp
@@ -167,8 +167,8 @@ bitonic_exchange4(simd<uint32_t, BASE_SZ> A, simd<ushort, 32> flip) {
   simd<uint32_t, BASE_SZ> B;
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MA = A.select<32, 1>(i).format<uint32_t, 4, 8>();
-    auto MB = B.select<32, 1>(i).format<uint32_t, 4, 8>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
     MB.select<4, 1, 4, 1>(0, 0) = MA.select<4, 1, 4, 1>(0, 4);
     MB.select<4, 1, 4, 1>(0, 4) = MA.select<4, 1, 4, 1>(0, 0);
     B.select<32, 1>(i).merge(A.select<32, 1>(i),
@@ -196,8 +196,8 @@ bitonic_exchange2(simd<uint32_t, BASE_SZ> A, simd<ushort, 32> flip) {
   simd<uint32_t, BASE_SZ> B;
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MB = B.select<32, 1>(i).format<long long, 4, 4>();
-    auto MA = A.select<32, 1>(i).format<long long, 4, 4>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
     MB.select<4, 1, 2, 2>(0, 0) = MA.select<4, 1, 2, 2>(0, 1);
     MB.select<4, 1, 2, 2>(0, 1) = MA.select<4, 1, 2, 2>(0, 0);
     B.select<32, 1>(i).merge(A.select<32, 1>(i),
@@ -326,8 +326,8 @@ ESIMD_INLINE void bitonic_merge(uint32_t offset, simd<uint32_t, BASE_SZ> &A,
   simd<ushort, 32> flip16(init_mask16);
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MA = A.select<32, 1>(i).format<uint32_t, 4, 8>();
-    auto MB = B.select<32, 1>(i).format<uint32_t, 4, 8>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
     MA.select<4, 1, 4, 1>(0, 0) = MB.select<4, 1, 4, 1>(0, 4);
     MA.select<4, 1, 4, 1>(0, 4) = MB.select<4, 1, 4, 1>(0, 0);
     bool dir_up = (((offset + i) >> (m + 1)) & 1) == 0;
@@ -346,8 +346,8 @@ ESIMD_INLINE void bitonic_merge(uint32_t offset, simd<uint32_t, BASE_SZ> &A,
   simd<ushort, 32> flip18(init_mask18);
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MB = B.select<32, 1>(i).format<long long, 4, 4>();
-    auto MA = A.select<32, 1>(i).format<long long, 4, 4>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
 
     MB.select<4, 1, 2, 2>(0, 0) = MA.select<4, 1, 2, 2>(0, 1);
     MB.select<4, 1, 2, 2>(0, 1) = MA.select<4, 1, 2, 2>(0, 0);

--- a/SYCL/ESIMD/BitonicSortKv2.cpp
+++ b/SYCL/ESIMD/BitonicSortKv2.cpp
@@ -84,8 +84,8 @@ bitonic_exchange4(simd<uint32_t, BASE_SZ> A, simd<ushort, 32> flip) {
   simd<uint32_t, BASE_SZ> B;
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MA = A.select<32, 1>(i).format<uint32_t, 4, 8>();
-    auto MB = B.select<32, 1>(i).format<uint32_t, 4, 8>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
     MB.select<4, 1, 4, 1>(0, 0) = MA.select<4, 1, 4, 1>(0, 4);
     MB.select<4, 1, 4, 1>(0, 4) = MA.select<4, 1, 4, 1>(0, 0);
     B.select<32, 1>(i).merge(A.select<32, 1>(i),
@@ -113,8 +113,8 @@ bitonic_exchange2(simd<uint32_t, BASE_SZ> A, simd<ushort, 32> flip) {
   simd<uint32_t, BASE_SZ> B;
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MB = B.select<32, 1>(i).format<long long, 4, 4>();
-    auto MA = A.select<32, 1>(i).format<long long, 4, 4>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
     MB.select<4, 1, 2, 2>(0, 0) = MA.select<4, 1, 2, 2>(0, 1);
     MB.select<4, 1, 2, 2>(0, 1) = MA.select<4, 1, 2, 2>(0, 0);
     B.select<32, 1>(i).merge(A.select<32, 1>(i),
@@ -243,8 +243,8 @@ ESIMD_INLINE void bitonic_merge(uint32_t offset, simd<uint32_t, BASE_SZ> &A,
   simd<ushort, 32> flip16 = esimd_unpack_mask<32>(0x0f0f0f0f); //(init_mask16);
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MA = A.select<32, 1>(i).format<uint32_t, 4, 8>();
-    auto MB = B.select<32, 1>(i).format<uint32_t, 4, 8>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<uint32_t, 4, 8>();
     MA.select<4, 1, 4, 1>(0, 0) = MB.select<4, 1, 4, 1>(0, 4);
     MA.select<4, 1, 4, 1>(0, 4) = MB.select<4, 1, 4, 1>(0, 0);
     bool dir_up = (((offset + i) >> (m + 1)) & 1) == 0;
@@ -263,8 +263,8 @@ ESIMD_INLINE void bitonic_merge(uint32_t offset, simd<uint32_t, BASE_SZ> &A,
   simd<ushort, 32> flip18 = esimd_unpack_mask<32>(0x33333333); //(init_mask18);
 #pragma unroll
   for (int i = 0; i < BASE_SZ; i += 32) {
-    auto MB = B.select<32, 1>(i).format<long long, 4, 4>();
-    auto MA = A.select<32, 1>(i).format<long long, 4, 4>();
+    auto MB = B.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
+    auto MA = A.select<32, 1>(i).bit_cast_view<long long, 4, 4>();
 
     MB.select<4, 1, 2, 2>(0, 0) = MA.select<4, 1, 2, 2>(0, 1);
     MB.select<4, 1, 2, 2>(0, 1) = MA.select<4, 1, 2, 2>(0, 0);

--- a/SYCL/ESIMD/PrefixSum.cpp
+++ b/SYCL/ESIMD/PrefixSum.cpp
@@ -22,11 +22,11 @@
 #define TUPLE_SZ 1
 
 #if TUPLE_SZ == 1
-#define GATHER_SCATTER_MASK ESIMD_R_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::R
 #elif TUPLE_SZ == 2
-#define GATHER_SCATTER_MASK ESIMD_GR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::GR
 #elif TUPLE_SZ == 4
-#define GATHER_SCATTER_MASK ESIMD_ABGR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::ABGR
 #endif
 
 #define LOG_ENTRIES 8
@@ -148,7 +148,7 @@ void cmk_acum_iterative(unsigned *buf, unsigned h_pos,
     S += T;
   }
 
-  auto cnt_table = S.format<unsigned int, 32, TUPLE_SZ>();
+  auto cnt_table = S.bit_cast_view<unsigned int, 32, TUPLE_SZ>();
   // sum reduction for each bin
   cnt_table.select<16, 1, TUPLE_SZ, 1>(0, 0) +=
       cnt_table.select<16, 1, TUPLE_SZ, 1>(16, 0);
@@ -186,7 +186,7 @@ void cmk_acum_final(unsigned *buf, unsigned h_pos, unsigned int stride_elems,
 
     S = gather4<unsigned int, 32, GATHER_SCATTER_MASK>(buf, element_offset, p);
 
-    auto cnt_table = S.format<unsigned int, TUPLE_SZ, 32>();
+    auto cnt_table = S.bit_cast_view<unsigned int, TUPLE_SZ, 32>();
     cnt_table.column(0) += prev;
 #pragma unroll
     for (unsigned j = 0; j < TUPLE_SZ; j++) {
@@ -254,7 +254,7 @@ void cmk_prefix_iterative(unsigned *buf, unsigned h_pos,
 
     S = gather4<unsigned int, 32, GATHER_SCATTER_MASK>(buf, element_offset);
 
-    auto cnt_table = S.format<unsigned int, TUPLE_SZ, 32>();
+    auto cnt_table = S.bit_cast_view<unsigned int, TUPLE_SZ, 32>();
     cnt_table.column(0) += prev;
 #pragma unroll
     for (unsigned j = 0; j < TUPLE_SZ; j++) {

--- a/SYCL/ESIMD/Prefix_Local_sum1.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum1.cpp
@@ -22,11 +22,11 @@
 #define TUPLE_SZ 1
 
 #if TUPLE_SZ == 1
-#define GATHER_SCATTER_MASK ESIMD_R_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::R
 #elif TUPLE_SZ == 2
-#define GATHER_SCATTER_MASK ESIMD_GR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::GR
 #elif TUPLE_SZ == 4
-#define GATHER_SCATTER_MASK ESIMD_ABGR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::ABGR
 #endif
 
 #define PREFIX_ENTRIES 256
@@ -87,7 +87,7 @@ void cmk_sum_tuple_count(unsigned int *buf, unsigned int h_pos) {
   }
 
   // format S to be a 32xTUPLE_SZ matrix
-  auto cnt_table = S.format<unsigned int, 32, TUPLE_SZ>();
+  auto cnt_table = S.bit_cast_view<unsigned int, 32, TUPLE_SZ>();
   // sum reduction for each bin
   cnt_table.select<16, 1, TUPLE_SZ, 1>(0, 0) +=
       cnt_table.select<16, 1, TUPLE_SZ, 1>(16, 0);

--- a/SYCL/ESIMD/Prefix_Local_sum2.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum2.cpp
@@ -22,11 +22,11 @@
 #define TUPLE_SZ 4
 
 #if TUPLE_SZ == 1
-#define GATHER_SCATTER_MASK ESIMD_R_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::R
 #elif TUPLE_SZ == 2
-#define GATHER_SCATTER_MASK ESIMD_GR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::GR
 #elif TUPLE_SZ == 4
-#define GATHER_SCATTER_MASK ESIMD_ABGR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::ABGR
 #endif
 
 #define PREFIX_ENTRIES 256
@@ -83,7 +83,7 @@ void cmk_acum_iterative(unsigned *buf, unsigned h_pos,
     S += T;
   }
 
-  auto cnt_table = S.format<unsigned int, TUPLE_SZ, 32>();
+  auto cnt_table = S.bit_cast_view<unsigned int, TUPLE_SZ, 32>();
 
   simd<unsigned, TUPLE_SZ> sum;
 #pragma unroll

--- a/SYCL/ESIMD/Prefix_Local_sum3.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum3.cpp
@@ -22,11 +22,11 @@
 #define TUPLE_SZ 2
 
 #if TUPLE_SZ == 1
-#define GATHER_SCATTER_MASK ESIMD_R_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::R
 #elif TUPLE_SZ == 2
-#define GATHER_SCATTER_MASK ESIMD_GR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::GR
 #elif TUPLE_SZ == 4
-#define GATHER_SCATTER_MASK ESIMD_ABGR_ENABLE
+#define GATHER_SCATTER_MASK rgba_channel_mask::ABGR
 #endif
 
 #define LOG_ENTRIES 8
@@ -110,7 +110,7 @@ void cmk_acum_iterative(unsigned *buf, unsigned h_pos,
     S += T;
   }
 
-  auto cnt_table = S.format<unsigned int, 32, TUPLE_SZ>();
+  auto cnt_table = S.bit_cast_view<unsigned int, 32, TUPLE_SZ>();
   // sum reduction for each bin
   cnt_table.select<16, 1, TUPLE_SZ, 1>(0, 0) +=
       cnt_table.select<16, 1, TUPLE_SZ, 1>(16, 0);
@@ -161,7 +161,7 @@ void cmk_acum_iterative_low(unsigned *buf, unsigned h_pos,
     S += T;
   }
 
-  auto cnt_table = S.format<unsigned int, 32, TUPLE_SZ>();
+  auto cnt_table = S.bit_cast_view<unsigned int, 32, TUPLE_SZ>();
   // sum reduction for each bin
   cnt_table.select<16, 1, TUPLE_SZ, 1>(0, 0) +=
       cnt_table.select<16, 1, TUPLE_SZ, 1>(16, 0);
@@ -199,7 +199,7 @@ void cmk_acum_final(unsigned *buf, unsigned h_pos, unsigned int stride_elems,
 
     S = gather4<unsigned int, 32, GATHER_SCATTER_MASK>(buf, element_offset, p);
 
-    auto cnt_table = S.format<unsigned int, TUPLE_SZ, 32>();
+    auto cnt_table = S.bit_cast_view<unsigned int, TUPLE_SZ, 32>();
     cnt_table.column(0) += prev;
     for (unsigned j = 0; j < TUPLE_SZ; j++) {
       // step 1

--- a/SYCL/ESIMD/Stencil.cpp
+++ b/SYCL/ESIMD/Stencil.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
 
             simd<float, (HEIGHT + 10) * 32> vin;
             // matrix HEIGHT+10 x 32
-            auto in = vin.format<float, HEIGHT + 10, 32>();
+            auto in = vin.bit_cast_view<float, HEIGHT + 10, 32>();
 
             //
             // rather than loading all data in

--- a/SYCL/ESIMD/histogram.cpp
+++ b/SYCL/ESIMD/histogram.cpp
@@ -199,7 +199,7 @@ int main(int argc, char *argv[]) {
                 src = histogram.select<8, 1>(i);
 
 #ifdef __SYCL_DEVICE_ONLY__
-                flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, unsigned int, 8>(
+                flat_atomic<atomic_op::add, unsigned int, 8>(
                     bins, offset, src, 1);
                 offset += 8 * sizeof(unsigned int);
 #else

--- a/SYCL/ESIMD/histogram.cpp
+++ b/SYCL/ESIMD/histogram.cpp
@@ -199,8 +199,8 @@ int main(int argc, char *argv[]) {
                 src = histogram.select<8, 1>(i);
 
 #ifdef __SYCL_DEVICE_ONLY__
-                flat_atomic<atomic_op::add, unsigned int, 8>(
-                    bins, offset, src, 1);
+                flat_atomic<atomic_op::add, unsigned int, 8>(bins, offset, src,
+                                                             1);
                 offset += 8 * sizeof(unsigned int);
 #else
                 simd<unsigned int, 8> vals;

--- a/SYCL/ESIMD/histogram_256_slm.cpp
+++ b/SYCL/ESIMD/histogram_256_slm.cpp
@@ -45,14 +45,14 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
     auto start_addr = ((unsigned int *)input_ptr) + start_off;
     simd<uint, 32> data;
     data.copy_from(start_addr);
-    auto in = data.format<uchar>();
+    auto in = data.bit_cast_view<uchar>();
 
 #pragma unroll
     for (int j = 0; j < BLOCK_WIDTH * sizeof(int); j += 16) {
       // Accumulate local histogram for each pixel value
       simd<uint, 16> dataOffset = in.select<16, 1>(j).read();
       dataOffset *= sizeof(int);
-      slm_atomic<EsimdAtomicOpType::ATOMIC_INC, uint, 16>(dataOffset, 1);
+      slm_atomic<atomic_op::inc, uint, 16>(dataOffset, 1);
     }
     start_off += BLOCK_WIDTH;
   }
@@ -61,9 +61,9 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   // Update global sum by atomically adding each local histogram
   simd<uint, 16> local_histogram;
   local_histogram = slm_load<uint32_t, 16>(slm_offset);
-  flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, 8>(
+  flat_atomic<atomic_op::add, uint32_t, 8>(
       output, slm_offset.select<8, 1>(0), local_histogram.select<8, 1>(0), 1);
-  flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, 8>(
+  flat_atomic<atomic_op::add, uint32_t, 8>(
       output, slm_offset.select<8, 1>(8), local_histogram.select<8, 1>(8), 1);
 }
 

--- a/SYCL/ESIMD/histogram_256_slm.cpp
+++ b/SYCL/ESIMD/histogram_256_slm.cpp
@@ -61,10 +61,10 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   // Update global sum by atomically adding each local histogram
   simd<uint, 16> local_histogram;
   local_histogram = slm_load<uint32_t, 16>(slm_offset);
-  flat_atomic<atomic_op::add, uint32_t, 8>(
-      output, slm_offset.select<8, 1>(0), local_histogram.select<8, 1>(0), 1);
-  flat_atomic<atomic_op::add, uint32_t, 8>(
-      output, slm_offset.select<8, 1>(8), local_histogram.select<8, 1>(8), 1);
+  flat_atomic<atomic_op::add, uint32_t, 8>(output, slm_offset.select<8, 1>(0),
+                                           local_histogram.select<8, 1>(0), 1);
+  flat_atomic<atomic_op::add, uint32_t, 8>(output, slm_offset.select<8, 1>(8),
+                                           local_histogram.select<8, 1>(8), 1);
 }
 
 // This function calculates histogram of the image with the CPU.

--- a/SYCL/ESIMD/histogram_256_slm_spec.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec.cpp
@@ -62,10 +62,10 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   // Update global sum by atomically adding each local histogram
   simd<uint, 16> local_histogram;
   local_histogram = slm_load<uint32_t, 16>(slm_offset);
-  flat_atomic<atomic_op::add, uint32_t, 8>(
-      output, slm_offset.select<8, 1>(0), local_histogram.select<8, 1>(0), 1);
-  flat_atomic<atomic_op::add, uint32_t, 8>(
-      output, slm_offset.select<8, 1>(8), local_histogram.select<8, 1>(8), 1);
+  flat_atomic<atomic_op::add, uint32_t, 8>(output, slm_offset.select<8, 1>(0),
+                                           local_histogram.select<8, 1>(0), 1);
+  flat_atomic<atomic_op::add, uint32_t, 8>(output, slm_offset.select<8, 1>(8),
+                                           local_histogram.select<8, 1>(8), 1);
 }
 
 // This function calculates histogram of the image with the CPU.

--- a/SYCL/ESIMD/histogram_256_slm_spec.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec.cpp
@@ -46,14 +46,14 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
     auto start_addr = ((unsigned int *)input_ptr) + start_off;
     simd<uint, 32> data;
     data.copy_from(start_addr);
-    auto in = data.format<uchar>();
+    auto in = data.bit_cast_view<uchar>();
 
 #pragma unroll
     for (int j = 0; j < BLOCK_WIDTH * sizeof(int); j += 16) {
       // Accumulate local histogram for each pixel value
       simd<uint, 16> dataOffset = in.select<16, 1>(j).read();
       dataOffset *= sizeof(int);
-      slm_atomic<EsimdAtomicOpType::ATOMIC_INC, uint, 16>(dataOffset, 1);
+      slm_atomic<atomic_op::inc, uint, 16>(dataOffset, 1);
     }
     start_off += BLOCK_WIDTH;
   }
@@ -62,9 +62,9 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   // Update global sum by atomically adding each local histogram
   simd<uint, 16> local_histogram;
   local_histogram = slm_load<uint32_t, 16>(slm_offset);
-  flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, 8>(
+  flat_atomic<atomic_op::add, uint32_t, 8>(
       output, slm_offset.select<8, 1>(0), local_histogram.select<8, 1>(0), 1);
-  flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, 8>(
+  flat_atomic<atomic_op::add, uint32_t, 8>(
       output, slm_offset.select<8, 1>(8), local_histogram.select<8, 1>(8), 1);
 }
 

--- a/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
@@ -40,14 +40,14 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   for (int y = 0; y < num_blocks; y++) {
     auto start_addr = ((unsigned int *)input_ptr) + start_off;
     auto data = block_load<uint, 32>(start_addr);
-    auto in = data.format<uchar>();
+    auto in = data.bit_cast_view<uchar>();
 
 #pragma unroll
     for (int j = 0; j < BLOCK_WIDTH * sizeof(int); j += 16) {
       // Accumulate local histogram for each pixel value
       simd<uint, 16> dataOffset = in.select<16, 1>(j).read();
       dataOffset *= sizeof(int);
-      slm_atomic<EsimdAtomicOpType::ATOMIC_INC, uint, 16>(dataOffset, 1);
+      slm_atomic<atomic_op::inc, uint, 16>(dataOffset, 1);
     }
     start_off += BLOCK_WIDTH;
   }
@@ -56,9 +56,9 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   // Update global sum by atomically adding each local histogram
   simd<uint, 16> local_histogram;
   local_histogram = slm_load<uint32_t, 16>(slm_offset);
-  flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, 8>(
+  flat_atomic<atomic_op::add, uint32_t, 8>(
       output, slm_offset.select<8, 1>(0), local_histogram.select<8, 1>(0), 1);
-  flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, uint32_t, 8>(
+  flat_atomic<atomic_op::add, uint32_t, 8>(
       output, slm_offset.select<8, 1>(8), local_histogram.select<8, 1>(8), 1);
 }
 

--- a/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
@@ -56,10 +56,10 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   // Update global sum by atomically adding each local histogram
   simd<uint, 16> local_histogram;
   local_histogram = slm_load<uint32_t, 16>(slm_offset);
-  flat_atomic<atomic_op::add, uint32_t, 8>(
-      output, slm_offset.select<8, 1>(0), local_histogram.select<8, 1>(0), 1);
-  flat_atomic<atomic_op::add, uint32_t, 8>(
-      output, slm_offset.select<8, 1>(8), local_histogram.select<8, 1>(8), 1);
+  flat_atomic<atomic_op::add, uint32_t, 8>(output, slm_offset.select<8, 1>(0),
+                                           local_histogram.select<8, 1>(0), 1);
+  flat_atomic<atomic_op::add, uint32_t, 8>(output, slm_offset.select<8, 1>(8),
+                                           local_histogram.select<8, 1>(8), 1);
 }
 
 // This function calculates histogram of the image with the CPU.

--- a/SYCL/ESIMD/histogram_2d.cpp
+++ b/SYCL/ESIMD/histogram_2d.cpp
@@ -191,8 +191,8 @@ int main(int argc, char *argv[]) {
               src = histogram.select<8, 1>(i);
 
 #ifdef __SYCL_DEVICE_ONLY__
-              flat_atomic<atomic_op::add, unsigned int, 8>(
-                  bins, offset, src, 1);
+              flat_atomic<atomic_op::add, unsigned int, 8>(bins, offset, src,
+                                                           1);
               offset += 8 * sizeof(unsigned int);
 #else
               simd<unsigned int, 8> vals;

--- a/SYCL/ESIMD/histogram_2d.cpp
+++ b/SYCL/ESIMD/histogram_2d.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
               src = histogram.select<8, 1>(i);
 
 #ifdef __SYCL_DEVICE_ONLY__
-              flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, unsigned int, 8>(
+              flat_atomic<atomic_op::add, unsigned int, 8>(
                   bins, offset, src, 1);
               offset += 8 * sizeof(unsigned int);
 #else

--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -216,8 +216,8 @@ int main(int argc, char *argv[]) {
 #ifdef __SYCL_DEVICE_ONLY__
               // flat_atomic<atomic_op::add, unsigned int,
               // 8>(bins, offset, src, 1);
-              atomic_write<atomic_op::add, unsigned int, 8>(
-                  bins, offset, src, 1);
+              atomic_write<atomic_op::add, unsigned int, 8>(bins, offset, src,
+                                                            1);
               offset += 8 * sizeof(unsigned int);
 #else
               simd<unsigned int, 8> vals;

--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -214,9 +214,9 @@ int main(int argc, char *argv[]) {
               src = histogram.select<8, 1>(i);
 
 #ifdef __SYCL_DEVICE_ONLY__
-              // flat_atomic<EsimdAtomicOpType::ATOMIC_ADD, unsigned int,
+              // flat_atomic<atomic_op::add, unsigned int,
               // 8>(bins, offset, src, 1);
-              atomic_write<EsimdAtomicOpType::ATOMIC_ADD, unsigned int, 8>(
+              atomic_write<atomic_op::add, unsigned int, 8>(
                   bins, offset, src, 1);
               offset += 8 * sizeof(unsigned int);
 #else

--- a/SYCL/ESIMD/kmeans/kmeans.cpp
+++ b/SYCL/ESIMD/kmeans/kmeans.cpp
@@ -234,10 +234,10 @@ int main(int argc, char *argv[]) {
           Range, [=](nd_item<1> it) SYCL_ESIMD_KERNEL {
             simd<float, 2 * NUM_CENTROIDS_ALLOCATED> centroids(0);
             auto centroidsXYXY =
-                centroids.format<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
+                centroids.bit_cast_view<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
                                  SIMD_SIZE * 2>();
             auto centroidsXY =
-                centroids.format<float, 2 * NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
+                centroids.bit_cast_view<float, 2 * NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
                                  SIMD_SIZE>();
 
 #pragma unroll
@@ -252,13 +252,13 @@ int main(int argc, char *argv[]) {
             simd<int, NUM_CENTROIDS_ALLOCATED> accumnpoints(0);
 
             auto xsum =
-                accumxsum.format<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
+                accumxsum.bit_cast_view<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
                                  SIMD_SIZE>();
             auto ysum =
-                accumysum.format<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
+                accumysum.bit_cast_view<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
                                  SIMD_SIZE>();
             auto npoints =
-                accumnpoints.format<int, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
+                accumnpoints.bit_cast_view<int, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
                                     SIMD_SIZE>();
 
             // each thread handles POINTS_PER_THREAD points
@@ -266,7 +266,7 @@ int main(int argc, char *argv[]) {
 
             for (int i = 0; i < POINTS_PER_THREAD / SIMD_SIZE; i++) {
               simd<float, 2 * SIMD_SIZE> points;
-              auto pointsXY = points.format<float, 2, SIMD_SIZE>();
+              auto pointsXY = points.bit_cast_view<float, 2, SIMD_SIZE>();
               simd<int, SIMD_SIZE> cluster(0);
 
               points.copy_from(kpoints4[index + i].xyn);
@@ -366,7 +366,7 @@ int main(int argc, char *argv[]) {
             int num = reduce<int>(npoints, std::plus<>());
             centroid.select<1, 0>(0) = reduce<float>(xsum, std::plus<>()) / num;
             centroid.select<1, 0>(1) = reduce<float>(ysum, std::plus<>()) / num;
-            (centroid.format<int>()).select<1, 0>(2) = num;
+            (centroid.bit_cast_view<int>()).select<1, 0>(2) = num;
 
             simd<ushort, SIMD_SIZE> mask(0);
             mask.select<3, 1>(0) = 1;

--- a/SYCL/ESIMD/kmeans/kmeans.cpp
+++ b/SYCL/ESIMD/kmeans/kmeans.cpp
@@ -233,12 +233,10 @@ int main(int argc, char *argv[]) {
       cgh.parallel_for<class kMeans>(
           Range, [=](nd_item<1> it) SYCL_ESIMD_KERNEL {
             simd<float, 2 * NUM_CENTROIDS_ALLOCATED> centroids(0);
-            auto centroidsXYXY =
-                centroids.bit_cast_view<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
-                                 SIMD_SIZE * 2>();
-            auto centroidsXY =
-                centroids.bit_cast_view<float, 2 * NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
-                                 SIMD_SIZE>();
+            auto centroidsXYXY = centroids.bit_cast_view<
+                float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE, SIMD_SIZE * 2>();
+            auto centroidsXY = centroids.bit_cast_view<
+                float, 2 * NUM_CENTROIDS_ALLOCATED / SIMD_SIZE, SIMD_SIZE>();
 
 #pragma unroll
             for (int i = 0; i < NUM_CENTROIDS_ALLOCATED / SIMD_SIZE; i++) {
@@ -251,15 +249,12 @@ int main(int argc, char *argv[]) {
             simd<float, NUM_CENTROIDS_ALLOCATED> accumysum(0);
             simd<int, NUM_CENTROIDS_ALLOCATED> accumnpoints(0);
 
-            auto xsum =
-                accumxsum.bit_cast_view<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
-                                 SIMD_SIZE>();
-            auto ysum =
-                accumysum.bit_cast_view<float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
-                                 SIMD_SIZE>();
-            auto npoints =
-                accumnpoints.bit_cast_view<int, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE,
-                                    SIMD_SIZE>();
+            auto xsum = accumxsum.bit_cast_view<
+                float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE, SIMD_SIZE>();
+            auto ysum = accumysum.bit_cast_view<
+                float, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE, SIMD_SIZE>();
+            auto npoints = accumnpoints.bit_cast_view<
+                int, NUM_CENTROIDS_ALLOCATED / SIMD_SIZE, SIMD_SIZE>();
 
             // each thread handles POINTS_PER_THREAD points
             int index = it.get_global_id(0) * POINTS_PER_THREAD / SIMD_SIZE;

--- a/SYCL/ESIMD/linear/linear.cpp
+++ b/SYCL/ESIMD/linear/linear.cpp
@@ -90,13 +90,13 @@ int main(int argc, char *argv[]) {
             using namespace sycl::ext::intel::experimental::esimd;
 
             simd<unsigned char, 8 * 32> vin;
-            auto in = vin.format<unsigned char, 8, 32>();
+            auto in = vin.bit_cast_view<unsigned char, 8, 32>();
 
             simd<unsigned char, 6 * 24> vout;
-            auto out = vout.format<uchar, 6, 24>();
+            auto out = vout.bit_cast_view<uchar, 6, 24>();
 
             simd<float, 6 * 24> vm;
-            auto m = vm.format<float, 6, 24>();
+            auto m = vm.bit_cast_view<float, 6, 24>();
 
             uint h_pos = it.get_id(0);
             uint v_pos = it.get_id(1);

--- a/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
@@ -71,7 +71,7 @@ ESIMD_INLINE void mandelbrot(ACC out_image, int ix, int iy, int crunch,
   // because the output is a y-tile 2D surface
   // we can only write 32-byte wide
   media_block_store<unsigned char, 2, 32>(out_image, ix * sizeof(int), iy,
-                                          color.format<unsigned char>());
+                                          color.bit_cast_view<unsigned char>());
 }
 
 int main(int argc, char *argv[]) {

--- a/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -70,7 +70,7 @@ ESIMD_INLINE void mandelbrot(ACC out_image, int ix, int iy, int crunch,
   // because the output is a y-tile 2D surface
   // we can only write 32-byte wide
   media_block_store<unsigned char, 2, 32>(out_image, ix * sizeof(int), iy,
-                                          color.format<unsigned char>());
+                                          color.bit_cast_view<unsigned char>());
 }
 
 class CrunchConst;

--- a/SYCL/ESIMD/matrix_transpose.cpp
+++ b/SYCL/ESIMD/matrix_transpose.cpp
@@ -73,8 +73,8 @@ ESIMD_INLINE simd<T, 64> transpose_matrix(simd<T, 64> v1) {
   // mask to control how to merge two vectors.
   simd<uint16_t, 16> mask = 0;
   mask.select<8, 2>(0) = 1;
-  auto t1 = v1.template format<T, 4, 16>();
-  auto t2 = v2.template format<T, 4, 16>();
+  auto t1 = v1.template bit_cast_view<T, 4, 16>();
+  auto t2 = v2.template bit_cast_view<T, 4, 16>();
 
   // j = 1
   t2.row(0).merge(t1.template replicate<8, 1, 2, 0>(0, 0),

--- a/SYCL/ESIMD/matrix_transpose_glb.cpp
+++ b/SYCL/ESIMD/matrix_transpose_glb.cpp
@@ -76,8 +76,8 @@ ESIMD_NOINLINE void transpose_matrix(int InR, int OuR) {
   // mask to control how to merge two vectors.
   simd<uint16_t, 16> mask = 0;
   mask.select<8, 2>(0) = 1;
-  auto t1 = GRF.template format<int, 48, 16>().select<4, 1, 16, 1>(InR >> 1, 0);
-  auto t2 = GRF.template format<int, 48, 16>().select<4, 1, 16, 1>(OuR >> 1, 0);
+  auto t1 = GRF.template bit_cast_view<int, 48, 16>().select<4, 1, 16, 1>(InR >> 1, 0);
+  auto t2 = GRF.template bit_cast_view<int, 48, 16>().select<4, 1, 16, 1>(OuR >> 1, 0);
 
   // j = 1
   t2.row(0).merge(t1.template replicate<8, 1, 2, 0>(0, 0),

--- a/SYCL/ESIMD/matrix_transpose_glb.cpp
+++ b/SYCL/ESIMD/matrix_transpose_glb.cpp
@@ -76,8 +76,10 @@ ESIMD_NOINLINE void transpose_matrix(int InR, int OuR) {
   // mask to control how to merge two vectors.
   simd<uint16_t, 16> mask = 0;
   mask.select<8, 2>(0) = 1;
-  auto t1 = GRF.template bit_cast_view<int, 48, 16>().select<4, 1, 16, 1>(InR >> 1, 0);
-  auto t2 = GRF.template bit_cast_view<int, 48, 16>().select<4, 1, 16, 1>(OuR >> 1, 0);
+  auto t1 = GRF.template bit_cast_view<int, 48, 16>().select<4, 1, 16, 1>(
+      InR >> 1, 0);
+  auto t2 = GRF.template bit_cast_view<int, 48, 16>().select<4, 1, 16, 1>(
+      OuR >> 1, 0);
 
   // j = 1
   t2.row(0).merge(t1.template replicate<8, 1, 2, 0>(0, 0),

--- a/SYCL/ESIMD/matrix_transpose_usm.cpp
+++ b/SYCL/ESIMD/matrix_transpose_usm.cpp
@@ -74,8 +74,8 @@ ESIMD_INLINE simd<T, 64> transpose_matrix(simd<T, 64> v1) {
   // mask to control how to merge two vectors.
   simd<uint16_t, 16> mask = 0;
   mask.select<8, 2>(0) = 1;
-  auto t1 = v1.template format<T, 4, 16>();
-  auto t2 = v2.template format<T, 4, 16>();
+  auto t1 = v1.template bit_cast_view<T, 4, 16>();
+  auto t2 = v2.template bit_cast_view<T, 4, 16>();
 
   // j = 1
   t2.row(0).merge(t1.template replicate<8, 1, 2, 0>(0, 0),

--- a/SYCL/ESIMD/slm_barrier.cpp
+++ b/SYCL/ESIMD/slm_barrier.cpp
@@ -62,7 +62,7 @@ void load_to_slm(uint grpSize, uint localId, uint slmOffset, char *addr,
     rowTrans.select<8, 1>(40) = row1.select<8, 4>(2);
     rowTrans.select<8, 1>(56) = row1.select<8, 4>(3);
 
-    slm_store4<uint, 16, ESIMD_ABGR_ENABLE>(rowTrans, vOffsets);
+    slm_store4<uint, 16, rgba_channel_mask::ABGR>(rowTrans, vOffsets);
     threadOffsetInMemory += grpSize * 256;
     vOffsets += (grpSize * 256);
   }

--- a/SYCL/ESIMD/slm_split_barrier.cpp
+++ b/SYCL/ESIMD/slm_split_barrier.cpp
@@ -62,14 +62,14 @@ void load_to_slm(uint grpSize, uint localId, uint slmOffset, char *addr,
     rowTrans.select<8, 1>(40) = row1.select<8, 4>(2);
     rowTrans.select<8, 1>(56) = row1.select<8, 4>(3);
 
-    slm_store4<uint, 16, ESIMD_ABGR_ENABLE>(rowTrans, vOffsets);
+    slm_store4<uint, 16, rgba_channel_mask::ABGR>(rowTrans, vOffsets);
     threadOffsetInMemory += grpSize * 256;
     vOffsets += (grpSize * 256);
   }
 
   esimd_fence(ESIMD_GLOBAL_COHERENT_FENCE);
-  esimd_sbarrier(ESIMD_SBARRIER_SIGNAL);
-  esimd_sbarrier(ESIMD_SBARRIER_WAIT);
+  esimd_sbarrier(split_barrier_action::signal);
+  esimd_sbarrier(split_barrier_action::wait);
 }
 
 int main(void) {

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 
             simd<float, (HEIGHT + 10) * 32> vin;
             // matrix HEIGHT+10 x 32
-            auto in = vin.format<float, HEIGHT + 10, 32>();
+            auto in = vin.bit_cast_view<float, HEIGHT + 10, 32>();
 
             //
             // rather than loading all data in

--- a/SYCL/ESIMD/vadd_2d.cpp
+++ b/SYCL/ESIMD/vadd_2d.cpp
@@ -68,15 +68,15 @@ int main(void) {
             int y = 0;
 
             simd<int, VL> va;
-            auto va_ref = va.format<int, 1, VL>();
+            auto va_ref = va.bit_cast_view<int, 1, VL>();
             va_ref = media_block_load<int, 1, VL>(accA, x, y);
 
             simd<int, VL> vb;
-            auto vb_ref = vb.format<int, 1, VL>();
+            auto vb_ref = vb.bit_cast_view<int, 1, VL>();
             vb_ref = media_block_load<int, 1, VL>(accB, x, y);
 
             simd<int, VL> vc;
-            auto vc_ref = vc.format<int, 1, VL>();
+            auto vc_ref = vc.bit_cast_view<int, 1, VL>();
             vc_ref = va_ref + vb_ref;
             media_block_store<int, 1, VL>(accC, x, y, vc_ref);
           });

--- a/SYCL/ESIMD/vadd_raw_send.cpp
+++ b/SYCL/ESIMD/vadd_raw_send.cpp
@@ -63,7 +63,7 @@ ESIMD_INLINE void block_write2(AccessorTy acc, unsigned int offset,
                                simd<T, N> data) {
   simd<T, 16> src0;
   auto src0_ref1 =
-      src0.template select<8, 1>(0).template format<unsigned int>();
+      src0.template select<8, 1>(0).template bit_cast_view<unsigned int>();
   auto src0_ref2 = src0.template select<8, 1>(8);
 
   src0_ref1.template select<1, 1>(2) = offset >> 4;


### PR DESCRIPTION
- 'format' -> 'bit_cast_view'
- 'ESIMD_*_ENABLE' -> 'rgba_channel_mask::*'
- 'ATOMIC_' -> 'atomic_op::'
- 'ESIMD_BARRIER_' -> 'split_barrier_action::'