### PR TITLE
[SYCL][HIP] Remove XFAIL from passing tests

### DIFF
--- a/SYCL/Basic/scalar_vec_access.cpp
+++ b/SYCL/Basic/scalar_vec_access.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
-//
-// Missing built-ins on AMD
-// XFAIL: hip_amd
 
 //==------- scalar_vec_access.cpp - SYCL scalar access to vec test ---------==//
 //

--- a/SYCL/DeviceLib/built-ins/scalar_geometric.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_geometric.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Missing built-ins on AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/DeviceLib/built-ins/scalar_math_2.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_math_2.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Missing llvm.isnan.f32 on AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/DeviceLib/built-ins/scalar_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_relational.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Missing llvm.isnan.f32 on AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/DeviceLib/built-ins/vector_math.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_math.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Missing llvm.isnan.f32 on AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/DeviceLib/built-ins/vector_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_relational.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Missing llvm.isnan.f32 on AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
These are now passing on the latest dpc++ on gfx906 and gfx908.

I'm unsure exactly why these failed or what fixed it, it could have to
do with https://github.com/intel/llvm/commit/34dbb6f8e215c17890024cf234f74e8a41f6d50a, but either way they're
passing now so it should be fine to remove the XFAIL.