### PR TITLE
[SYCL][ROCm] UNSUPPORTED: rocm line to tests

### DIFF
--- a/SYCL/Basic/image/image.cpp
+++ b/SYCL/Basic/image/image.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/image/image_accessor_readsampler.cpp
+++ b/SYCL/Basic/image/image_accessor_readsampler.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA cannot support SYCL 1.2.1 images.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out

--- a/SYCL/Basic/image/image_accessor_readwrite.cpp
+++ b/SYCL/Basic/image/image_accessor_readwrite.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA cannot support SYCL 1.2.1 images.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out

--- a/SYCL/Basic/image/image_accessor_readwrite_half.cpp
+++ b/SYCL/Basic/image/image_accessor_readwrite_half.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA cannot support SYCL 1.2.1 images.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out

--- a/SYCL/Basic/image/image_array.cpp
+++ b/SYCL/Basic/image/image_array.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA cannot support SYCL 1.2.1 images.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out

--- a/SYCL/Basic/image/image_read.cpp
+++ b/SYCL/Basic/image/image_read.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/image/image_read_fp16.cpp
+++ b/SYCL/Basic/image/image_read_fp16.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/image/image_sample.cpp
+++ b/SYCL/Basic/image/image_sample.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/Basic/image/image_write.cpp
+++ b/SYCL/Basic/image/image_write.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // TODO: re-enable on cuda device.
 // See https://github.com/intel/llvm/issues/1542#issuecomment-707877817 for more
 // details.

--- a/SYCL/Basic/image/image_write_fp16.cpp
+++ b/SYCL/Basic/image/image_write_fp16.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
+++ b/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
@@ -6,7 +6,7 @@
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 //
 // -fsycl-device-code-split is not supported for cuda
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/DeviceCodeSplit/aot-gpu.cpp
+++ b/SYCL/DeviceCodeSplit/aot-gpu.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: ocloc, gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA does neither support device code splitting nor SPIR.
 //
 // The test is failing with GPU RT 30.0.100.9667

--- a/SYCL/DeviceCodeSplit/split-per-kernel.cpp
+++ b/SYCL/DeviceCodeSplit/split-per-kernel.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA does not support device code splitting.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_kernel -o %t.out %s

--- a/SYCL/DeviceCodeSplit/split-per-source-main.cpp
+++ b/SYCL/DeviceCodeSplit/split-per-source-main.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA does not support device code splitting.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_source -I %S/Inputs -o %t.out %s %S/Inputs/split-per-source-second-file.cpp

--- a/SYCL/ESIMD/BitonicSortK.cpp
+++ b/SYCL/ESIMD/BitonicSortK.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/BitonicSortKv2.cpp
+++ b/SYCL/ESIMD/BitonicSortKv2.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/PrefixSum.cpp
+++ b/SYCL/ESIMD/PrefixSum.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out 20
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20

--- a/SYCL/ESIMD/Prefix_Local_sum1.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum1.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out 20
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20

--- a/SYCL/ESIMD/Prefix_Local_sum2.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum2.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out 20
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20

--- a/SYCL/ESIMD/Prefix_Local_sum3.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum3.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/Stencil.cpp
+++ b/SYCL/ESIMD/Stencil.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/accessor.cpp
+++ b/SYCL/ESIMD/accessor.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -D_CRT_SECURE_NO_WARNINGS=1 %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/accessor_gather_scatter.cpp
+++ b/SYCL/ESIMD/accessor_gather_scatter.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/accessor_load_store.cpp
+++ b/SYCL/ESIMD/accessor_load_store.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/esimd_bit_ops.cpp
+++ b/SYCL/ESIMD/api/esimd_bit_ops.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_binop_integer_promotion.cpp
+++ b/SYCL/ESIMD/api/simd_binop_integer_promotion.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_memory_access.cpp
+++ b/SYCL/ESIMD/api/simd_memory_access.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_subscript_operator.cpp
+++ b/SYCL/ESIMD/api/simd_subscript_operator.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/ext_math.cpp
+++ b/SYCL/ESIMD/ext_math.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/fp_call_from_func.cpp
+++ b/SYCL/ESIMD/fp_call_from_func.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: TEMPORARY_DISABLED
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // The test hangs after driver update to 21.23.20043
 // REQUIRES: TEMPORARY_DISABLE

