### PR TITLE
[SYCL][CUDA] Unoptimized stream regression test

### DIFF
--- a/SYCL/Regression/unoptimized_stream.cpp
+++ b/SYCL/Regression/unoptimized_stream.cpp
@@ -1,0 +1,15 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O0 -o %t.out
+// RUN: %HOST_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  q.submit([&](sycl::handler &cgh) {
+    sycl::stream os(1024, 256, cgh);
+    cgh.single_task([=]() { os << "test"; });
+  });
+  return 0;
+}


### PR DESCRIPTION
Previously the CUDA backend would fail due to invalid atomic memory orders not being optimized out. The use of these invalid memory orders have been removed in https://github.com/intel/llvm/pull/4106, so this commit adds a regression test to make sure they do not resurface.