### PR TITLE
[SYCL][HIP] Marked failing tests as xfail or unsupported on hip_nvidia.

### DIFF
--- a/SYCL/Basic/device_event.cpp
+++ b/SYCL/Basic/device_event.cpp
@@ -5,8 +5,9 @@
 // TODO: nd_item::barrier() is not implemented on HOST
 // RUNx: %HOST_RUN_PLACEHOLDER %t.run
 //
-// Crashes on AMD
-// XFAIL: hip_amd
+// Crashes on AMD, returns error "Barrier is not supported on the host device
+// yet." with Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 //==--------device_event.cpp - SYCL class device_event test ----------------==//
 //

--- a/SYCL/Basic/host-task-dependency.cpp
+++ b/SYCL/Basic/host-task-dependency.cpp
@@ -5,7 +5,7 @@
 //
 // TODO: Behaviour is unstable for level zero on Windows. Enable when fixed.
 // TODO: The test is sporadically fails on CUDA. Enable when fixed.
-// UNSUPPORTED: (windows && level_zero) || cuda
+// UNSUPPORTED: (windows && level_zero) || cuda || hip_nvidia
 
 #define SYCL2020_DISABLE_DEPRECATION_WARNINGS
 

--- a/SYCL/Basic/kernel_info.cpp
+++ b/SYCL/Basic/kernel_info.cpp
@@ -6,8 +6,8 @@
 // Fail is flaky for level_zero, enable when fixed.
 // UNSUPPORTED: level_zero
 //
-// Failing on HIP AMD
-// XFAIL: hip_amd
+// Failing on HIP AMD and HIP Nvidia
+// XFAIL: hip_amd || hip_nvidia
 
 //==--- kernel_info.cpp - SYCL kernel info test ----------------------------==//
 //

--- a/SYCL/DeprecatedFeatures/parallel_for_range.cpp
+++ b/SYCL/DeprecatedFeatures/parallel_for_range.cpp
@@ -2,8 +2,8 @@
 // UNSUPPORTED: windows
 // Level0 testing times out on Windows.
 //
-// Failing on HIP AMD
-// UNSUPPORTED: hip_amd
+// Failing on HIP AMD and HIP NVIDIA
+// UNSUPPORTED: hip_amd || hip_nvidia
 
 // RUN: %clangxx -D__SYCL_INTERNAL_API -fsycl -fno-sycl-id-queries-fit-in-int -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeprecatedFeatures/program_link.cpp
+++ b/SYCL/DeprecatedFeatures/program_link.cpp
@@ -7,8 +7,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER SYCL_PI_TRACE=-1 SYCL_PROGRAM_COMPILE_OPTIONS="-cl-opt-disable" %t.out %GPU_CHECK_PLACEHOLDER --check-prefix=CHECK-IS-OPT-DISABLE
 // RUN: %ACC_RUN_PLACEHOLDER SYCL_PI_TRACE=-1 SYCL_PROGRAM_COMPILE_OPTIONS="-cl-opt-disable" %t.out %ACCPU_CHECK_PLACEHOLDER --check-prefix=CHECK-IS-OPT-DISABLE
 //
-// Hits an assertion on AMD with multiple GPUs available
-// XFAIL: hip_amd
+// Hits an assertion on AMD with multiple GPUs available, fails trace on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 #include <CL/sycl.hpp>
 #include <iostream>

