### PR TITLE
[SYCL][FPGA] Allow use of devicelib assert in two-step compilation tests due to workaround

### DIFF
--- a/SYCL/Basic/fpga_tests/fpga_aocx.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx.cpp
@@ -11,20 +11,16 @@
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image. To avoid appending objects to
 // leftover archives, remove one if exists.
-// FIXME Disabled use of devicelib by assert feature until the 2-step build gets
-// fixed. For the time being when 2-step build is employed and there's a call to
-// devicelib function from kernel, the binary image gets corrupted. Due to
-// fallback assert implementation adds a kernel with appropriate call, we have
-// it disabled for this test.
+
 // RUN: rm %t_image.a || true
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
+// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o
+// RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o
 
 // AOCX with source
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga %S/Inputs/fpga_host.cpp %t_image.a -o %t_aocx_src.out
+// RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp %t_image.a -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga %t.o %t_image.a -o %t_aocx_obj.out
+// RUN: %clangxx -fsycl -fintelfpga %t.o %t_image.a -o %t_aocx_obj.out
 //
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_src.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_obj.out

--- a/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -12,20 +12,16 @@
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image. To avoid appending objects to
 // leftover archives, remove one if exists.
-// FIXME Disabled use of devicelib by assert feature until the 2-step build gets
-// fixed. For the time being when 2-step build is employed and there's a call to
-// devicelib function from kernel, the binary image gets corrupted. Due to
-// fallback assert implementation adds a kernel with appropriate call, we have
-// it disabled for this test.
+
 // RUN: rm %t_image.a || true
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
+// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj
+// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj
 
 // AOCX with source
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
+// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
+// RUN: %clangxx -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
 //
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_src.out
 // RUN: %ACC_RUN_PLACEHOLDER %t_aocx_obj.out


### PR DESCRIPTION
Patch https://github.com/intel/llvm/pull/4893 turned off device code splitting
for FPGA target by default. That in turn unblocked using of functions from device
libraries on that target in two-step compilation scenario.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>