### PR TITLE
[SYCL] Temporary disable of DeviceLib tests

### DIFF
--- a/SYCL/DeviceLib/built-ins/vector_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_relational.cpp
@@ -1,4 +1,4 @@
-// FIXME unsupported on windows (opencl and level-zero) until fix of libdevice fails
+// FIXME unsupported on windows (opencl and level-zero) until fix of libdevice
 // UNSUPPORTED: windows && (opencl || level_zero)
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/built-ins/vector_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_relational.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: TEMPORARILY_DISABLED
+// FIXME unsupported on windows (opencl and level-zero) until fix of libdevice fails
+// UNSUPPORTED: windows && (opencl || level_zero)
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/built-ins/vector_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_relational.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: TEMPORARILY_DISABLED
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/cmath_fp64_test.cpp
+++ b/SYCL/DeviceLib/cmath_fp64_test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: TEMPORARILY_DISABLED
+// FIXME unsupported on windows (opencl) until fix of libdevice fails
+// UNSUPPORTED: windows && opencl
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/cmath_fp64_test.cpp
+++ b/SYCL/DeviceLib/cmath_fp64_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: TEMPORARILY_DISABLED
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/cmath_test.cpp
+++ b/SYCL/DeviceLib/cmath_test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: TEMPORARILY_DISABLED
+// FIXME unsupported on windows (opencl) until fix of libdevice fails
+// UNSUPPORTED: windows && opencl
 // RUN: %clangxx -fsycl -fno-builtin %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/cmath_test.cpp
+++ b/SYCL/DeviceLib/cmath_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: TEMPORARILY_DISABLED
 // RUN: %clangxx -fsycl -fno-builtin %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/math_fp64_test.cpp
+++ b/SYCL/DeviceLib/math_fp64_test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: TEMPORARILY_DISABLED
+// FIXME unsupported on windows (opencl) until fix of libdevice fails
+// UNSUPPORTED: windows && opencl
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/math_fp64_test.cpp
+++ b/SYCL/DeviceLib/math_fp64_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: TEMPORARILY_DISABLED
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/math_test.cpp
+++ b/SYCL/DeviceLib/math_test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: TEMPORARILY_DISABLED
+// FIXME unsupported on windows (opencl) until fix of libdevice fails
+// UNSUPPORTED: windows && opencl
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceLib/math_test.cpp
+++ b/SYCL/DeviceLib/math_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: TEMPORARILY_DISABLED
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Disabled tests: SYCL/DeviceLib/built-ins/vector_relational.cpp, SYCL/DeviceLib/cmath_fp64_test.cpp, SYCL/DeviceLib/cmath_test.cpp, SYCL/DeviceLib/math_fp64_test.cpp, SYCL/DeviceLib/math_test.cpp