--- a/SYCL/ESIMD/fp_call_recursive.cpp
+++ b/SYCL/ESIMD/fp_call_recursive.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: gpu
 // Recursion is not supported in ESIMD (intel/llvm PR#3390)
 // REQUIRES: TEMPORARY_DISBLED
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/fp_in_phi.cpp
+++ b/SYCL/ESIMD/fp_in_phi.cpp
@@ -12,7 +12,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // The test checks that ESIMD kernels correctly handle function pointers as
 // arguments of LLVM's PHI function.

--- a/SYCL/ESIMD/fp_in_select.cpp
+++ b/SYCL/ESIMD/fp_in_select.cpp
@@ -12,7 +12,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // The test fails on JITing due to use of too many registers
 // REQUIRES: TEMPORARY_DISBLED
 //

--- a/SYCL/ESIMD/histogram.cpp
+++ b/SYCL/ESIMD/histogram.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram_256_slm.cpp
+++ b/SYCL/ESIMD/histogram_256_slm.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/histogram_256_slm_spec.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // TODO enable on Windows
 // REQUIRES: linux && gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 16
 

--- a/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
@@ -1,6 +1,6 @@
 // TODO enable on Windows
 // REQUIRES: linux && gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 16
 

--- a/SYCL/ESIMD/histogram_2d.cpp
+++ b/SYCL/ESIMD/histogram_2d.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/kmeans/kmeans.cpp
+++ b/SYCL/ESIMD/kmeans/kmeans.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %S/points.csv
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %S/points.csv

--- a/SYCL/ESIMD/linear/linear.cpp
+++ b/SYCL/ESIMD/linear/linear.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp

--- a/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %T/output.ppm %S/golden_hw.ppm
 

--- a/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // TODO enable on Windows
 // REQUIRES: linux && gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %T/output_spec.ppm %S/golden_hw.ppm 512 -2.09798 -1.19798 0.004 4.0
 

--- a/SYCL/ESIMD/matrix_transpose.cpp
+++ b/SYCL/ESIMD/matrix_transpose.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/matrix_transpose2.cpp
+++ b/SYCL/ESIMD/matrix_transpose2.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/matrix_transpose_glb.cpp
+++ b/SYCL/ESIMD/matrix_transpose_glb.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/matrix_transpose_usm.cpp
+++ b/SYCL/ESIMD/matrix_transpose_usm.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_192.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_192.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_256.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_256.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_512.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_512.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_64.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_64.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_96.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_96.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_192.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_192.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_256.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_256.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_512.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_512.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_64.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_64.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_96.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_96.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/noinline_call_from_func.cpp
+++ b/SYCL/ESIMD/noinline_call_from_func.cpp
@@ -12,7 +12,7 @@
 // REQUIRES: TEMPORARY_DISABLED
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // The test checks that ESIMD kernels support call of noinline function from
 // within other functions.

--- a/SYCL/ESIMD/noinline_call_recursive.cpp
+++ b/SYCL/ESIMD/noinline_call_recursive.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: gpu
 // Recursion is not supported in ESIMD (intel/llvm PR#3390)
 // REQUIRES: TEMPORARY_DISBLED
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/private_memory/pm_access_1.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_1.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // Temporarily disabled due to flaky behavior
 // REQUIRES: TEMPORARY_DISABLED
 // RUN: %clangxx -fsycl -Xs "-stateless-stack-mem-size=131072" -I%S/.. %S/Inputs/pm_common.cpp -o %t.out

--- a/SYCL/ESIMD/private_memory/pm_access_2.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_2.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // Temporarily disabled due to flaky behavior
 // REQUIRES: TEMPORARY_DISABLED
 // RUN: %clangxx -fsycl -Xs "-stateless-stack-mem-size=131072" -I%S/.. %S/Inputs/pm_common.cpp -o %t.out

