### PR TITLE
[SYCL] Disable Basic/get_backend test

### DIFF
--- a/SYCL/Basic/get_backend.cpp
+++ b/SYCL/Basic/get_backend.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: TEMPORARY_DISABLED
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_FILTER=%sycl_be %t.out
 //


### PR DESCRIPTION
Disable Basic/get_backend test due to sporadic failures in prs:
https://github.com/intel/llvm/pull/5191
https://github.com/intel/llvm/pull/5121