### PR TITLE
Fixed memory leak in prefetch.cpp

### DIFF
--- a/SYCL/InorderQueue/in_order_event_release.cpp
+++ b/SYCL/InorderQueue/in_order_event_release.cpp
@@ -54,6 +54,7 @@ int main() {
       if (A[i] != 3)
         return 1;
     }
+    free(A, ctx);
   }
 
   return 0;

--- a/SYCL/USM/prefetch.cpp
+++ b/SYCL/USM/prefetch.cpp
@@ -71,6 +71,8 @@ int main() {
         assert(dest[i] == i * 3);
       }
     }
+    free(src, q);
+    free(dest, q);
   }
   return 0;
 }


### PR DESCRIPTION
The test is missing a call to free() to avoid memory leak.