### PR TITLE
[SYCL][Matrix] test the two features: fill a matrix and element wise operations

### DIFF
--- a/SYCL/Matrix/element_wise_all_ops_half.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_half.cpp
@@ -1,0 +1,255 @@
+//==----------- element_wise_all_ops_half.cpp  - DPC++ joint_matrix---------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: matrix
+
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+#include <iostream>
+#include <random>
+
+using namespace sycl;
+using namespace sycl::ext::intel;
+using namespace sycl::ext::oneapi::experimental::matrix;
+
+#define SG_SZ 8
+
+#define TM 8
+#define TN SG_SZ
+#define TK 16
+
+template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
+public:
+  T *mat;
+
+public:
+  T *get_data() { return mat; }
+  void set_data(T *data) { mat = data; }
+  big_matrix(T *data) : mat(data) {}
+};
+
+template <typename T, size_t M, size_t N>
+void assert_ops_ref(/*const T &C*/ accessor<T, 2, access::mode::read,
+                                            access::target::host_buffer>
+                        C,
+                    const float ref) {
+  for (size_t i = 0; i < M; i++)
+    for (size_t j = 0; j < N; j++) {
+      auto diff = C[i][j] - ref;
+      assert(std::fabs(static_cast<float>(diff)) <
+             std::numeric_limits<float>::epsilon());
+    }
+}
+template <typename T, size_t M, size_t N>
+void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
+                       const float ref) {
+  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
+
+  q.submit([&](handler &cgh) {
+     auto accA = bufA.get_access<access::mode::read_write>(cgh);
+
+     cgh.parallel_for<class imatrix>(r, [accA](nd_item<2> spmd_item) {
+       const auto global_idx = spmd_item.get_global_id(0);
+       const auto global_idy = spmd_item.get_global_id(1);
+       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+
+       ext::oneapi::sub_group sg = spmd_item.get_sub_group();
+       joint_matrix<T, TM, TK> sub_a(sg);
+
+       joint_matrix_fill(sg, sub_a, 5.0);
+
+       auto wi_slice_a = sub_a.get_wi_data();
+       for (int i = 0; i < wi_slice_a.length(); i++) {
+         wi_slice_a[i] = wi_slice_a[i] + 2;
+       }
+       joint_matrix_store(sg, sub_a,
+                          accA.get_pointer() + (sg_startx * TM) * N +
+                              sg_starty / SG_SZ * TN,
+                          N, matrix_layout::row_major);
+     }); // parallel for
+   }).wait();
+  assert_ops_ref<T, M, N>(bufA.get_access<access::mode::read>(), ref);
+}
+
+template <typename T, size_t M, size_t N>
+void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
+                       const float ref) {
+  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
+
+  q.submit([&](handler &cgh) {
+     auto accA = bufA.get_access<access::mode::read_write>(cgh);
+
+     cgh.parallel_for<class imatrix>(r, [accA](nd_item<2> spmd_item) {
+       const auto global_idx = spmd_item.get_global_id(0);
+       const auto global_idy = spmd_item.get_global_id(1);
+       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+
+       ext::oneapi::sub_group sg = spmd_item.get_sub_group();
+       joint_matrix<T, TM, TK> sub_a(sg);
+
+       joint_matrix_fill(sg, sub_a, 5.0);
+
+       auto wi_slice_a = sub_a.get_wi_data();
+       for (int i = 0; i < wi_slice_a.length(); i++) {
+         wi_slice_a[i] = wi_slice_a[i] - 2;
+       }
+       joint_matrix_store(sg, sub_a,
+                          accA.get_pointer() + (sg_startx * TM) * N +
+                              sg_starty / SG_SZ * TN,
+                          N, matrix_layout::row_major);
+     }); // parallel for
+   }).wait();
+  assert_ops_ref<T, M, N>(bufA.get_access<access::mode::read>(), ref);
+}
+
+template <typename T, size_t M, size_t N>
+void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
+                       const float ref) {
+  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
+
+  q.submit([&](handler &cgh) {
+     auto accA = bufA.get_access<access::mode::read_write>(cgh);
+
+     cgh.parallel_for<class imatrix>(r, [accA](nd_item<2> spmd_item) {
+       const auto global_idx = spmd_item.get_global_id(0);
+       const auto global_idy = spmd_item.get_global_id(1);
+       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+
+       ext::oneapi::sub_group sg = spmd_item.get_sub_group();
+       joint_matrix<T, TM, TK> sub_a(sg);
+
+       joint_matrix_fill(sg, sub_a, 5.0);
+
+       auto wi_slice_a = sub_a.get_wi_data();
+       for (int i = 0; i < wi_slice_a.length(); i++) {
+         wi_slice_a[i] = wi_slice_a[i] * 3.0;
+       }
+       joint_matrix_store(sg, sub_a,
+                          accA.get_pointer() + (sg_startx * TM) * N +
+                              sg_starty / SG_SZ * TN,
+                          N, matrix_layout::row_major);
+     }); // parallel for
+   }).wait();
+  assert_ops_ref<T, M, N>(bufA.get_access<access::mode::read>(), ref);
+}
+
+template <typename T, size_t M, size_t N>
+void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
+                       const float ref) {
+  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
+
+  q.submit([&](handler &cgh) {
+     auto accA = bufA.get_access<access::mode::read_write>(cgh);
+
+     cgh.parallel_for<class imatrix>(r, [accA](nd_item<2> spmd_item) {
+       const auto global_idx = spmd_item.get_global_id(0);
+       const auto global_idy = spmd_item.get_global_id(1);
+       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+
+       ext::oneapi::sub_group sg = spmd_item.get_sub_group();
+       joint_matrix<T, TM, TK> sub_a(sg);
+
+       joint_matrix_fill(sg, sub_a, 4.0);
+
+       auto wi_slice_a = sub_a.get_wi_data();
+       for (int i = 0; i < wi_slice_a.length(); i++) {
+         wi_slice_a[i] = wi_slice_a[i] / 2.0;
+       }
+       joint_matrix_store(sg, sub_a,
+                          accA.get_pointer() + (sg_startx * TM) * N +
+                              sg_starty / SG_SZ * TN,
+                          N, matrix_layout::row_major);
+     }); // parallel for
+   }).wait();
+  assert_ops_ref<T, M, N>(bufA.get_access<access::mode::read>(), ref);
+}
+
+template <typename T, size_t M, size_t N>
+void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
+                         const float ref) {
+  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
+
+  q.submit([&](handler &cgh) {
+     auto accA = bufA.get_access<access::mode::read_write>(cgh);
+
+     cgh.parallel_for<class imatrix>(r, [accA](nd_item<2> spmd_item) {
+       const auto global_idx = spmd_item.get_global_id(0);
+       const auto global_idy = spmd_item.get_global_id(1);
+       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+
+       ext::oneapi::sub_group sg = spmd_item.get_sub_group();
+       joint_matrix<T, TM, TK> sub_a(sg);
+
+       joint_matrix_fill(sg, sub_a, 5.0);
+
+       auto wi_slice_a = sub_a.get_wi_data();
+       for (int i = 0; i < wi_slice_a.length(); i++) {
+         if (wi_slice_a[i]) {
+           if (wi_slice_a[i] > 2.0 || wi_slice_a[i] >= 2.0 ||
+               wi_slice_a[i] < 2.0 || wi_slice_a[i] <= 2.0) {
+             T val = (wi_slice_a[i] != 2.0) ? wi_slice_a[i] : 2.0;
+             val--;
+             val++;
+             if (wi_slice_a[i] == 2.0) {
+               val -= 2;
+               val *= 3.0;
+               val /= 2.0;
+             } else {
+               val += 2;
+             }
+             wi_slice_a[i] = val;
+           }
+         }
+       }
+       joint_matrix_store(sg, sub_a,
+                          accA.get_pointer() + (sg_startx * TM) * N +
+                              sg_starty / SG_SZ * TN,
+                          N, matrix_layout::row_major);
+     }); // parallel for
+   }).wait();
+  assert_ops_ref<T, M, N>(bufA.get_access<access::mode::read>(), ref);
+}
+
+static constexpr size_t MATRIX_M = TM * 2;
+static constexpr size_t MATRIX_N = TN * 2;
+half A[MATRIX_M][MATRIX_N];
+float D[MATRIX_M][MATRIX_N];
+
+void matrix_ops_ref(float *D, int M, int N) {
+  for (int m = 0; m < M; m++)
+    for (int n = 0; n < N; n++) {
+      *(D + m * N + n) = 0;
+      *(D + m * N + n) *= 2;
+    }
+}
+
+int main() {
+
+  big_matrix<float, MATRIX_M, MATRIX_N> MD((float *)&D);
+  big_matrix<half, MATRIX_M, MATRIX_N> MA((half *)&A);
+
+  size_t NDRangeM = MATRIX_M / TM;
+  size_t NDRangeN = MATRIX_N / TN;
+  queue q;
+  nd_range<2> r({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ});
+
+  matrix_verify_add<half, MATRIX_M, MATRIX_N>(q, MA, r, 7.0);
+  matrix_verify_sub<half, MATRIX_M, MATRIX_N>(q, MA, r, 3.0);
+  matrix_verify_mul<half, MATRIX_M, MATRIX_N>(q, MA, r, 15.0);
+  matrix_verify_div<half, MATRIX_M, MATRIX_N>(q, MA, r, 2.0);
+  matrix_verify_logic<half, MATRIX_M, MATRIX_N>(q, MA, r, 7.0);
+
+  return 0;
+}

