### PR TITLE
[SYCL] Disable Basic/image/image_accessor_readsampler.cpp

### DIFF
--- a/SYCL/Basic/image/image_accessor_readsampler.cpp
+++ b/SYCL/Basic/image/image_accessor_readsampler.cpp
@@ -1,4 +1,5 @@
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: cuda || hip || (windows && level_zero)
+// unsupported on windows (level-zero) due to fail of Jenkins/pre-ci-windows
 // CUDA cannot support SYCL 1.2.1 images.
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out


### PR DESCRIPTION
Disable Basic/image/image_accessor_readsampler.cpp due to fails of Jenkins/pre-ci-windows 31.01.2022