### PR TITLE
[SYCL] Add a test for group sorting algorithm

### DIFF
--- a/SYCL/GroupAlgorithm/SYCL2020/sort.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/sort.cpp
@@ -163,7 +163,7 @@ int test_joint_sort(sycl::queue &q, std::size_t n_items, std::size_t local,
          [=](sycl::nd_item<1> id) {
            auto group_id = id.get_group(0);
            auto ptr_keys = &aI1[group_id * n_items];
-          //  auto ptr_keys = aI1.get_pointer() + group_id * n_items;
+           //  auto ptr_keys = aI1.get_pointer() + group_id * n_items;
 
            scratch[0] = std::uint8_t{};
            switch (test_case) {

--- a/SYCL/GroupAlgorithm/SYCL2020/sort.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/sort.cpp
@@ -3,17 +3,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missinsg __spirv_GroupIAdd, __spirv_GroupSMin and __spirv_GroupSMax on AMD:
-// XFAIL: rocm_amd
-
-// TODO: enable compile+runtime checks for operations defined in SPIR-V 1.3.
-// That requires either adding a switch to clang (-spirv-max-version=1.3) or
-// raising the spirv version from 1.1. to 1.3 for spirv translator
-// unconditionally. Using operators specific for spirv 1.3 and higher with
-// -spirv-max-version=1.1 being set by default causes assert/check fails
-// in spirv translator.
-// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple -DSPIRV_1_3 %s -I . -o \
-   %t13.out
+// RUNx: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -I . -o %t13.out
 
 #include "support.h"
 #include <CL/sycl.hpp>
@@ -173,7 +163,7 @@ int test_joint_sort(sycl::queue &q, std::size_t n_items, std::size_t local,
          [=](sycl::nd_item<1> id) {
            auto group_id = id.get_group(0);
            auto ptr_keys = &aI1[group_id * n_items];
-           // auto ptr = aI.get_pointer() + group_id * n_items;
+          //  auto ptr_keys = aI1.get_pointer() + group_id * n_items;
 
            scratch[0] = std::uint8_t{};
            switch (test_case) {

--- a/SYCL/GroupAlgorithm/SYCL2020/sort.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/sort.cpp
@@ -100,13 +100,13 @@ int test_sort_over_group(sycl::queue &q, std::size_t local,
               << std::endl;
   q.submit([&](sycl::handler &h) {
      auto aI1 = sycl::accessor(bufI1, h);
-     sycl::accessor<std::uint8_t, 1, sycl::access_mode::read_write,
+     sycl::accessor<std::byte, 1, sycl::access_mode::read_write,
                     sycl::access::target::local>
          scratch({local_memory_size}, h);
 
      h.parallel_for<sort_over_group_kernel_name<T, Compare>>(
          sycl::nd_range<1>(local_range, local_range), [=](sycl::nd_item<1> id) {
-           scratch[0] = std::uint8_t{};
+           scratch[0] = std::byte{};
            auto local_id = id.get_local_id();
            switch (test_case) {
            case 0:
@@ -154,7 +154,7 @@ int test_joint_sort(sycl::queue &q, std::size_t n_items, std::size_t local,
               << std::endl;
   q.submit([&](sycl::handler &h) {
      auto aI1 = sycl::accessor(bufI1, h);
-     sycl::accessor<std::uint8_t, 1, sycl::access_mode::read_write,
+     sycl::accessor<std::byte, 1, sycl::access_mode::read_write,
                     sycl::access::target::local>
          scratch({local_memory_size}, h);
 
@@ -163,9 +163,10 @@ int test_joint_sort(sycl::queue &q, std::size_t n_items, std::size_t local,
          [=](sycl::nd_item<1> id) {
            auto group_id = id.get_group(0);
            auto ptr_keys = &aI1[group_id * n_items];
+           //  Replacing the line above with the line below also works
            //  auto ptr_keys = aI1.get_pointer() + group_id * n_items;
 
-           scratch[0] = std::uint8_t{};
+           scratch[0] = std::byte{};
            switch (test_case) {
            case 0:
              if constexpr (std::is_same_v<Compare, std::less<T>> &&


### PR DESCRIPTION
Implementation of sorting algorithm is here: https://github.com/intel/llvm/pull/4439

Cases that were added:
Data types: 
*	uint32_t
*	double
*	sycl::half
*	uint16_t
*	size_t
*	int8_t
*	int32_t
*	float
*	custom type
Functors:
*	less
*	greater
*	custom
Sorters:
*	default
*	custom
Sorting function:
*	joint
*	over_group
Interfaces
*	sorter
*	compare
*	w/o compare or sorter
Data size:
*	1 group
*	multiple groups
Generic group:
*	work-group

Cases that were not added:
* sub-group

Signed-off-by: Fedorov, Andrey <andrey.fedorov@intel.com>