### PR TITLE
[SYCL] Add 2nd sycl include path to LIT tests

### DIFF
--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -136,13 +136,13 @@ config.substitutions.append( ('%opencl_include_dir',  config.opencl_include_dir)
 if cl_options:
     config.substitutions.append( ('%sycl_options',  ' sycl.lib /I' +
                                 config.sycl_include + ' /I' + os.path.join(config.sycl_include, 'sycl')) )
-    config.substitutions.append( ('%include_option',  '/FI') )
+    config.substitutions.append( ('%include_option',  '/FI' ) )
     config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
     config.substitutions.append( ('%cxx_std_option',  '/std:' ) )
 else:
     config.substitutions.append( ('%sycl_options', ' -lsycl -I' +
                                 config.sycl_include + ' -I' + os.path.join(config.sycl_include, 'sycl')) )
-    config.substitutions.append( ('%include_option',  '-include') )
+    config.substitutions.append( ('%include_option',  '-include' ) )
     config.substitutions.append( ('%debug_option',  '-g' ) )
     config.substitutions.append( ('%cxx_std_option',  '-std=' ) )
 

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -110,7 +110,7 @@ with open(check_l0_file, 'w') as fp:
     fp.write('int main() { uint32_t t; zeDriverGet(&t,nullptr); return t; }')
 
 config.level_zero_libs_dir=lit_config.params.get("level_zero_libs_dir", config.level_zero_libs_dir)
-config.level_zero_include=lit_config.params.get("level_zero_include", (config.level_zero_include if config.level_zero_include else os.path.join(config.sycl_include, '..')))
+config.level_zero_include=lit_config.params.get("level_zero_include", (config.level_zero_include if config.level_zero_include else config.sycl_include))
 
 level_zero_options=level_zero_options = (' -L'+config.level_zero_libs_dir if config.level_zero_libs_dir else '')+' -lze_loader '+' -I'+config.level_zero_include
 if cl_options:
@@ -134,13 +134,15 @@ if config.opencl_libs_dir:
 config.substitutions.append( ('%opencl_include_dir',  config.opencl_include_dir) )
 
 if cl_options:
-    config.substitutions.append( ('%sycl_options',  ' sycl.lib /I'+config.sycl_include ) )
-    config.substitutions.append( ('%include_option',  '/FI' ) )
+    config.substitutions.append( ('%sycl_options',  ' sycl.lib /I' +
+                                config.sycl_include + ' /I' + os.path.join(config.sycl_include, 'sycl')) )
+    config.substitutions.append( ('%include_option',  '/FI') )
     config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
     config.substitutions.append( ('%cxx_std_option',  '/std:' ) )
 else:
-    config.substitutions.append( ('%sycl_options', ' -lsycl -I'+config.sycl_include ) )
-    config.substitutions.append( ('%include_option',  '-include' ) )
+    config.substitutions.append( ('%sycl_options', ' -lsycl -I' +
+                                config.sycl_include + ' -I' + os.path.join(config.sycl_include, 'sycl')) )
+    config.substitutions.append( ('%include_option',  '-include') )
     config.substitutions.append( ('%debug_option',  '-g' ) )
     config.substitutions.append( ('%cxx_std_option',  '-std=' ) )
 

--- a/SYCL/lit.site.cfg.py.in
+++ b/SYCL/lit.site.cfg.py.in
@@ -11,7 +11,7 @@ config.llvm_tools_dir = os.path.join(config.dpcpp_root_dir, 'bin')
 config.lit_tools_dir = os.path.dirname("@TEST_SUITE_LIT@")
 config.dump_ir_supported = lit_config.params.get("dump_ir", ("@DUMP_IR_SUPPORTED@" if "@DUMP_IR_SUPPORTED@" else False))
 config.sycl_tools_dir = config.llvm_tools_dir
-config.sycl_include = os.path.join(config.dpcpp_root_dir, 'include', 'sycl')
+config.sycl_include = os.path.join(config.dpcpp_root_dir, 'include')
 config.sycl_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
 config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.system() == "Windows" else 'lib'))
 
@@ -19,7 +19,7 @@ config.opencl_libs_dir = (os.path.dirname("@OpenCL_LIBRARY@") if "@OpenCL_LIBRAR
 config.level_zero_libs_dir = "@LEVEL_ZERO_LIBS_DIR@"
 config.level_zero_include = "@LEVEL_ZERO_INCLUDE@"
 
-config.opencl_include_dir = config.sycl_include
+config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
 config.target_devices = lit_config.params.get("target_devices", "@SYCL_TARGET_DEVICES@")
 config.sycl_be = lit_config.params.get("sycl_be", "@SYCL_BE@")
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'


### PR DESCRIPTION
This patch adds 2nd include path <build_dir>/include (in addition to
<build_dir>/include/sycl) to LIT infra  to add a ability to compile
DPC++ code with oneapi and intel extensions which  moved from (e.g.,
for intel) <build_dir>/include/CL/sycl/INTEL to
<build_dir>/include/sycl/ext/intel in intel/llvm:#4014