### PR TITLE
[SYCL][CUDA] Enable queue barrier tests

### DIFF
--- a/SYCL/Basic/barrier_order.cpp
+++ b/SYCL/Basic/barrier_order.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 
 #include <CL/sycl.hpp>
 #include <stdlib.h>

--- a/SYCL/Basic/enqueue_barrier.cpp
+++ b/SYCL/Basic/enqueue_barrier.cpp
@@ -1,11 +1,11 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out 2>&1 %CPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // RUN: env SYCL_PI_TRACE=2 %ACC_RUN_PLACEHOLDER %t.out 2>&1 %ACC_CHECK_PLACEHOLDER
 
 // The test is failing sporadically on Windows OpenCL RTs
 // Disabling on windows until fixed
-// UNSUPPORTED: cuda || windows || hip
+// UNSUPPORTED: windows || hip
 
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/fpga_device_selector.hpp>

--- a/SYCL/Basic/submit_barrier.cpp
+++ b/SYCL/Basic/submit_barrier.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 
 #include <CL/sycl.hpp>
 #include <stdlib.h>


### PR DESCRIPTION
These are passing with CUDA, as far as I can tell this feature was
implemented as part of intel/llvm#3932.

`enqueue_barrier.cpp` had to be tweaked to accept a triple as that is
required when using the CUDA plugin.

Note that this feature is missing from the hip plugin which is why these
are still unsupported for hip.