--- a/SYCL/Matrix/element_wise_all_ops_half.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_half.cpp
@@ -11,6 +11,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// There is a known bug in joint_matrix_fill when type is half
+// A PR is being developed to fix the bug
+// Will remove the XFAIL once this is fixed
+// XFAIL: *
+
 #include <CL/sycl.hpp>
 #include <iostream>
 #include <random>

--- a/SYCL/Matrix/element_wise_ops.cpp
+++ b/SYCL/Matrix/element_wise_ops.cpp
@@ -95,10 +95,10 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                                    sg_starty / SG_SZ * TN * 4,
                                N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
-             auto wi_slice_c = sub_c.get_wi_data();
-             for (int i = 0; i < wi_slice_c.length(); i++) {
-               wi_slice_c[i] *= 2;
-             }
+           }
+           auto wi_slice_c = sub_c.get_wi_data();
+           for (int i = 0; i < wi_slice_c.length(); i++) {
+             wi_slice_c[i] *= 2;
            }
            joint_matrix_store(sg, sub_c,
                               accC.get_pointer() + (sg_startx * TM) * N +
@@ -130,6 +130,7 @@ void matrix_multiply_ref(int32_t *A_mem, int32_t *B_mem, int32_t *C_mem, int M,
         }
         *(C_mem + m * N + n) = acc;
       }
