### PR TITLE
[SYCL][ESIMD] More updates to print performance data in uniform way

### DIFF
--- a/SYCL/ESIMD/BitonicSortK.cpp
+++ b/SYCL/ESIMD/BitonicSortK.cpp
@@ -592,74 +592,94 @@ int BitonicSort::Solve(uint32_t *pInputs, uint32_t *pOutputs, uint32_t size) {
   // Number of workitems in a workgroup
   cl::sycl::range<1> SortLocalRange{1};
 
-  double total_time = 0;
-  try {
-    buffer<uint32_t, 1> bufi(pInputs, range<1>(size));
-    buffer<uint32_t, 1> bufo(pOutputs, range<1>(size));
-    // enqueue sort265 kernel
-    auto e = pQueue_->submit([&](handler &cgh) {
-      auto acci = bufi.get_access<access::mode::read>(cgh);
-      auto acco = bufo.get_access<access::mode::write>(cgh);
-      cgh.parallel_for<class Sort256>(
-          SortGlobalRange * SortLocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
-            using namespace sycl::ext::intel::experimental::esimd;
-            cmk_bitonic_sort_256(acci, acco, i);
-          });
-    });
-    e.wait();
-    total_time += esimd_test::report_time("kernel time", e, e);
-  } catch (cl::sycl::exception const &e) {
-    std::cout << "SYCL exception caught: " << e.what() << '\n';
-    return e.get_cl_code();
-  }
+  // Start Timer
+  esimd_test::Timer timer;
+  double start;
 
-  // Each HW thread swap two 256-element chunks. Hence, we only need
-  // to launch size/ (base_sort_size*2) HW threads
-  total_threads = size / (base_sort_size_ * 2);
-  // create ranges
-  // We need that many workitems
-  auto MergeGlobalRange = cl::sycl::range<1>(total_threads);
-  // Number of workitems in a workgroup
-  cl::sycl::range<1> MergeLocalRange{1};
+  // Launches the task on the GPU.
+  double kernel_times = 0;
+  unsigned num_iters = 10;
 
-  // enqueue merge kernel multiple times
-  // this loop is for stage 8 to stage LOG2_ELEMENTS.
-  event mergeEvent[(LOG2_ELEMENTS - 8) * (LOG2_ELEMENTS - 7) / 2];
-  int k = 0;
-  try {
-    for (int i = 8; i < LOG2_ELEMENTS; i++) {
-      // each step halves the stride distance of its prior step.
-      // 1<<j is the stride distance that the invoked step will handle.
-      // The recursive steps continue until stride distance 1 is complete.
-      // For stride distance less than 1<<8, no global synchronization
-      // is needed, i.e., all work can be done locally within HW threads.
-      // Hence, the invocation of j==8 cmk_bitonic_merge finishes stride 256
-      // compare-and-swap and then performs stride 128, 64, 32, 16, 8, 4, 2, 1
-      // locally.
-      for (int j = i; j >= 8; j--) {
-        buffer<uint32_t, 1> buf(pOutputs, range<1>(size));
-        mergeEvent[k] = pQueue_->submit([&](handler &cgh) {
-          auto acc = buf.get_access<access::mode::read_write>(cgh);
-          cgh.parallel_for<class Merge>(
-              MergeGlobalRange * MergeLocalRange,
-              [=](id<1> tid) SYCL_ESIMD_KERNEL {
-                using namespace sycl::ext::intel::experimental::esimd;
-                cmk_bitonic_merge(acc, j, i, tid);
-              });
-        });
-        k++;
-      }
+  // num_iters + 1, iteration#0 is for warmup
+  for (int iter = 0; iter <= num_iters; ++iter) {
+    try {
+      buffer<uint32_t, 1> bufi(pInputs, range<1>(size));
+      buffer<uint32_t, 1> bufo(pOutputs, range<1>(size));
+      // enqueue sort265 kernel
+      auto e = pQueue_->submit([&](handler &cgh) {
+        auto acci = bufi.get_access<access::mode::read>(cgh);
+        auto acco = bufo.get_access<access::mode::write>(cgh);
+        cgh.parallel_for<class Sort256>(
+            SortGlobalRange * SortLocalRange, [=](id<1> i) SYCL_ESIMD_KERNEL {
+              using namespace sycl::ext::intel::experimental::esimd;
+              cmk_bitonic_sort_256(acci, acco, i);
+            });
+      });
+      e.wait();
+      double etime = esimd_test::report_time("kernel1 time", e, e);
+      if (iter > 0)
+        kernel_times += etime;
+    } catch (cl::sycl::exception const &e) {
+      std::cout << "SYCL exception caught: " << e.what() << '\n';
+      return 0;
     }
-  } catch (cl::sycl::exception const &e) {
-    std::cout << "SYCL exception caught: " << e.what() << '\n';
-    return e.get_cl_code();
+
+    // Each HW thread swap two 256-element chunks. Hence, we only need
+    // to launch size/ (base_sort_size*2) HW threads
+    total_threads = size / (base_sort_size_ * 2);
+    // create ranges
+    // We need that many workitems
+    auto MergeGlobalRange = cl::sycl::range<1>(total_threads);
+    // Number of workitems in a workgroup
+    cl::sycl::range<1> MergeLocalRange{1};
+
+    // enqueue merge kernel multiple times
+    // this loop is for stage 8 to stage LOG2_ELEMENTS.
+    event mergeEvent[(LOG2_ELEMENTS - 8) * (LOG2_ELEMENTS - 7) / 2];
+    int k = 0;
+    try {
+      for (int i = 8; i < LOG2_ELEMENTS; i++) {
+        // each step halves the stride distance of its prior step.
+        // 1<<j is the stride distance that the invoked step will handle.
+        // The recursive steps continue until stride distance 1 is complete.
+        // For stride distance less than 1<<8, no global synchronization
+        // is needed, i.e., all work can be done locally within HW threads.
+        // Hence, the invocation of j==8 cmk_bitonic_merge finishes stride 256
+        // compare-and-swap and then performs stride 128, 64, 32, 16, 8, 4, 2, 1
+        // locally.
+        for (int j = i; j >= 8; j--) {
+          buffer<uint32_t, 1> buf(pOutputs, range<1>(size));
+          mergeEvent[k] = pQueue_->submit([&](handler &cgh) {
+            auto acc = buf.get_access<access::mode::read_write>(cgh);
+            cgh.parallel_for<class Merge>(
+                MergeGlobalRange * MergeLocalRange,
+                [=](id<1> tid) SYCL_ESIMD_KERNEL {
+                  using namespace sycl::ext::intel::experimental::esimd;
+                  cmk_bitonic_merge(acc, j, i, tid);
+                });
+          });
+          k++;
+        }
+      }
+    } catch (cl::sycl::exception const &e) {
+      std::cout << "SYCL exception caught: " << e.what() << '\n';
+      return 0;
+    }
+
+    mergeEvent[k - 1].wait();
+    double etime = esimd_test::report_time("kernel2 time", mergeEvent[0],
+                                           mergeEvent[k - 1]);
+    if (iter > 0)
+      kernel_times += etime;
+    else
+      start = timer.Elapsed();
   }
 
-  mergeEvent[k - 1].wait();
-  total_time +=
-      esimd_test::report_time("kernel time", mergeEvent[0], mergeEvent[k - 1]);
+  // End timer.
+  double end = timer.Elapsed();
 
-  cout << " Sorting Time = " << total_time << " msec " << std::endl;
+  esimd_test::display_timing_stats(kernel_times, num_iters,
+                                   (end - start) * 1000);
   return 1;
 }
 

--- a/SYCL/ESIMD/Prefix_Local_sum1.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum1.cpp
@@ -176,8 +176,9 @@ int main(int argc, char *argv[]) {
     }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    free(pInputs, q);
+    free(pDeviceOutputs, q);
     free(pExpectOutputs);
+    free(pInputs);
     return 1;
   }
 