--- a/SYCL/ESIMD/api/simd_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_negation_operator.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
+++ b/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_view_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_view_negation_operator.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/slm_gather_scatter.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/regression/replicate_bug.cpp
+++ b/SYCL/ESIMD/regression/replicate_bug.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/usm_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/usm_gather_scatter_rgba.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_opcode.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
+++ b/SYCL/InlineAsm/Negative/asm_bad_operand_syntax.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_duplicate_label.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
+++ b/SYCL/InlineAsm/Negative/asm_illegal_exec_size.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_missing_label.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_label.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_missing_region.cpp
+++ b/SYCL/InlineAsm/Negative/asm_missing_region.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_simple.cpp
+++ b/SYCL/InlineAsm/Negative/asm_simple.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_decl.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
+++ b/SYCL/InlineAsm/Negative/asm_undefined_pred.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
+++ b/SYCL/InlineAsm/Negative/asm_wrong_declare.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_16_empty.cpp
+++ b/SYCL/InlineAsm/asm_16_empty.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_16_matrix_mult.cpp
+++ b/SYCL/InlineAsm/asm_16_matrix_mult.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_16_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_16_no_input_int.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_16_no_opts.cpp
+++ b/SYCL/InlineAsm/asm_16_no_opts.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_8_empty.cpp
+++ b/SYCL/InlineAsm/asm_8_empty.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_8_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_8_no_input_int.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
+++ b/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_decl_in_scope.cpp
+++ b/SYCL/InlineAsm/asm_decl_in_scope.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_float_add.cpp
+++ b/SYCL/InlineAsm/asm_float_add.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_float_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_float_imm_arg.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_float_neg.cpp
+++ b/SYCL/InlineAsm/asm_float_neg.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_if.cpp
+++ b/SYCL/InlineAsm/asm_if.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_imm_arg.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_loop.cpp
+++ b/SYCL/InlineAsm/asm_loop.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_mul.cpp
+++ b/SYCL/InlineAsm/asm_mul.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_no_output.cpp
+++ b/SYCL/InlineAsm/asm_no_output.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_plus_mod.cpp
+++ b/SYCL/InlineAsm/asm_plus_mod.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/InlineAsm/asm_switch.cpp
+++ b/SYCL/InlineAsm/asm_switch.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // REQUIRES: gpu,linux
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Plugin/enqueue-arg-order-buffer.cpp
+++ b/SYCL/Plugin/enqueue-arg-order-buffer.cpp
@@ -1,5 +1,5 @@
 // Temporarily disabled due to CUDA context related failures.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda || hip_nvidia
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER

--- a/SYCL/Reduction/reduction_big_data.cpp
+++ b/SYCL/Reduction/reduction_big_data.cpp
@@ -3,8 +3,9 @@
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupFMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupFMax on AMD, error message `Group algorithms are not
+// supported on host device` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out
 // TODO: Enable the test for HOST when it supports ext::oneapi::reduce() and

--- a/SYCL/Reduction/reduction_nd_conditional.cpp
+++ b/SYCL/Reduction/reduction_nd_conditional.cpp
@@ -4,8 +4,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd on AMD, error message `The implementation handling
+// parallel_for with reduction requires work group size not bigger than 1` on
+// Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reduction and conditional increment of the reduction variable.

--- a/SYCL/Reduction/reduction_nd_ext_double.cpp
+++ b/SYCL/Reduction/reduction_nd_ext_double.cpp
@@ -3,8 +3,10 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupFAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupFAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD, error
+// message `The implementation handling parallel_for with reduction requires
+// work group size not bigger than 1` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: Enable the test for HOST when it supports intel::reduce() and barrier()
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/Reduction/reduction_nd_ext_half.cpp
+++ b/SYCL/Reduction/reduction_nd_ext_half.cpp
@@ -3,8 +3,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupFAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupFAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD, error
+// message `The implementation handling parallel_for with reduction requires
+// work group size not bigger than 1` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: Enable the test for HOST when it supports intel::reduce() and barrier()
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/Reduction/reduction_nd_lambda.cpp
+++ b/SYCL/Reduction/reduction_nd_lambda.cpp
@@ -4,8 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Inconsistently fails on HIP AMD
-// UNSUPPORTED: hip_amd
+// Inconsistently fails on HIP AMD, error message `Barrier is not supported on
+// the host device yet.` on HIP Nvidia.
+// UNSUPPORTED: hip_amd || hip_nvidia
 
 // This test performs basic checks of parallel_for(nd_range, reduction, lambda)
 