+      *(C_mem + m * N + n) *= 2;
     }
 }
 

--- a/SYCL/Matrix/element_wise_ops.cpp
+++ b/SYCL/Matrix/element_wise_ops.cpp
@@ -1,4 +1,4 @@
-//==-------- joint_matrix_ss_int8.cpp  - DPC++ joint_matrix------------ ----==//
+//==----------- element_wise_ops.cpp  - DPC++ joint_matrix------------- ----==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -59,8 +59,9 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
      cgh.parallel_for<class imatrix>(
          nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [ accA, accB, accC, M, N,
-           K ](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+         [accA, accB, accC, M, N, K](nd_item<2> spmd_item)
+
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -78,7 +79,12 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix<int8_t, TK, TN, matrix_layout::packed_b> sub_b(sg);
            joint_matrix<int32_t, TM, TN> sub_c(sg);
 
-           joint_matrix_fill(sg, sub_c, 0);
+           // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
+           // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
+           joint_matrix_load(sg, sub_c,
+                             accC.get_pointer() + (sg_startx * TM) * N +
+                                 sg_starty / SG_SZ * TN,
+                             N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
                  sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
@@ -89,6 +95,10 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                                    sg_starty / SG_SZ * TN * 4,
                                N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
+             auto wi_slice_c = sub_c.get_wi_data();
+             for (int i = 0; i < wi_slice_c.length(); i++) {
+               wi_slice_c[i] *= 2;
+             }
            }
            joint_matrix_store(sg, sub_c,
                               accC.get_pointer() + (sg_startx * TM) * N +
@@ -136,8 +146,8 @@ int main() {
   }
   for (int i = 0; i < MATRIX_M; i++) {
     for (int j = 0; j < MATRIX_N; j++) {
-      C[i][j] = 0;
-      D[i][j] = 0;
+      C[i][j] = 1;
+      D[i][j] = 1;
     }
   }
 

--- a/SYCL/Matrix/joint_matrix_ss_int8.cpp
+++ b/SYCL/Matrix/joint_matrix_ss_int8.cpp
@@ -11,6 +11,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+//Two patches are not merged yet causing this test to fail
+//Will remove the XFAIL once these pacthes are merged
 // XFAIL: *
 
 #include <CL/sycl.hpp>

--- a/SYCL/Matrix/joint_matrix_ss_int8.cpp
+++ b/SYCL/Matrix/joint_matrix_ss_int8.cpp
@@ -11,6 +11,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// XFAIL: *
+
 #include <CL/sycl.hpp>
 #include <iostream>
 

--- a/SYCL/Matrix/joint_matrix_ss_int8.cpp
+++ b/SYCL/Matrix/joint_matrix_ss_int8.cpp
@@ -11,8 +11,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-//Two patches are not merged yet causing this test to fail
-//Will remove the XFAIL once these pacthes are merged
+// Two patches are not merged yet causing this test to fail
+// Will remove the XFAIL once these pacthes are merged
 // XFAIL: *
 
 #include <CL/sycl.hpp>


### PR DESCRIPTION
Two new matrix features are being added to the DPC++ compiler namely: fill a matrix and element wise operations. This PR adds tests for these two features.


Signed-off-by: Dounia Khaldi <dounia.khaldi@intel.com>