--- a/SYCL/ESIMD/Prefix_Local_sum1.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum1.cpp
@@ -38,8 +38,8 @@
 using namespace cl::sycl;
 using namespace sycl::ext::intel::experimental::esimd;
 
-void compute_local_prefixsum(unsigned int input[], unsigned int prefixSum[],
-                             unsigned int size) {
+void compute_local_prefixsum(const unsigned int input[],
+                             unsigned int prefixSum[], unsigned int size) {
 
   memcpy(prefixSum, input, size * TUPLE_SZ * sizeof(unsigned));
   unsigned local_sum[TUPLE_SZ];
@@ -117,7 +117,6 @@ void cmk_sum_tuple_count(unsigned int *buf, unsigned int h_pos) {
 //************************************
 int main(int argc, char *argv[]) {
 
-  unsigned int *pInputs;
   if (argc < 2) {
     std::cout << "Usage: prefix [N]. N is 2^N entries x TUPLE_SZ" << std::endl;
     exit(1);
@@ -127,18 +126,23 @@ int main(int argc, char *argv[]) {
 
   cl::sycl::range<2> LocalRange{1, 1};
 
-  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
+  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
+          property::queue::enable_profiling{});
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
   auto ctxt = q.get_context();
 
   // allocate and initialized input
-  pInputs = static_cast<unsigned int *>(
-      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
+  unsigned int *pInputs = static_cast<unsigned int *>(
+      malloc(size * TUPLE_SZ * sizeof(unsigned int)));
   for (unsigned int i = 0; i < size * TUPLE_SZ; ++i) {
     pInputs[i] = rand() % 128;
   }
+
+  // allocate device buffer
+  unsigned int *pDeviceOutputs = static_cast<unsigned int *>(
+      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
 
   // allocate & compute expected result
   unsigned int *pExpectOutputs = static_cast<unsigned int *>(
@@ -147,27 +151,50 @@ int main(int argc, char *argv[]) {
 
   // compute local sum for every chunk of PREFIX_ENTRIES
   cl::sycl::range<2> GlobalRange{size / PREFIX_ENTRIES, 1};
+
+  // Start Timer
+  esimd_test::Timer timer;
+  double start;
+
+  double kernel_times = 0;
+  unsigned num_iters = 10;
+
   try {
-    auto e0 = q.submit([&](handler &cgh) {
-      cgh.parallel_for<class Sum_tuple>(
-          GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {
-            cmk_sum_tuple_count(pInputs, it.get_id(0));
-          });
-    });
-    e0.wait();
+    for (int iter = 0; iter <= num_iters; ++iter) {
+      memcpy(pDeviceOutputs, pInputs, size * TUPLE_SZ * sizeof(unsigned int));
+      auto e0 = q.submit([&](handler &cgh) {
+        cgh.parallel_for<class Sum_tuple>(
+            GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {
+              cmk_sum_tuple_count(pDeviceOutputs, it.get_id(0));
+            });
+      });
+      e0.wait();
+      double etime = esimd_test::report_time("kernel time", e0, e0);
+      if (iter > 0)
+        kernel_times += etime;
+      else
+        start = timer.Elapsed();
+    }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
     free(pInputs, ctxt);
     free(pExpectOutputs);
-    return e.get_cl_code();
+    return 1;
   }
 
-  bool pass = memcmp(pInputs, pExpectOutputs,
+  // End timer.
+  double end = timer.Elapsed();
+
+  esimd_test::display_timing_stats(kernel_times, num_iters,
+                                   (end - start) * 1000);
+
+  bool pass = memcmp(pDeviceOutputs, pExpectOutputs,
                      size * TUPLE_SZ * sizeof(unsigned int)) == 0;
   std::cout << "Prefix " << (pass ? "=> PASSED" : "=> FAILED") << std::endl
             << std::endl;
 
-  free(pInputs, ctxt);
+  free(pDeviceOutputs, ctxt);
   free(pExpectOutputs);
+  free(pInputs);
   return 0;
 }

--- a/SYCL/ESIMD/Prefix_Local_sum1.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum1.cpp
@@ -131,7 +131,6 @@ int main(int argc, char *argv[]) {
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
-  auto ctxt = q.get_context();
 
   // allocate and initialized input
   unsigned int *pInputs = static_cast<unsigned int *>(
@@ -141,8 +140,8 @@ int main(int argc, char *argv[]) {
   }
 
   // allocate device buffer
-  unsigned int *pDeviceOutputs = static_cast<unsigned int *>(
-      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
+  unsigned int *pDeviceOutputs =
+      malloc_shared<unsigned int>(size * TUPLE_SZ, q);
 
   // allocate & compute expected result
   unsigned int *pExpectOutputs = static_cast<unsigned int *>(
@@ -177,7 +176,7 @@ int main(int argc, char *argv[]) {
     }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    free(pInputs, ctxt);
+    free(pInputs, q);
     free(pExpectOutputs);
     return 1;
   }
@@ -193,7 +192,7 @@ int main(int argc, char *argv[]) {
   std::cout << "Prefix " << (pass ? "=> PASSED" : "=> FAILED") << std::endl
             << std::endl;
 
-  free(pDeviceOutputs, ctxt);
+  free(pDeviceOutputs, q);
   free(pExpectOutputs);
   free(pInputs);
   return 0;

--- a/SYCL/ESIMD/Prefix_Local_sum2.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum2.cpp
@@ -126,7 +126,6 @@ int main(int argc, char *argv[]) {
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
-  auto ctxt = q.get_context();
 
   // allocate and initialized input
   unsigned int *pInputs = static_cast<unsigned int *>(
@@ -136,8 +135,8 @@ int main(int argc, char *argv[]) {
   }
 
   // allocate device buffer
-  unsigned int *pDeviceOutputs = static_cast<unsigned int *>(
-      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
+  unsigned int *pDeviceOutputs =
+      malloc_shared<unsigned int>(size * TUPLE_SZ, q);
 
   // allocate & compute expected result
   unsigned int *pExpectOutputs = static_cast<unsigned int *>(
@@ -171,7 +170,7 @@ int main(int argc, char *argv[]) {
     }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    free(pInputs, ctxt);
+    free(pInputs, q);
     free(pExpectOutputs);
     return 1;
   }
@@ -187,7 +186,7 @@ int main(int argc, char *argv[]) {
   std::cout << "Prefix " << (pass ? "=> PASSED" : "=> FAILED") << std::endl
             << std::endl;
 
-  free(pDeviceOutputs, ctxt);
+  free(pDeviceOutputs, q);
   free(pExpectOutputs);
   free(pInputs);
   return 0;

--- a/SYCL/ESIMD/Prefix_Local_sum2.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum2.cpp
@@ -38,8 +38,8 @@
 using namespace cl::sycl;
 using namespace sycl::ext::intel::experimental::esimd;
 
-void compute_local_prefixsum(unsigned int input[], unsigned int prefixSum[],
-                             unsigned int size) {
+void compute_local_prefixsum(const unsigned int input[],
+                             unsigned int prefixSum[], unsigned int size) {
 
   memcpy(prefixSum, input, size * TUPLE_SZ * sizeof(unsigned));
   unsigned local_sum[TUPLE_SZ];
@@ -112,7 +112,6 @@ void cmk_acum_iterative(unsigned *buf, unsigned h_pos,
 //************************************
 int main(int argc, char *argv[]) {
 
-  unsigned int *pInputs;
   if (argc < 2) {
     std::cout << "Usage: prefix [N]. N is 2^N entries x TUPLE_SZ" << std::endl;
     exit(1);
@@ -122,53 +121,74 @@ int main(int argc, char *argv[]) {
 
   cl::sycl::range<2> LocalRange{1, 1};
 
-  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
+  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
+          property::queue::enable_profiling{});
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
   auto ctxt = q.get_context();
 
   // allocate and initialized input
-  pInputs = static_cast<unsigned int *>(
-      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
+  unsigned int *pInputs = static_cast<unsigned int *>(
+      malloc(size * TUPLE_SZ * sizeof(unsigned int)));
   for (unsigned int i = 0; i < size * TUPLE_SZ; ++i) {
     pInputs[i] = rand() % 128;
   }
 
-  unsigned sum[2];
-  sum[0] = sum[1] = 0;
-  for (int i = 0; i < 256; i++) {
-    sum[0] += pInputs[i * TUPLE_SZ];
-    sum[1] += pInputs[i * TUPLE_SZ + 1];
-  }
+  // allocate device buffer
+  unsigned int *pDeviceOutputs = static_cast<unsigned int *>(
+      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
 
   // allocate & compute expected result
   unsigned int *pExpectOutputs = static_cast<unsigned int *>(
       malloc(size * TUPLE_SZ * sizeof(unsigned int)));
   compute_local_prefixsum(pInputs, pExpectOutputs, size);
 
+  // Start Timer
+  esimd_test::Timer timer;
+  double start;
+
+  double kernel_times = 0;
+  unsigned num_iters = 10;
+
   try {
-    auto e1 = q.submit([&](handler &cgh) {
-      cgh.parallel_for<class Accum_iterative>(
-          range<2>{size / PREFIX_ENTRIES, 1} * LocalRange,
-          [=](item<2> it) SYCL_ESIMD_KERNEL {
-            cmk_acum_iterative(pInputs, it.get_id(0), 1, PREFIX_ENTRIES);
-          });
-    });
-    e1.wait();
+    for (int iter = 0; iter <= num_iters; ++iter) {
+      memcpy(pDeviceOutputs, pInputs, size * TUPLE_SZ * sizeof(unsigned int));
+      auto e1 = q.submit([&](handler &cgh) {
+        cgh.parallel_for<class Accum_iterative>(
+            range<2>{size / PREFIX_ENTRIES, 1} * LocalRange,
+            [=](item<2> it) SYCL_ESIMD_KERNEL {
+              cmk_acum_iterative(pDeviceOutputs, it.get_id(0), 1,
+                                 PREFIX_ENTRIES);
+            });
+      });
+      e1.wait();
+      double etime = esimd_test::report_time("kernel time", e1, e1);
+      if (iter > 0)
+        kernel_times += etime;
+      else
+        start = timer.Elapsed();
+    }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
     free(pInputs, ctxt);
     free(pExpectOutputs);
-    return e.get_cl_code();
+    return 1;
   }
 
-  bool pass = memcmp(pInputs, pExpectOutputs,
+  // End timer.
+  double end = timer.Elapsed();
+
+  esimd_test::display_timing_stats(kernel_times, num_iters,
+                                   (end - start) * 1000);
+
+  bool pass = memcmp(pDeviceOutputs, pExpectOutputs,
                      size * TUPLE_SZ * sizeof(unsigned int)) == 0;
   std::cout << "Prefix " << (pass ? "=> PASSED" : "=> FAILED") << std::endl
             << std::endl;
 
-  free(pInputs, ctxt);
+  free(pDeviceOutputs, ctxt);
   free(pExpectOutputs);
+  free(pInputs);
   return 0;
 }

--- a/SYCL/ESIMD/Prefix_Local_sum2.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum2.cpp
@@ -170,8 +170,9 @@ int main(int argc, char *argv[]) {
     }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    free(pInputs, q);
+    free(pDeviceOutputs, q);
     free(pExpectOutputs);
+    free(pInputs);
     return 1;
   }
 

--- a/SYCL/ESIMD/Prefix_Local_sum3.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum3.cpp
@@ -332,7 +332,6 @@ int main(int argc, char *argv[]) {
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
-  auto ctxt = q.get_context();
 
   // allocate and initialized input data
   unsigned int *pInputs = static_cast<unsigned int *>(
@@ -342,8 +341,8 @@ int main(int argc, char *argv[]) {
   }
 
   // allocate kernel buffer
-  unsigned int *pDeviceOutputs = static_cast<unsigned int *>(
-      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
+  unsigned int *pDeviceOutputs =
+      malloc_shared<unsigned int>(size * TUPLE_SZ, q);
 
   // allocate & intialize expected result
   unsigned int *pExpectOutputs = static_cast<unsigned int *>(
@@ -389,7 +388,7 @@ int main(int argc, char *argv[]) {
   std::cout << "Prefix " << (pass ? "=> PASSED" : "=> FAILED") << std::endl
             << std::endl;
 
-  free(pDeviceOutputs, ctxt);
+  free(pDeviceOutputs, q);
   free(pExpectOutputs);
   free(pInputs);
   return 0;

--- a/SYCL/ESIMD/Prefix_Local_sum3.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum3.cpp
@@ -235,42 +235,49 @@ void cmk_acum_final(unsigned *buf, unsigned h_pos, unsigned int stride_elems,
   }
 }
 
-void hierarchical_prefix(queue &q, unsigned *buf, unsigned elem_stride,
-                         unsigned thrd_stride, unsigned n_entries,
-                         unsigned entry_per_th) {
+double hierarchical_prefix(queue &q, unsigned *buf, unsigned elem_stride,
+                           unsigned thrd_stride, unsigned n_entries,
+                           unsigned entry_per_th) {
+  double kernel_times = 0;
   try {
     if (n_entries <= REMAINING_ENTRIES) {
+#ifdef DEBUG_DUMPS
       std::cout << "... n_entries: " << n_entries
                 << " elem_stide: " << elem_stride
                 << " thread_stride: " << thrd_stride
                 << " entry per thread: " << entry_per_th << std::endl;
+#endif // DEBUG_DUMPS
       // one single thread
-      q.submit([&](handler &cgh) {
+      auto e = q.submit([&](handler &cgh) {
         cgh.parallel_for<class Accum_final>(
             range<2>{1, 1} * range<2>{1, 1}, [=](item<2> it) SYCL_ESIMD_KERNEL {
               cmk_acum_final(buf, it.get_id(0), elem_stride, n_entries);
             });
       });
-      q.wait();
-      return;
+      e.wait();
+      kernel_times += esimd_test::report_time("kernel1 time", e, e);
+      return kernel_times;
     }
 
+#ifdef DEBUG_DUMPS
     std::cout << "*** n_entries: " << n_entries
               << " elem_stide: " << elem_stride
               << " thread_stride: " << thrd_stride
               << " entry per thread: " << entry_per_th << std::endl;
+#endif // DEBUG_DUMPS
 
     if (entry_per_th == PREFIX_ENTRIES) {
-      q.submit([&](handler &cgh) {
+      auto e = q.submit([&](handler &cgh) {
         cgh.parallel_for<class Accum_iterative1>(
             range<2>{n_entries / entry_per_th, 1} * range<2>{1, 1},
             [=](item<2> it) SYCL_ESIMD_KERNEL {
               cmk_acum_iterative(buf, it.get_id(0), elem_stride, thrd_stride);
             });
       });
-      q.wait();
+      e.wait();
+      kernel_times += esimd_test::report_time("kernel2 time", e, e);
     } else {
-      q.submit([&](handler &cgh) {
+      auto e = q.submit([&](handler &cgh) {
         cgh.parallel_for<class Accum_iterative2>(
             range<2>{n_entries / entry_per_th, 1} * range<2>{1, 1},
             [=](item<2> it) SYCL_ESIMD_KERNEL {
@@ -278,7 +285,8 @@ void hierarchical_prefix(queue &q, unsigned *buf, unsigned elem_stride,
                                      thrd_stride);
             });
       });
-      q.wait();
+      e.wait();
+      kernel_times += esimd_test::report_time("kernel3 time", e, e);
     }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
@@ -287,15 +295,21 @@ void hierarchical_prefix(queue &q, unsigned *buf, unsigned elem_stride,
   // if number of remaining entries <= 4K , each thread  accumulates smaller
   // number of entries to keep EUs saturated
   if (n_entries / entry_per_th > 4096)
-    hierarchical_prefix(q, buf, thrd_stride, thrd_stride * PREFIX_ENTRIES,
-                        n_entries / entry_per_th, PREFIX_ENTRIES);
+    kernel_times +=
+        hierarchical_prefix(q, buf, thrd_stride, thrd_stride * PREFIX_ENTRIES,
+                            n_entries / entry_per_th, PREFIX_ENTRIES);
   else
-    hierarchical_prefix(q, buf, thrd_stride, thrd_stride * PREFIX_ENTRIES_LOW,
-                        n_entries / entry_per_th, PREFIX_ENTRIES_LOW);
+    kernel_times += hierarchical_prefix(
+        q, buf, thrd_stride, thrd_stride * PREFIX_ENTRIES_LOW,
+        n_entries / entry_per_th, PREFIX_ENTRIES_LOW);
 
+#ifdef DEBUG_DUMPS
   std::cout << "=== n_entries: " << n_entries << " elem_stide: " << elem_stride
             << " thread_stride: " << thrd_stride
             << " entry per thread: " << entry_per_th << std::endl;
+#endif // DEBUG_DUMPS
+
+  return kernel_times;
 }
 
 //************************************
@@ -308,31 +322,56 @@ void hierarchical_prefix(queue &q, unsigned *buf, unsigned elem_stride,
 //************************************
 int main(int argc, char *argv[]) {
 
-  unsigned int *pInputs;
   unsigned log2_element = 26;
   unsigned int size = 1 << log2_element;
 
   cl::sycl::range<2> LocalRange{1, 1};
 
-  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
+  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
+          property::queue::enable_profiling{});
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
   auto ctxt = q.get_context();
 
-  // allocate and initialized input
-  pInputs = static_cast<unsigned int *>(
-      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
+  // allocate and initialized input data
+  unsigned int *pInputs = static_cast<unsigned int *>(
+      malloc(size * TUPLE_SZ * sizeof(unsigned int)));
   for (unsigned int i = 0; i < size * TUPLE_SZ; ++i) {
     pInputs[i] = rand() % 128;
   }
 
-  // allocate & compute expected result
+  // allocate kernel buffer
+  unsigned int *pDeviceOutputs = static_cast<unsigned int *>(
+      malloc_shared(size * TUPLE_SZ * sizeof(unsigned int), dev, ctxt));
+
+  // allocate & intialize expected result
   unsigned int *pExpectOutputs = static_cast<unsigned int *>(
       malloc(size * TUPLE_SZ * sizeof(unsigned int)));
   memcpy(pExpectOutputs, pInputs, size * TUPLE_SZ * sizeof(unsigned));
 
-  hierarchical_prefix(q, pInputs, 1, PREFIX_ENTRIES, size, PREFIX_ENTRIES);
+  // Start Timer
+  esimd_test::Timer timer;
+  double start;
+
+  double kernel_times = 0;
+  unsigned num_iters = 10;
+
+  for (int iter = 0; iter <= num_iters; ++iter) {
+    memcpy(pDeviceOutputs, pInputs, size * TUPLE_SZ * sizeof(unsigned));
+    double etime = hierarchical_prefix(q, pDeviceOutputs, 1, PREFIX_ENTRIES,
+                                       size, PREFIX_ENTRIES);
+    if (iter > 0)
+      kernel_times += etime;
+    else
+      start = timer.Elapsed();
+  }
+
+  // End timer.
+  double end = timer.Elapsed();
+
+  esimd_test::display_timing_stats(kernel_times, num_iters,
+                                   (end - start) * 1000);
 
   compute_local_prefixsum(pExpectOutputs, size, 1, PREFIX_ENTRIES,
                           PREFIX_ENTRIES);
@@ -345,12 +384,13 @@ int main(int argc, char *argv[]) {
                                     PREFIX_ENTRIES * PREFIX_ENTRIES *
                                         PREFIX_ENTRIES_LOW);
 
-  bool pass = memcmp(pInputs, pExpectOutputs,
+  bool pass = memcmp(pDeviceOutputs, pExpectOutputs,
                      size * TUPLE_SZ * sizeof(unsigned int)) == 0;
   std::cout << "Prefix " << (pass ? "=> PASSED" : "=> FAILED") << std::endl
             << std::endl;
 
-  free(pInputs, ctxt);
+  free(pDeviceOutputs, ctxt);
   free(pExpectOutputs);
+  free(pInputs);
   return 0;
 }

--- a/SYCL/ESIMD/linear/linear.cpp
+++ b/SYCL/ESIMD/linear/linear.cpp
@@ -54,6 +54,13 @@ int main(int argc, char *argv[]) {
   // Sets output to blank image.
   output_image.setData(new unsigned char[img_size]);
 
+  // Start Timer
+  esimd_test::Timer timer;
+  double start;
+
+  double kernel_times = 0;
+  unsigned num_iters = 10;
+
   try {
     unsigned int img_width = width * bpp / (8 * sizeof(int));
 
@@ -73,59 +80,73 @@ int main(int argc, char *argv[]) {
     // Number of workitems in a workgroup
     cl::sycl::range<2> LocalRange{1, 1};
 
-    queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
+    queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
+            property::queue::enable_profiling{});
 
     auto dev = q.get_device();
     auto ctxt = q.get_context();
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
-    auto e = q.submit([&](cl::sycl::handler &cgh) {
-      auto accInput =
-          imgInput.get_access<uint4, cl::sycl::access::mode::read>(cgh);
-      auto accOutput =
-          imgOutput.get_access<uint4, cl::sycl::access::mode::write>(cgh);
+    for (int iter = 0; iter <= num_iters; ++iter) {
+      auto e = q.submit([&](cl::sycl::handler &cgh) {
+        auto accInput =
+            imgInput.get_access<uint4, cl::sycl::access::mode::read>(cgh);
+        auto accOutput =
+            imgOutput.get_access<uint4, cl::sycl::access::mode::write>(cgh);
 
-      cgh.parallel_for<class Test>(
-          GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {
-            using namespace sycl::ext::intel::experimental::esimd;
+        cgh.parallel_for<class Test>(
+            GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {
+              using namespace sycl::ext::intel::experimental::esimd;
 
-            simd<unsigned char, 8 * 32> vin;
-            auto in = vin.bit_cast_view<unsigned char, 8, 32>();
+              simd<unsigned char, 8 * 32> vin;
+              auto in = vin.bit_cast_view<unsigned char, 8, 32>();
 
-            simd<unsigned char, 6 * 24> vout;
-            auto out = vout.bit_cast_view<uchar, 6, 24>();
+              simd<unsigned char, 6 * 24> vout;
+              auto out = vout.bit_cast_view<uchar, 6, 24>();
 
-            simd<float, 6 * 24> vm;
-            auto m = vm.bit_cast_view<float, 6, 24>();
+              simd<float, 6 * 24> vm;
+              auto m = vm.bit_cast_view<float, 6, 24>();
 
-            uint h_pos = it.get_id(0);
-            uint v_pos = it.get_id(1);
+              uint h_pos = it.get_id(0);
+              uint v_pos = it.get_id(1);
 
-            in = media_block_load<unsigned char, 8, 32>(accInput, h_pos * 24,
-                                                        v_pos * 6);
+              in = media_block_load<unsigned char, 8, 32>(accInput, h_pos * 24,
+                                                          v_pos * 6);
 
-            m = in.select<6, 1, 24, 1>(1, 3);
-            m += in.select<6, 1, 24, 1>(0, 0);
-            m += in.select<6, 1, 24, 1>(0, 3);
-            m += in.select<6, 1, 24, 1>(0, 6);
-            m += in.select<6, 1, 24, 1>(1, 0);
-            m += in.select<6, 1, 24, 1>(1, 6);
-            m += in.select<6, 1, 24, 1>(2, 0);
-            m += in.select<6, 1, 24, 1>(2, 3);
-            m += in.select<6, 1, 24, 1>(2, 6);
-            m = m * 0.111f;
+              m = in.select<6, 1, 24, 1>(1, 3);
+              m += in.select<6, 1, 24, 1>(0, 0);
+              m += in.select<6, 1, 24, 1>(0, 3);
+              m += in.select<6, 1, 24, 1>(0, 6);
+              m += in.select<6, 1, 24, 1>(1, 0);
+              m += in.select<6, 1, 24, 1>(1, 6);
+              m += in.select<6, 1, 24, 1>(2, 0);
+              m += in.select<6, 1, 24, 1>(2, 3);
+              m += in.select<6, 1, 24, 1>(2, 6);
+              m = m * 0.111f;
 
-            vout = convert<unsigned char>(vm);
+              vout = convert<unsigned char>(vm);
 
-            media_block_store<unsigned char, 6, 24>(accOutput, h_pos * 24,
-                                                    v_pos * 6, out);
-          });
-    });
-    e.wait();
+              media_block_store<unsigned char, 6, 24>(accOutput, h_pos * 24,
+                                                      v_pos * 6, out);
+            });
+      });
+      e.wait();
+      double etime = esimd_test::report_time("kernel time", e, e);
+      if (iter > 0)
+        kernel_times += etime;
+      else
+        start = timer.Elapsed();
+    }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    return e.get_cl_code();
+    return 1;
   }
+
+  // End timer.
+  double end = timer.Elapsed();
+
+  esimd_test::display_timing_stats(kernel_times, num_iters,
+                                   (end - start) * 1000);
 
   output_image.save("linear_out.bmp");
   bool passed = sycl::intel::util::bitmap::BitMap::checkResult("linear_out.bmp",

--- a/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -96,6 +96,13 @@ int main(int argc, char *argv[]) {
   // Sets output to blank image.
   unsigned char *buf = new unsigned char[img_size];
 
+  // Start Timer
+  esimd_test::Timer timer;
+  double start;
+
+  double kernel_times = 0;
+  unsigned num_iters = 10;
+
   try {
     sycl::image<2> imgOutput((unsigned int *)buf, image_channel_order::rgba,
                              image_channel_type::unsigned_int8,
@@ -109,7 +116,8 @@ int main(int argc, char *argv[]) {
     // Number of workitems in a workgroup
     sycl::range<2> LocalRange{1, 1};
 
-    queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
+    queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
+            property::queue::enable_profiling{});
 
     auto dev = q.get_device();
     auto ctxt = q.get_context();
@@ -127,34 +135,47 @@ int main(int argc, char *argv[]) {
                 << ", yoff = " << yoff << ", scale = " << scale
                 << ", thrs = " << thrs << "\n";
     }
-    auto e = q.submit([&](sycl::handler &cgh) {
-      auto accOutput =
-          imgOutput.get_access<uint4, sycl::access::mode::write>(cgh);
+    for (int iter = 0; iter <= num_iters; ++iter) {
+      auto e = q.submit([&](sycl::handler &cgh) {
+        auto accOutput =
+            imgOutput.get_access<uint4, sycl::access::mode::write>(cgh);
 
-      cgh.set_specialization_constant<CrunchConst>(crunch);
-      cgh.set_specialization_constant<XoffConst>(xoff);
-      cgh.set_specialization_constant<YoffConst>(yoff);
-      cgh.set_specialization_constant<ScaleConst>(scale);
-      cgh.set_specialization_constant<ThrsConst>(thrs);
-      cgh.parallel_for<Test>(
-          GlobalRange * LocalRange,
-          [=](item<2> it, kernel_handler h) SYCL_ESIMD_KERNEL {
-            uint h_pos = it.get_id(0);
-            uint v_pos = it.get_id(1);
-            mandelbrot(accOutput, h_pos, v_pos,
-                       h.get_specialization_constant<CrunchConst>(),
-                       h.get_specialization_constant<XoffConst>(),
-                       h.get_specialization_constant<YoffConst>(),
-                       h.get_specialization_constant<ScaleConst>(),
-                       h.get_specialization_constant<ThrsConst>());
-          });
-    });
-    e.wait();
+        cgh.set_specialization_constant<CrunchConst>(crunch);
+        cgh.set_specialization_constant<XoffConst>(xoff);
+        cgh.set_specialization_constant<YoffConst>(yoff);
+        cgh.set_specialization_constant<ScaleConst>(scale);
+        cgh.set_specialization_constant<ThrsConst>(thrs);
+        cgh.parallel_for<Test>(
+            GlobalRange * LocalRange,
+            [=](item<2> it, kernel_handler h) SYCL_ESIMD_KERNEL {
+              uint h_pos = it.get_id(0);
+              uint v_pos = it.get_id(1);
+              mandelbrot(accOutput, h_pos, v_pos,
+                         h.get_specialization_constant<CrunchConst>(),
+                         h.get_specialization_constant<XoffConst>(),
+                         h.get_specialization_constant<YoffConst>(),
+                         h.get_specialization_constant<ScaleConst>(),
+                         h.get_specialization_constant<ThrsConst>());
+            });
+      });
+      e.wait();
+      double etime = esimd_test::report_time("kernel time", e, e);
+      if (iter > 0)
+        kernel_times += etime;
+      else
+        start = timer.Elapsed();
+    }
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
     delete[] buf;
-    return e.get_cl_code();
+    return 1;
   }
+
+  // End timer.
+  double end = timer.Elapsed();
+
+  esimd_test::display_timing_stats(kernel_times, num_iters,
+                                   (end - start) * 1000);
 
   char *out_file = argv[1];
   FILE *dumpfile = fopen(out_file, "wb");

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -91,7 +91,8 @@ int main(int argc, char *argv[]) {
             << std::endl;
   cl::sycl::range<2> LocalRange{1, 1};
 
-  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
+  queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
+          property::queue::enable_profiling{});
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
@@ -105,85 +106,108 @@ int main(int argc, char *argv[]) {
   InitializeSquareMatrix(inputMatrix, DIM_SIZE, false);
   InitializeSquareMatrix(outputMatrix, DIM_SIZE, true);
 
+  // Start Timer
+  esimd_test::Timer timer;
+  double start;
+
+  double kernel_times = 0;
+  unsigned num_iters = 10;
+
   try {
-    auto e = q.submit([&](handler &cgh) {
-      cgh.parallel_for<class Stencil_kernel>(
-          GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {
-            using namespace sycl::ext::intel::experimental::esimd;
-            uint h_pos = it.get_id(0);
-            uint v_pos = it.get_id(1);
+    for (int iter = 0; iter <= num_iters; ++iter) {
+      auto e = q.submit([&](handler &cgh) {
+        cgh.parallel_for<class Stencil_kernel>(
+            GlobalRange * LocalRange, [=](item<2> it) SYCL_ESIMD_KERNEL {
+              using namespace sycl::ext::intel::experimental::esimd;
+              uint h_pos = it.get_id(0);
+              uint v_pos = it.get_id(1);
 
-            simd<float, (HEIGHT + 10) * 32> vin;
-            // matrix HEIGHT+10 x 32
-            auto in = vin.bit_cast_view<float, HEIGHT + 10, 32>();
+              simd<float, (HEIGHT + 10) * 32> vin;
+              // matrix HEIGHT+10 x 32
+              auto in = vin.bit_cast_view<float, HEIGHT + 10, 32>();
 
-            //
-            // rather than loading all data in
-            // the code will interleave data loading and compute
-            // first, we load enough data for the first 16 pixels
-            //
-            unsigned off = (v_pos * HEIGHT) * DIM_SIZE + h_pos * WIDTH;
+              //
+              // rather than loading all data in
+              // the code will interleave data loading and compute
+              // first, we load enough data for the first 16 pixels
+              //
+              unsigned off = (v_pos * HEIGHT) * DIM_SIZE + h_pos * WIDTH;
 #pragma unroll
-            for (unsigned i = 0; i < 10; i++) {
-              simd<float, 32> data;
-              data.copy_from(inputMatrix + off);
-              in.row(i) = data;
-              off += DIM_SIZE;
-            }
+              for (unsigned i = 0; i < 10; i++) {
+                simd<float, 32> data;
+                data.copy_from(inputMatrix + off);
+                in.row(i) = data;
+                off += DIM_SIZE;
+              }
 
-            unsigned out_off =
-                (((v_pos * HEIGHT + 5) * DIM_SIZE + (h_pos * WIDTH) + 5)) *
-                sizeof(float);
-            simd<unsigned, WIDTH> elm16(0, 1);
+              unsigned out_off =
+                  (((v_pos * HEIGHT + 5) * DIM_SIZE + (h_pos * WIDTH) + 5)) *
+                  sizeof(float);
+              simd<unsigned, WIDTH> elm16(0, 1);
 
 #pragma unroll
-            for (unsigned i = 0; i < HEIGHT; i++) {
-              simd<float, 32> data;
-              data.copy_from(inputMatrix + off);
-              in.row(10 + i) = data;
-              off += DIM_SIZE;
+              for (unsigned i = 0; i < HEIGHT; i++) {
+                simd<float, 32> data;
+                data.copy_from(inputMatrix + off);
+                in.row(10 + i) = data;
+                off += DIM_SIZE;
 
-              simd<float, WIDTH> sum =
-                  vin.select<WIDTH, 1>(GET_IDX(i, 5)) * -0.02f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 1, 5)) * -0.025f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 2, 5)) * -0.0333333333333f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 3, 5)) * -0.05f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 4, 5)) * -0.1f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 0)) * -0.02f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 1)) * -0.025f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 2)) * -0.0333333333333f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 3)) * -0.05f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 4)) * -0.1f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 6)) * 0.1f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 7)) * 0.05f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 8)) * 0.0333333333333f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 9)) * 0.025f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 5, 10)) * 0.02f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 6, 5)) * 0.1f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 7, 5)) * 0.05f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 8, 5)) * 0.0333333333333f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 9, 5)) * 0.025f +
-                  vin.select<WIDTH, 1>(GET_IDX(i + 10, 5)) * 0.02f;
+                simd<float, WIDTH> sum =
+                    vin.select<WIDTH, 1>(GET_IDX(i, 5)) * -0.02f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 1, 5)) * -0.025f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 2, 5)) *
+                        -0.0333333333333f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 3, 5)) * -0.05f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 4, 5)) * -0.1f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 0)) * -0.02f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 1)) * -0.025f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 2)) *
+                        -0.0333333333333f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 3)) * -0.05f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 4)) * -0.1f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 6)) * 0.1f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 7)) * 0.05f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 8)) * 0.0333333333333f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 9)) * 0.025f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 5, 10)) * 0.02f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 6, 5)) * 0.1f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 7, 5)) * 0.05f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 8, 5)) * 0.0333333333333f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 9, 5)) * 0.025f +
+                    vin.select<WIDTH, 1>(GET_IDX(i + 10, 5)) * 0.02f;
 