--- a/SYCL/Reduction/reduction_nd_s0_dw.cpp
+++ b/SYCL/Reduction/reduction_nd_s0_dw.cpp
@@ -3,8 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD, error
+// message `Group algorithms are not supported on host device.` on HIP Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_nd_s0_rw.cpp
+++ b/SYCL/Reduction/reduction_nd_s0_rw.cpp
@@ -3,8 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD, error
+// message `Group algorithms are not supported on host device.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_nd_s1_dw.cpp
+++ b/SYCL/Reduction/reduction_nd_s1_dw.cpp
@@ -4,8 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD, error
+// message `Group algorithms are not supported on host device.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_nd_s1_rw.cpp
+++ b/SYCL/Reduction/reduction_nd_s1_rw.cpp
@@ -3,8 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd, __spirv_GroupSMin, __spirv_GroupSMax on AMD, error
+// message `Group algorithms are not supported on host device.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_placeholder.cpp
+++ b/SYCL/Reduction/reduction_placeholder.cpp
@@ -3,8 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd, __spirv_GroupFMin on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd, __spirv_GroupFMin on AMD, error message `Group
+// algorithms are not supported on host device.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out
 // TODO: Enable the test for HOST when it supports ext::oneapi::reduce() and

--- a/SYCL/Reduction/reduction_queue_parallel_for.cpp
+++ b/SYCL/Reduction/reduction_queue_parallel_for.cpp
@@ -3,8 +3,9 @@
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd on AMD, error message `Group algorithms are not
+// supported on host device.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_range_usm_dw.cpp
+++ b/SYCL/Reduction/reduction_range_usm_dw.cpp
@@ -3,8 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupFAdd on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupFAdd on AMD, error message `Group algorithms are not
+// supported on host device.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_usm.cpp
+++ b/SYCL/Reduction/reduction_usm.cpp
@@ -3,8 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_GroupIAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD, error
+// message `Group algorithms are not supported on host device.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_usm_dw.cpp
+++ b/SYCL/Reduction/reduction_usm_dw.cpp
@@ -6,8 +6,9 @@
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero
 //
-// Missing __spirv_GroupIAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD
-// XFAIL: hip_amd
+// Missing __spirv_GroupIAdd, __spirv_GroupFMin, __spirv_GroupFMax on AMD, error
+// message `Group algorithms are not supported on host device` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with USM var. It tests only SYCL-2020 reduction

--- a/SYCL/SubGroup/sub_group_as.cpp
+++ b/SYCL/SubGroup/sub_group_as.cpp
@@ -8,7 +8,8 @@
 // __spirv_SubgroupInvocationId, __spirv_GenericCastToPtrExplicit_ToGlobal,
 // __spirv_SubgroupBlockReadINTEL, __assert_fail,
 // __spirv_SubgroupBlockWriteINTEL on AMD
-// XFAIL: hip_amd
+// error message `Barrier is not supported on the host device yet.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 #include <CL/sycl.hpp>
 #include <cassert>

--- a/SYCL/SubGroup/sub_group_as_vec.cpp
+++ b/SYCL/SubGroup/sub_group_as_vec.cpp
@@ -8,7 +8,8 @@
 // __spirv_SubgroupLocalInvocationId, __spirv_GenericCastToPtrExplicit_ToGlobal,
 // __spirv_SubgroupBlockReadINTEL, __assert_fail,
 // __spirv_SubgroupBlockWriteINTEL on AMD
-// XFAIL: hip_amd
+// error message `Barrier is not supported on the host device yet.` on Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 #include "helper.hpp"
 #include <CL/sycl.hpp>

--- a/SYCL/SubGroup/sub_groups_sycl2020.cpp
+++ b/SYCL/SubGroup/sub_groups_sycl2020.cpp
@@ -3,7 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Missing __spirv_SubgroupLocalInvocationId on AMD
-// XFAIL: hip_amd
+// Assertion `!MHostPlatform && "Plugin is not available for Host."' failed on
+// Nvidia.
+// XFAIL: hip_amd || hip_nvidia
 
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
Tests that already failed for cuda/hip_amd and also fail on hip_nvidia have been marked as UNSUPPORTED or XFAIL.

### XFAILS on both hip_amd and hip_nvidia:

  Basic/device_event.cpp
  Basic/kernel_info.cpp
  Reduction/reduction_big_data.cpp
  Reduction/reduction_nd_conditional.cpp
  Reduction/reduction_nd_ext_double.cpp
  Reduction/reduction_nd_ext_half.cpp
  Reduction/reduction_nd_lambda.cpp
  Reduction/reduction_nd_s0_dw.cpp
  Reduction/reduction_nd_s0_rw.cpp
  Reduction/reduction_nd_s1_dw.cpp
  Reduction/reduction_nd_s1_rw.cpp
  Reduction/reduction_placeholder.cpp
  Reduction/reduction_queue_parallel_for.cpp
  Reduction/reduction_usm.cpp
  Reduction/reduction_usm_dw.cpp
  SubGroup/sub_group_as.cpp
  SubGroup/sub_group_as_vec.cpp
  SubGroup/sub_groups_sycl2020.cpp 

  ### UNSUPPORTED hip_amd and hip_nvidia:
  
  DeprecatedFeatures/parallel_for_range.cpp

