### PR TITLE
[SYCL] Switch to legacy include path

### DIFF
--- a/SYCL/Regression/2020-spec-constants-debug-info.cpp
+++ b/SYCL/Regression/2020-spec-constants-debug-info.cpp
@@ -6,7 +6,8 @@
 // simple example without crashes/assertions firing at llvm-spirv step due to
 // debug info corrupted by sycl-post-link
 
-#include <sycl/sycl.hpp>
+// TODO: Switch to sycl/sycl.hpp once all compiler versions support it
+#include <CL/sycl.hpp>
 
 constexpr sycl::specialization_id<int> test_id_1{42};
 

--- a/SYCL/SubGroup/sub_groups_sycl2020.cpp
+++ b/SYCL/SubGroup/sub_groups_sycl2020.cpp
@@ -2,7 +2,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-#include <sycl/sycl.hpp>
+// TODO: Switch to sycl/sycl.hpp once all compiler versions support it
+#include <CL/sycl.hpp>
 
 class TestKernel;
 class TestKernelCUDA;


### PR DESCRIPTION
Not all compiler versions have sycl/sycl.hpp path. Switching to CL/sycl.hpp
allows to run tests on all existing compiler versions.