### PR TITLE
enable kernel handler tests for hip

### DIFF
--- a/SYCL/SpecConstants/2020/kernel_lambda_with_kernel_handler_arg.cpp
+++ b/SYCL/SpecConstants/2020/kernel_lambda_with_kernel_handler_arg.cpp
@@ -1,8 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-//
-// Hits an assert in the Lower Work Group Scope Code pass on AMD:
-// XFAIL: hip_amd
 
 // This test checks all possible scenarios of running single_task, parallel_for
 // and parallel_for_work_group to verify that this code compiles and runs

--- a/SYCL/SpecConstants/2020/non_native/aot_w_kernel_handler_wo_spec_consts.cpp
+++ b/SYCL/SpecConstants/2020/non_native/aot_w_kernel_handler_wo_spec_consts.cpp
@@ -1,8 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
-//
-// Hits an assert in the Lower Work Group Scope Code pass on AMD:
-// XFAIL: hip_amd
 
 // This test checks correctness of compiling and running of application with
 // kernel lambdas containing kernel_handler arguments and w/o usage of


### PR DESCRIPTION
This PR enables the tests `SpecConstants/2020/kernel_lambda_with_kernel_handler_arg.cpp` and `SpecConstants/2020/non_native/aot_w_kernel_handler_wo_spec_consts.cpp` for the HIP backend.

The change is dependent upon https://github.com/intel/llvm/pull/5006