### PR TITLE
[SYCL] Switch to legacy header path

### DIFF
--- a/SYCL/SpecConstants/2020/handler-api.cpp
+++ b/SYCL/SpecConstants/2020/handler-api.cpp
@@ -17,7 +17,8 @@
 
 #include <cstdlib>
 #include <iostream>
-#include <sycl/sycl.hpp>
+// TODO: Switch to sycl/sycl.hpp once compiler supports it
+#include <CL/sycl.hpp>
 
 #include "common.hpp"
 

--- a/SYCL/SpecConstants/2020/kernel-bundle-api.cpp
+++ b/SYCL/SpecConstants/2020/kernel-bundle-api.cpp
@@ -17,7 +17,8 @@
 
 #include <cstdlib>
 #include <iostream>
-#include <sycl/sycl.hpp>
+// TODO: Switch to sycl/sycl.hpp once compiler supports it
+#include <CL/sycl.hpp>
 
 #include "common.hpp"
 


### PR DESCRIPTION
Not all compiler versions have sycl/sycl.hpp path. Switching to CL/sycl.hpp
allows to run tests on all existing compiler versions.