### PR TITLE
[SYCL][HIP] Remove XFAIL for select.cpp test

### DIFF
--- a/SYCL/FilterSelector/select.cpp
+++ b/SYCL/FilterSelector/select.cpp
@@ -3,9 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t1.out
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // RUN: %ACC_RUN_PLACEHOLDER %t1.out
-//
-// Failing on HIP AMD
-// XFAIL: hip_amd
 
 //==------------------- select.cpp - filter_selector test ------------------==//
 //


### PR DESCRIPTION
This will be fixed in intel/llvm#5171