### PR TITLE
[SYCL] Specify namespace for online_compiler in SYCL LIT tests

### DIFF
--- a/SYCL/OnlineCompiler/online_compiler_common.hpp
+++ b/SYCL/OnlineCompiler/online_compiler_common.hpp
@@ -56,7 +56,8 @@ int main(int argc, char **argv) {
 
   { // Compile and run a trivial OpenCL kernel.
     std::cout << "Test case1\n";
-    online_compiler<source_language::opencl_c> Compiler;
+    sycl::INTEL::online_compiler<sycl::INTEL::source_language::opencl_c>
+        Compiler;
     std::vector<byte> IL;
     try {
       IL = Compiler.compile(
@@ -78,7 +79,8 @@ int main(int argc, char **argv) {
   { // Compile and run a trivial OpenCL kernel using online_compiler()
     // constructor accepting SYCL device.
     std::cout << "Test case2\n";
-    online_compiler<source_language::opencl_c> Compiler(Device);
+    sycl::INTEL::online_compiler<sycl::INTEL::source_language::opencl_c>
+        Compiler(Device);
     std::vector<byte> IL;
     try {
       IL = Compiler.compile(CLSource);
@@ -97,7 +99,7 @@ int main(int argc, char **argv) {
   // PATHs to clangFEWrapper library properly.
   { // Compile a trivial CM kernel.
     std::cout << "Test case3\n";
-    online_compiler<source_language::cm> Compiler;
+    sycl::INTEL::online_compiler<sycl::INTEL::source_language::cm> Compiler;
     try {
       std::vector<byte> IL = Compiler.compile(CMSource);
 
@@ -111,7 +113,8 @@ int main(int argc, char **argv) {
 
   { // Compile a source with syntax errors.
     std::cout << "Test case4\n";
-    online_compiler<source_language::opencl_c> Compiler;
+    sycl::INTEL::online_compiler<sycl::INTEL::source_language::opencl_c>
+        Compiler;
     std::vector<byte> IL;
     bool TestPassed = false;
     try {
@@ -130,7 +133,8 @@ int main(int argc, char **argv) {
 
   { // Compile a good CL source using unrecognized compilation options.
     std::cout << "Test case5\n";
-    online_compiler<source_language::opencl_c> Compiler;
+    sycl::INTEL::online_compiler<sycl::INTEL::source_language::opencl_c>
+        Compiler;
     std::vector<byte> IL;
     bool TestPassed = false;
     try {
@@ -152,7 +156,8 @@ int main(int argc, char **argv) {
 
   { // Try compiling CM source with OpenCL compiler.
     std::cout << "Test case6\n";
-    online_compiler<source_language::opencl_c> Compiler;
+    sycl::INTEL::online_compiler<sycl::INTEL::source_language::opencl_c>
+        Compiler;
     std::vector<byte> IL;
     bool TestPassed = false;
     try {


### PR DESCRIPTION
This patch fixes failure in intel/llvm:#4014 caused by existance of the
online_compiler class in deprecated sycl::INTEL namespace and in modern
one sycl::ext::intel