--- a/SYCL/ESIMD/private_memory/pm_access_3.cpp
+++ b/SYCL/ESIMD/private_memory/pm_access_3.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // Temporarily disabled due to flaky behavior
 // REQUIRES: TEMPORARY_DISABLED
 // RUN: %clangxx -fsycl -Xs "-stateless-stack-mem-size=131072" -I%S/.. %S/Inputs/pm_common.cpp -o %t.out

--- a/SYCL/ESIMD/reduction.cpp
+++ b/SYCL/ESIMD/reduction.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/big_const_initializer.cpp
+++ b/SYCL/ESIMD/regression/big_const_initializer.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/regression/dgetrf.cpp
+++ b/SYCL/ESIMD/regression/dgetrf.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -DUSE_REF %s -I%S/.. -o %t.ref.out
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.ref.out 3 2 1

--- a/SYCL/ESIMD/regression/noinline_bypointers_vadd.cpp
+++ b/SYCL/ESIMD/regression/noinline_bypointers_vadd.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // XFAIL: *

--- a/SYCL/ESIMD/regression/operator_decrement.cpp
+++ b/SYCL/ESIMD/regression/operator_decrement.cpp
@@ -8,7 +8,7 @@
 // This is a test for a bug found simd_view::operator--
 //
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/regression/store_zero_const.cpp
+++ b/SYCL/ESIMD/regression/store_zero_const.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_kernel -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // XFAIL: windows

--- a/SYCL/ESIMD/regression/unused_load.cpp
+++ b/SYCL/ESIMD/regression/unused_load.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/slm_barrier.cpp
+++ b/SYCL/ESIMD/slm_barrier.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/slm_split_barrier.cpp
+++ b/SYCL/ESIMD/slm_split_barrier.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: gpu
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include "esimd_test_utils.hpp"
 

--- a/SYCL/ESIMD/spec_const/spec_const_bool.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_bool.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_char.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_char.cpp
@@ -16,7 +16,7 @@
 // type size.
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_double.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_double.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_float.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_float.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_int.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_int.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_int64.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_int64.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_short.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_short.cpp
@@ -16,7 +16,7 @@
 // type size.
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
@@ -16,7 +16,7 @@
 // type size.
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_uint.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uint.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_uint64.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uint64.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
@@ -18,7 +18,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %clangxx -fsycl -I%S/.. -DSYCL2020 %s -o %t.2020.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.2020.out
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdint>
 

--- a/SYCL/ESIMD/spec_const_redefine_esimd.cpp
+++ b/SYCL/ESIMD/spec_const_redefine_esimd.cpp
@@ -4,7 +4,7 @@
 // program builds at run-time
 // RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT -fsycl %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 //==----------- spec_const_redefine_esimd.cpp ------------------------------==//
 //

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/sycl_esimd_mix.cpp
+++ b/SYCL/ESIMD/sycl_esimd_mix.cpp
@@ -9,7 +9,7 @@
 // in the same program .
 
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER --check-prefixes=CHECK,CHECK-NO-VAR
 // RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER --check-prefixes=CHECK,CHECK-WITH-VAR

--- a/SYCL/ESIMD/test_id_3d.cpp
+++ b/SYCL/ESIMD/test_id_3d.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/vadd_1d.cpp
+++ b/SYCL/ESIMD/vadd_1d.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: env SYCL_PI_TRACE=-1 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 

--- a/SYCL/ESIMD/vadd_2d.cpp
+++ b/SYCL/ESIMD/vadd_2d.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/vadd_2d_acc.cpp
+++ b/SYCL/ESIMD/vadd_2d_acc.cpp
@@ -9,7 +9,7 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // The test checks that 2D workitem addressing works correctly with SIMD
 // kernels.

