### PR TITLE
[SYCL][HIP] Remove XFAIL from tests affected by global offset bug

### DIFF
--- a/SYCL/Basic/buffer/buffer_full_copy.cpp
+++ b/SYCL/Basic/buffer/buffer_full_copy.cpp
@@ -5,9 +5,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
-//
-// Incorrect results with hip
-// XFAIL: hip
 
 //==------------- buffer_full_copy.cpp - SYCL buffer basic test ------------==//
 //

--- a/SYCL/Basic/buffer/subbuffer.cpp
+++ b/SYCL/Basic/buffer/subbuffer.cpp
@@ -4,8 +4,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// Test failing with hip on AMD
-// XFAIL: hip_amd
 //==---------- subbuffer.cpp --- sub-buffer basic test ---------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/KernelParams/array-kernel-param-run.cpp
+++ b/SYCL/KernelParams/array-kernel-param-run.cpp
@@ -5,9 +5,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Incorrect results with hip on AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 #include <iostream>

--- a/SYCL/Reduction/reduction_range_1d_s1_dw.cpp
+++ b/SYCL/Reduction/reduction_range_1d_s1_dw.cpp
@@ -2,9 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Incorrect results on HIP AMD
-// XFAIL: hip_amd
 
 // TODO: test disabled due to sporadic fails in level_zero:gpu RT.
 // UNSUPPORTED: linux && level_zero

--- a/SYCL/Reduction/reduction_range_2d_s1_dw.cpp
+++ b/SYCL/Reduction/reduction_range_2d_s1_dw.cpp
@@ -1,9 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-//
-// Failling on HIP AMD
-// XFAIL: hip_amd
 
 // TODO: accelerator may not suport atomics required by the current
 // implementation. Enable testing when implementation is fixed.

--- a/SYCL/Reduction/reduction_range_lambda.cpp
+++ b/SYCL/Reduction/reduction_range_lambda.cpp
@@ -2,9 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-//
-// Incorrect results on HIP AMD
-// XFAIL: hip_amd
 
 // This test performs basic checks of parallel_for(range, reduction, lambda)
 // with reductions initialized with 1-dimensional accessor accessing

--- a/SYCL/USM/copy.cpp
+++ b/SYCL/USM/copy.cpp
@@ -11,9 +11,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
-//
-// Memory access fault on HIP AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/USM/fill.cpp
+++ b/SYCL/USM/fill.cpp
@@ -11,9 +11,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
-//
-// Memory access fault with HIP AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
These tests have been fixed as part of: intel/llvm#4905

This should only be merged once intel/llvm#4905 is merged.