### PR TITLE
Revert "[SYCL][L0] Re-enable test for dynamic batching"

### DIFF
--- a/SYCL/Plugin/level_zero_dynamic_batch_test.cpp
+++ b/SYCL/Plugin/level_zero_dynamic_batch_test.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: gpu, level_zero
+// REQUIRES: gpu, level_zero, TEMPORARILY_DISABLED
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 


### PR DESCRIPTION
Reverts intel/llvm-test-suite#471 due to sporadic failure
Fail log: http://icl-jenkins.sc.intel.com:8080/blue/organizations/jenkins/LLVM-Test-Suite-CI-TMP%2FLLVM-Test-Suite-CI-WIN/detail/LLVM-Test-Suite-CI-WIN/796/pipeline