### PR TITLE
Ignore changes in build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # External/*
 /test-suite-externals
 *.pyc
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 # External/*
 /test-suite-externals
 *.pyc
-/build
+/build*


### PR DESCRIPTION
Ignore changes(files) in user-created llvm-test-suite/build dir, because they are machine-generated and should not be committed.