### PR TITLE
Disable Matrix/joint_matrix_tensorcore_double.cpp

### DIFF
--- a/SYCL/Matrix/joint_matrix_tensorcore_double.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore_double.cpp
@@ -1,7 +1,5 @@
-// REQUIRES: gpu, cuda
-
-// The test is marked as expected to fail due to devil's issue #666
-// XFAIL:*
+// The test is disabled to devil's issue #666
+// REQUIRES: gpu, cuda, TEMPORARY_DISABLED
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3  %s -o %t.out
 //

--- a/SYCL/Matrix/joint_matrix_tensorcore_double.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore_double.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: gpu, cuda
 
+// The test is marked as expected to fail due to devil's issue #666
+// XFAIL:*
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3  %s -o %t.out
 //
 // Specifying the sm version via the --cuda-gpu-arch flag is necessary


### PR DESCRIPTION
This should fix llvm-test-suite validation status on CUDA.