### PR TITLE
[SYCL][ROCm] Add XFAIL rocm to dep_events.cpp

### DIFF
--- a/SYCL/USM/dep_events.cpp
+++ b/SYCL/USM/dep_events.cpp
@@ -13,7 +13,7 @@
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
 //
 // XFAIL: cuda || rocm
-// TODO enable the test when cuda_piextUSMEnqueuePrefetch rocm_piextUSMEnqueuePrefetch starts handling flags
+// TODO enable the test when cuda_piextUSMEnqueuePrefetch and rocm_piextUSMEnqueuePrefetch starts handling flags
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/USM/dep_events.cpp
+++ b/SYCL/USM/dep_events.cpp
@@ -12,8 +12,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
 //
-// XFAIL: cuda
-// TODO enable the test when cuda_piextUSMEnqueuePrefetch starts handling flags
+// XFAIL: cuda || rocm
+// TODO enable the test when cuda_piextUSMEnqueuePrefetch rocm_piextUSMEnqueuePrefetch starts handling flags
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/USM/dep_events.cpp
+++ b/SYCL/USM/dep_events.cpp
@@ -13,7 +13,8 @@
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
 //
 // XFAIL: cuda || rocm
-// TODO enable the test when cuda_piextUSMEnqueuePrefetch and rocm_piextUSMEnqueuePrefetch starts handling flags
+// TODO enable the test when cuda_piextUSMEnqueuePrefetch and
+// rocm_piextUSMEnqueuePrefetch starts handling flags
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
 rocm_piextUSMEnqueuePrefetch like cuda_piextUSMEnqueuePrefetch do not currently take flags, so fails with an assert.

Flag feature is waiting on details of Prefetch in USM extension.
Relevant comment from pi_rocm.cpp
```
// TODO implement handling the flags once the expected behaviour
// of piextUSMEnqueuePrefetch is detailed in the USM extension
  assert(flags == 0u);
```
USM/prefetch.cpp is currently passing for rocm so is not being set to expected fail.