-              // predciate output
-              simd_mask<WIDTH> p = (elm16 + h_pos * WIDTH) < (DIM_SIZE - 10);
+                // predciate output
+                simd_mask<WIDTH> p = (elm16 + h_pos * WIDTH) < (DIM_SIZE - 10);
 
-              simd<unsigned, WIDTH> elm16_off = elm16 * sizeof(float) + out_off;
-              scatter<float, WIDTH>(outputMatrix, sum, elm16_off, p);
-              out_off += DIM_SIZE * sizeof(float);
+                simd<unsigned, WIDTH> elm16_off =
+                    elm16 * sizeof(float) + out_off;
+                scatter<float, WIDTH>(outputMatrix, sum, elm16_off, p);
+                out_off += DIM_SIZE * sizeof(float);
 
-              if (v_pos * HEIGHT + 10 + i >= DIM_SIZE - 1)
-                break;
-            }
-          });
-    });
-    e.wait();
+                if (v_pos * HEIGHT + 10 + i >= DIM_SIZE - 1)
+                  break;
+              }
+            });
+      });
+      e.wait();
+      double etime = esimd_test::report_time("kernel time", e, e);
+      if (iter > 0)
+        kernel_times += etime;
+      else
+        start = timer.Elapsed();
+    }
   } catch (cl::sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
     free(inputMatrix, ctxt);
     free(outputMatrix, ctxt);
-    return e.get_cl_code();
+    return 1;
   }
+
+  // End timer.
+  double end = timer.Elapsed();
+
+  esimd_test::display_timing_stats(kernel_times, num_iters,
+                                   (end - start) * 1000);
 
   // check result
   bool passed = CheckResults(outputMatrix, inputMatrix, DIM_SIZE);


### PR DESCRIPTION
This patch changes stencil, linear, mandelbrot, BitonicSort and
Prefix_local_sum tests to print performance data the same way as it
was done in PR#524 for histogram tests.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>