### PR TITLE
[SYCL][CUDA] Mark tests as XFAIL after LLORG pulldown

### DIFF
--- a/SYCL/Basic/multisource.cpp
+++ b/SYCL/Basic/multisource.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// XFAIL: cuda
+
 // Separate kernel sources and host code sources
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -c -o %t.kernel.o %s -DINIT_KERNEL -DCALC_KERNEL
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -c -o %t.main.o %s -DMAIN_APP

--- a/SYCL/SeparateCompile/same-kernel.cpp
+++ b/SYCL/SeparateCompile/same-kernel.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// XFAIL: cuda
 //===----------------------------------------------------------------------===//
 // >> ---- compile src1
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -c %s -o %t-same-kernel-a.o

--- a/SYCL/SeparateCompile/sycl-external.cpp
+++ b/SYCL/SeparateCompile/sycl-external.cpp
@@ -1,3 +1,5 @@
+// XFAIL: cuda
+
 // Test1 - check that kernel can call a SYCL_EXTERNAL function defined in a
 // different object file.
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSOURCE1 -c %s -o %t1.o


### PR DESCRIPTION
Tests failure is covered by https://github.com/intel/llvm/issues/4079