--- a/SYCL/ESIMD/vadd_raw_send.cpp
+++ b/SYCL/ESIMD/vadd_raw_send.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/vadd_usm.cpp
+++ b/SYCL/ESIMD/vadd_usm.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
+++ b/SYCL/FunctionPointers/fp-as-kernel-arg.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA does not support the function pointer as kernel argument extension.
 
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out

--- a/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
+++ b/SYCL/FunctionPointers/pass-fp-through-buffer.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // CUDA does not support the function pointer as kernel argument extension.
 
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl %s -o %t.out

--- a/SYCL/Plugin/enqueue-arg-order-image.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-image.cpp
@@ -1,5 +1,5 @@
 // Temporarily disabled due to CUDA context related failures.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // Native images are created with host pointers only with host unified memory
 // support, enforce it for this test.

--- a/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
@@ -20,4 +20,4 @@
 // is present.
 // The test crashed on CUDA CI machines with the latest OpenCL GPU RT
 // (21.19.19792).
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm

--- a/SYCL/Plugin/sycl-ls.cpp
+++ b/SYCL/Plugin/sycl-ls.cpp
@@ -11,4 +11,4 @@
 //===----------------------------------------------------------------------===//
 // The test crashed on CUDA CI machines with the latest OpenCL GPU RT
 // (21.19.19792).
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm

