### PR TITLE
[SYCL][Matrix] remove XFAIL as the bug was fixed

### DIFF
--- a/SYCL/Matrix/joint_matrix_ss_int8.cpp
+++ b/SYCL/Matrix/joint_matrix_ss_int8.cpp
@@ -11,10 +11,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// Two patches are not merged yet causing this test to fail
-// Will remove the XFAIL once these pacthes are merged
-// XFAIL: *
-
 #include <CL/sycl.hpp>
 #include <iostream>
 


### PR DESCRIPTION
The bug causing the fill instruction to fail has been fixed: https://github.com/intel/llvm/pull/5277