### PR TITLE
[SYCL][HIP] Update HIP AMD XFAILs

### DIFF
--- a/SYCL/Basic/kernel_info.cpp
+++ b/SYCL/Basic/kernel_info.cpp
@@ -5,9 +5,6 @@
 //
 // Fail is flaky for level_zero, enable when fixed.
 // UNSUPPORTED: level_zero
-//
-// Failing on HIP AMD and HIP Nvidia
-// XFAIL: hip_amd || hip_nvidia
 
 //==--- kernel_info.cpp - SYCL kernel info test ----------------------------==//
 //

--- a/SYCL/Basic/linear-sub_group.cpp
+++ b/SYCL/Basic/linear-sub_group.cpp
@@ -4,8 +4,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing built-ins on AMD
-// XFAIL: hip_amd
 //==--------------- linear-sub_group.cpp - SYCL linear id test -------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/DeprecatedFeatures/get_backend.cpp
+++ b/SYCL/DeprecatedFeatures/get_backend.cpp
@@ -19,6 +19,7 @@ bool check(backend be) {
   case backend::level_zero:
   case backend::cuda:
   case backend::host:
+  case backend::hip:
     return true;
   default:
     return false;

--- a/SYCL/ESIMD/api/simd_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_negation_operator.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
+++ b/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_view_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_view_negation_operator.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/slm_gather_scatter.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: gpu
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: gpu
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/regression/replicate_bug.cpp
+++ b/SYCL/ESIMD/regression/replicate_bug.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/usm_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/usm_gather_scatter_rgba.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
-// UNSUPPORTED: cuda || hip_nvidia
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/GroupAlgorithm/SYCL2020/permute_select.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/permute_select.cpp
@@ -3,10 +3,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_SubgroupId, __spirv_SubgroupMaxSize, __spirv_SubgroupShuffle*
-// on AMD:
-// XFAIL: hip_amd
-//
 //==------------ permute_select.cpp -*- C++ -*-----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/GroupAlgorithm/SYCL2020/shift_left_right.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/shift_left_right.cpp
@@ -3,10 +3,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_SubgroupId, __spirv_SubgroupMaxSize, __spirv_SubgroupShuffle*
-// on AMD:
-// XFAIL: hip_amd
-//
 //==------------ shift_left_right.cpp -*- C++ -*----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/Regression/kernel_bundle_ignore_sycl_external.cpp
+++ b/SYCL/Regression/kernel_bundle_ignore_sycl_external.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// XFAIL: cuda || hip
+// XFAIL: cuda || hip_nvidia
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/SubGroup/common.cpp
+++ b/SYCL/SubGroup/common.cpp
@@ -4,9 +4,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_SubgroupLocalInvocationId on AMD
-// XFAIL: hip_amd
-
 //==-------------- common.cpp - SYCL sub_group common test -----*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/SubGroup/generic_reduce.cpp
+++ b/SYCL/SubGroup/generic_reduce.cpp
@@ -4,10 +4,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t_gpu.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Missing __spirv_SubgroupShuffleXorINTEL, __spirv_SubgroupLocalInvocationId,
-// __spirv_SubgroupShuffleINTEL, __spirv_SubgroupShuffleXorINTEL  on AMD
-// XFAIL: hip_amd
 
 #include "helper.hpp"
 #include <CL/sycl.hpp>

--- a/SYCL/SubGroup/sub_groups_sycl2020.cpp
+++ b/SYCL/SubGroup/sub_groups_sycl2020.cpp
@@ -2,10 +2,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
-// Missing __spirv_SubgroupLocalInvocationId on AMD
 // Assertion `!MHostPlatform && "Plugin is not available for Host."' failed on
 // Nvidia.
-// XFAIL: hip_amd || hip_nvidia
+// XFAIL: hip_nvidia
 
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
The get_backend test was missing the HIP plugin case.

The ESIMD tests are not supported for HIP in general, not just on
Nvidia.

The subgroup built-ins were added for AMD in intel/llvm#4208.

The kernel_info.cpp test was fixed in #474 and now passes with HIP.

The kernel_bundle_ignore_sycl_external.cpp only fails with HIP Nvidia,
not on AMD.