### PR TITLE
fixed memory leak

### DIFF
--- a/SYCL/InorderQueue/in_order_event_release.cpp
+++ b/SYCL/InorderQueue/in_order_event_release.cpp
@@ -54,6 +54,7 @@ int main() {
       if (A[i] != 3)
         return 1;
     }
+    free(A, ctx);
   }
 
   return 0;


### PR DESCRIPTION
The test is missing a call to free() to avoid memory leak.

Signed-off-by: Byoungro So <byoungro.so@intel.com>