### UNSUPPORTED cuda and hip_nvidia:
  
  Basic/host-task-dependency.cpp
  ESIMD/api/simd_negation_operator.cpp
  ESIMD/api/simd_view_copy_move_assign.cpp
  ESIMD/api/simd_view_negation_operator.cpp
  ESIMD/api/slm_gather_scatter.cpp
  ESIMD/api/slm_gather_scatter_rgba.cpp
  ESIMD/regression/replicate_bug.cpp
  ESIMD/usm_gather_scatter_rgba.cpp
  InlineAsm/Negative/asm_bad_opcode.cpp
  InlineAsm/Negative/asm_bad_operand_syntax.cpp
  InlineAsm/Negative/asm_duplicate_label.cpp
  InlineAsm/Negative/asm_illegal_exec_size.cpp
  InlineAsm/Negative/asm_missing_label.cpp
  InlineAsm/Negative/asm_missing_region.cpp
  InlineAsm/Negative/asm_simple.cpp
  InlineAsm/Negative/asm_undefined_decl.cpp
  InlineAsm/Negative/asm_undefined_pred.cpp
  InlineAsm/Negative/asm_wrong_declare.cpp
  InlineAsm/asm_16_empty.cpp
  InlineAsm/asm_16_matrix_mult.cpp
  InlineAsm/asm_16_no_input_int.cpp
  InlineAsm/asm_16_no_opts.cpp
  InlineAsm/asm_8_empty.cpp
  InlineAsm/asm_8_no_input_int.cpp
  InlineAsm/asm_arbitrary_ops_order.cpp
  InlineAsm/asm_decl_in_scope.cpp
  InlineAsm/asm_float_add.cpp
  InlineAsm/asm_float_imm_arg.cpp
  InlineAsm/asm_float_neg.cpp
  InlineAsm/asm_if.cpp
  InlineAsm/asm_imm_arg.cpp
  InlineAsm/asm_loop.cpp
  InlineAsm/asm_mul.cpp
  InlineAsm/asm_no_output.cpp
  InlineAsm/asm_plus_mod.cpp
  InlineAsm/asm_switch.cpp
  Plugin/enqueue-arg-order-buffer.cpp

### Notes for future work:

Sometimes it appears that tests are failing on hip_nvidia for different reasons that the test is failing on hip_amd.
Error messages etc for hip_nvidia are noted in the test header in such cases.

There are cases that are failing on hip_nvidia that did not fail on hip_amd or cuda and require further investigation:

  Basic/diagnostics/handler.cpp
  Basic/memory-consumption.cpp
  Basic/partition_supported.cpp
  Basic/queue/queue.cpp
  Basic/queue/release.cpp
  Basic/stream/auto_flush.cpp
  DeprecatedFeatures/kernel_info.cpp
  DeprecatedFeatures/queue_old_interop.cpp
  InorderQueue/in_order_property_trace.cpp
  Plugin/sycl-ls-gpu-hip.cpp
  Reduction/reduction_reducer_op_eq.cpp
  Regression/context_is_destroyed_after_exception.cpp
  Scheduler/InOrderQueueDeps.cpp
  Scheduler/MemObjRemapping.cpp
  Scheduler/MultipleDevices.cpp
  Scheduler/ReleaseResourcesTest.cpp
  SubGroup/sub_group_as.cpp
  SubGroup/sub_group_as_vec.cpp
  Tracing/buffer_printers.cpp
  Tracing/pi_tracing_test.cpp

Eight tests are unexpectedly passing on hip_nvidia.

### Unexpectedly Passed Tests (8):
  SYCL :: Basic/aspects.cpp
  SYCL :: Basic/buffer/buffer_full_copy.cpp
  SYCL :: Basic/span.cpp
  SYCL :: DeprecatedFeatures/get-options.cpp
  SYCL :: DeprecatedFeatures/kernel-and-program.cpp
  SYCL :: Regression/same_unnamed_kernels.cpp
  SYCL :: Sampler/normalized-clampedge-linear-float.cpp
  SYCL :: Scheduler/CommandCleanupThreadSafety.cpp

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>