--- a/SYCL/Sampler/basic-rw-float.cpp
+++ b/SYCL/Sampler/basic-rw-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/basic-rw.cpp
+++ b/SYCL/Sampler/basic-rw.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-clamp-linear-float.cpp
+++ b/SYCL/Sampler/normalized-clamp-linear-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/normalized-clamp-nearest.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-mirror-linear-float.cpp
+++ b/SYCL/Sampler/normalized-mirror-linear-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-mirror-nearest.cpp
+++ b/SYCL/Sampler/normalized-mirror-nearest.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-none-linear-float.cpp
+++ b/SYCL/Sampler/normalized-none-linear-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-none-nearest.cpp
+++ b/SYCL/Sampler/normalized-none-nearest.cpp
@@ -4,7 +4,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 
-
 /*
     This file sets up an image, initializes it with data,
     and verifies that the data is sampled correctly with a

--- a/SYCL/Sampler/normalized-repeat-linear-float.cpp
+++ b/SYCL/Sampler/normalized-repeat-linear-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/normalized-repeat-nearest.cpp
+++ b/SYCL/Sampler/normalized-repeat-nearest.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/unnormalized-clamp-linear-float.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-linear-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/unnormalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-nearest.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/unnormalized-clampedge-linear-float.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-linear-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/unnormalized-none-linear-float.cpp
+++ b/SYCL/Sampler/unnormalized-none-linear-float.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER

--- a/SYCL/Sampler/unnormalized-none-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-none-nearest.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: rocm
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Scheduler/HostAccDestruction.cpp
+++ b/SYCL/Scheduler/HostAccDestruction.cpp
@@ -2,7 +2,7 @@
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //==---------------------- HostAccDestruction.cpp --------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/SpecConstants/1.2.1/composite-in-functor.cpp
+++ b/SYCL/SpecConstants/1.2.1/composite-in-functor.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER

--- a/SYCL/SpecConstants/1.2.1/composite-type.cpp
+++ b/SYCL/SpecConstants/1.2.1/composite-type.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/SpecConstants/1.2.1/multiple-usages-of-composite.cpp
+++ b/SYCL/SpecConstants/1.2.1/multiple-usages-of-composite.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // RUN: %clangxx -fsycl %s -o %t.out -v
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER

--- a/SYCL/SpecConstants/1.2.1/spec_const_hw.cpp
+++ b/SYCL/SpecConstants/1.2.1/spec_const_hw.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/SpecConstants/1.2.1/spec_const_neg.cpp
+++ b/SYCL/SpecConstants/1.2.1/spec_const_neg.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // Specialization constants are not supported on FPGA h/w and emulator.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 //==----------- spec_const_hw.cpp ------------------------------------------==//
 //

--- a/SYCL/SpecConstants/1.2.1/spec_const_redefine.cpp
+++ b/SYCL/SpecConstants/1.2.1/spec_const_redefine.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // FIXME Disable fallback assert so that it doesn't interferes with number of
 // program builds at run-time

--- a/SYCL/SpecConstants/1.2.1/specialization_constants.cpp
+++ b/SYCL/SpecConstants/1.2.1/specialization_constants.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // Specialization constants are not supported on FPGA h/w and emulator.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 //==----------- specialization_constants.cpp -------------------------------==//
 //

--- a/SYCL/SpecConstants/1.2.1/specialization_constants_negative.cpp
+++ b/SYCL/SpecConstants/1.2.1/specialization_constants_negative.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // Specialization constants are not supported on FPGA h/w and emulator.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 //==----------- specialization_constants_negative.cpp ----------------------==//
 //

--- a/SYCL/SpecConstants/1.2.1/specialization_constants_override.cpp
+++ b/SYCL/SpecConstants/1.2.1/specialization_constants_override.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // Specialization constants are not supported on FPGA h/w and emulator.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 //==----------- specialization_constants_override.cpp ----------------------==//
 //

--- a/SYCL/SpecConstants/1.2.1/unpacked-composite-type.cpp
+++ b/SYCL/SpecConstants/1.2.1/unpacked-composite-type.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 //
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out %HOST_CHECK_PLACEHOLDER

--- a/SYCL/SpecConstants/2020/handler-api.cpp
+++ b/SYCL/SpecConstants/2020/handler-api.cpp
@@ -13,7 +13,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // FIXME: ACC devices use emulation path, which is not yet supported
 // FIXME: CUDA uses emulation path, which is not yet supported
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdlib>
 #include <iostream>

--- a/SYCL/SpecConstants/2020/kernel-bundle-api.cpp
+++ b/SYCL/SpecConstants/2020/kernel-bundle-api.cpp
@@ -13,7 +13,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // FIXME: ACC devices use emulation path, which is not yet supported
 // FIXME: CUDA uses emulation path, which is not yet supported
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 #include <cstdlib>
 #include <iostream>

--- a/SYCL/SubGroup/info.cpp
+++ b/SYCL/SubGroup/info.cpp
@@ -1,5 +1,5 @@
 // See https://github.com/intel/llvm/issues/2922 for more info
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/SubGroup/reduce_spirv13.cpp
+++ b/SYCL/SubGroup/reduce_spirv13.cpp
@@ -2,7 +2,7 @@
 // #2252 Disable until all variants of built-ins are available in OpenCL CPU
 // runtime for every supported ISA
 
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/SubGroup/reduce_spirv13_fp16.cpp
+++ b/SYCL/SubGroup/reduce_spirv13_fp16.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/SubGroup/reduce_spirv13_fp64.cpp
+++ b/SYCL/SubGroup/reduce_spirv13_fp64.cpp
@@ -2,7 +2,7 @@
 // #2252 Disable until all variants of built-ins are available in OpenCL CPU
 // runtime for every supported ISA
 
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/SubGroup/scan_spirv13.cpp
+++ b/SYCL/SubGroup/scan_spirv13.cpp
@@ -2,7 +2,7 @@
 // #2252 Disable until all variants of built-ins are available in OpenCL CPU
 // runtime for every supported ISA
 
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/SubGroup/scan_spirv13_fp16.cpp
+++ b/SYCL/SubGroup/scan_spirv13_fp16.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/SubGroup/scan_spirv13_fp64.cpp
+++ b/SYCL/SubGroup/scan_spirv13_fp64.cpp
@@ -2,7 +2,7 @@
 // #2252 Disable until all variants of built-ins are available in OpenCL CPU
 // runtime for every supported ISA
 
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || rocm
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Adding UNSUPPORTED: rocm line to tests.
Most changes are to test groups:
1. ESIMD
2. SpecConstants
3. Sampler
4. Basic/image

Results for ROCm backend on AMD GPU:
Testing Time: 51.39s
  Unsupported: 232
  Passed: 171
  Expectedly Failed:   2
  Failed: 129
  Unexpectedly Passed:   1
