### PR TITLE
[SYCL][ESIMD] Replace "dim", "dimensions" with "size", "sizes", etc.

### DIFF
--- a/SYCL/ESIMD/api/functional/ctors/ctor_array.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_array.hpp
@@ -91,8 +91,8 @@ private:
 
 // The main test routine.
 // Using functor class to be able to iterate over the pre-defined data types.
-template <typename DataT, typename DimT, typename TestCaseT> class run_test {
-  static constexpr int NumElems = DimT::value;
+template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
+  static constexpr int NumElems = SizeT::value;
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {

--- a/SYCL/ESIMD/api/functional/ctors/ctor_array_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_array_core.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd constructor from an array.
-// This test uses different data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses different data types, sizes and different simd constructor
+// invocation contexts.
 // The test does the following actions:
 //  - construct fixed-size array that filled with reference values
 //  - use std::move() to provide it to simd constructor
@@ -33,12 +33,13 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::core>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_array_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_array_fp_extra.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd constructor from an array.
-// This test uses extra fp data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses extra fp data types, sizes and different simd constructor
+// invocation contexts.
 // The test does the following actions:
 //  - construct fixed-size array that filled with reference values
 //  - use std::move() to provide it to simd constructor
@@ -33,12 +33,13 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::fp_extra>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_copy.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_copy.hpp
@@ -88,8 +88,8 @@ private:
 
 // The main test routine.
 // Using functor class to be able to iterate over the pre-defined data types.
-template <typename DataT, typename DimT, typename TestCaseT> class run_test {
-  static constexpr int NumElems = DimT::value;
+template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
+  static constexpr int NumElems = SizeT::value;
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {

--- a/SYCL/ESIMD/api/functional/ctors/ctor_copy_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_copy_core.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd copy constructor.
-// This test uses different data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses different data types, sizes and different simd constructor
+// invocation contexts.
 // The test do the following actions:
 //  - construct simd object with golden values calls copy constructor from
 //    constructed simd object
@@ -33,12 +33,13 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::core>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_copy_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_copy_fp_extra.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd copy constructor.
-// This test uses extra fp data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses different data types, sizes and different simd constructor
+// invocation contexts.
 // The test do the following actions:
 //  - construct simd object with golden values calls copy constructor from
 //    constructed simd object
@@ -33,12 +33,13 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::fp_extra>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
@@ -76,8 +76,8 @@ struct const_ref {
 };
 
 // Struct that calls simd in provided context and then verifies obtained result.
-template <typename DataT, typename DimT, typename TestCaseT> struct run_test {
-  static constexpr int NumElems = DimT::value;
+template <typename DataT, typename SizeT, typename TestCaseT> struct run_test {
+  static constexpr int NumElems = SizeT::value;
 
   bool operator()(sycl::queue &queue, const std::string &data_type) {
     bool passed = true;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default_core.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd default constructor.
-// This test uses different data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses different data types, sizes and different simd constructor
+// invocation contexts.
 // The test do the following actions:
 //  - call simd default constructor
 //  - verify that values from simd is equal to default value of provided
@@ -33,12 +33,13 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::core>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default_fp_extra.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd default constructor.
-// This test uses extra fp data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses different data types, sizes and different simd constructor
+// invocation contexts.
 // The test do the following actions:
 //  - call simd default constructor
 //  - verify that values from simd is equal to default value of provided
@@ -33,12 +33,13 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::fp_extra>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
@@ -195,10 +195,10 @@ template <init_val... Values> auto get_init_values_pack() {
   return value_pack<init_val, Values...>::generate_unnamed();
 }
 
-template <typename DataT, typename DimT, typename TestCaseT, typename BaseValT,
+template <typename DataT, typename SizeT, typename TestCaseT, typename BaseValT,
           typename StepT>
 class run_test {
-  static constexpr int NumElems = DimT::value;
+  static constexpr int NumElems = SizeT::value;
   static constexpr init_val BaseVal = BaseValT::value;
   static constexpr init_val Step = StepT::value;
   using KernelT = kernel_for_fill<DataT, NumElems, TestCaseT, BaseVal, Step>;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
@@ -35,10 +35,10 @@ int main(int, char **) {
 
   bool passed = true;
 
-  // Using single dimension and context to verify the accuracy of operations
+  // Using single size and context to verify the accuracy of operations
   // with floating point data types
   const auto types = get_tested_types<tested_types::fp>();
-  const auto single_dim = get_dimensions<8>();
+  const auto single_size = get_sizes<8>();
   const auto context = unnamed_type_pack<ctors::var_decl>::generate();
 
 // Run for specific combinations of types, base and step values and vector
@@ -48,7 +48,7 @@ int main(int, char **) {
     const auto base_values = ctors::get_init_values_pack<init_val::denorm>();
     const auto step_values = ctors::get_init_values_pack<init_val::ulp>();
     passed &= for_all_combinations<ctors::run_test>(
-        types, single_dim, context, base_values, step_values, queue);
+        types, single_size, context, base_values, step_values, queue);
   }
 #endif
   {
@@ -57,7 +57,7 @@ int main(int, char **) {
     const auto step_values =
         ctors::get_init_values_pack<init_val::ulp, init_val::ulp_half>();
     passed &= for_all_combinations<ctors::run_test>(
-        types, single_dim, context, base_values, step_values, queue);
+        types, single_size, context, base_values, step_values, queue);
   }
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
@@ -35,7 +35,7 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::fp_extra>();
-  const auto single_dim = get_dimensions<8>();
+  const auto single_size = get_sizes<8>();
   const auto context = unnamed_type_pack<ctors::var_decl>::generate();
 // Run for specific combinations of types, base and step values and vector
 // length.
@@ -48,7 +48,7 @@ int main(int, char **) {
     const auto step_values =
         ctors::get_init_values_pack<ctors::init_val::ulp>();
     passed &= for_all_combinations<ctors::run_test>(
-        types, single_dim, context, base_values, step_values, queue);
+        types, single_size, context, base_values, step_values, queue);
   }
 #endif
   {
@@ -59,7 +59,7 @@ int main(int, char **) {
         ctors::get_init_values_pack<ctors::init_val::ulp,
                                     ctors::init_val::ulp_half>();
     passed &= for_all_combinations<ctors::run_test>(
-        types, single_dim, context, base_values, step_values, queue);
+        types, single_size, context, base_values, step_values, queue);
   }
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -15,7 +15,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd fill constructor for core types.
-// This test uses different data types, dimensionality, base and step values and
+// This test uses different data types, sizes, base and step values and
 // different simd constructor invocation contexts. The test do the following
 // actions:
 //  - construct simd with pre-defined base and step value
@@ -38,7 +38,7 @@ int main(int, char **) {
   {
     // Validate basic functionality works for every invocation context
     const auto types = named_type_pack<char, int>::generate("char", "int");
-    const auto dims = get_dimensions<1, 8>();
+    const auto sizes = get_sizes<1, 8>();
     const auto contexts =
         unnamed_type_pack<ctors::initializer, ctors::var_decl,
                           ctors::rval_in_expr, ctors::const_ref>::generate();
@@ -47,7 +47,7 @@ int main(int, char **) {
           ctors::get_init_values_pack<init_val::min_half>();
       const auto step_values = ctors::get_init_values_pack<init_val::zero>();
       passed &= for_all_combinations<ctors::run_test>(
-          types, dims, contexts, base_values, step_values, queue);
+          types, sizes, contexts, base_values, step_values, queue);
     }
     {
       const auto base_values =
@@ -55,20 +55,20 @@ int main(int, char **) {
       const auto step_values =
           ctors::get_init_values_pack<init_val::positive>();
       passed &= for_all_combinations<ctors::run_test>(
-          types, dims, contexts, base_values, step_values, queue);
+          types, sizes, contexts, base_values, step_values, queue);
     }
   }
   {
     // Validate basic functionality works for every type
     const auto types = get_tested_types<tested_types::core>();
-    const auto dims = get_all_dimensions();
+    const auto sizes = get_all_sizes();
     const auto contexts = unnamed_type_pack<ctors::var_decl>::generate();
     {
       const auto base_values =
           ctors::get_init_values_pack<init_val::min, init_val::max_half>();
       const auto step_values = ctors::get_init_values_pack<init_val::zero>();
       passed &= for_all_combinations<ctors::run_test>(
-          types, dims, contexts, base_values, step_values, queue);
+          types, sizes, contexts, base_values, step_values, queue);
     }
     {
       const auto base_values =
@@ -76,12 +76,12 @@ int main(int, char **) {
       const auto step_values =
           ctors::get_init_values_pack<init_val::positive, init_val::negative>();
       passed &= for_all_combinations<ctors::run_test>(
-          types, dims, contexts, base_values, step_values, queue);
+          types, sizes, contexts, base_values, step_values, queue);
     }
   }
   {
     // Verify specific cases for different type groups
-    const auto dims = get_dimensions<8>();
+    const auto sizes = get_sizes<8>();
     const auto contexts = unnamed_type_pack<ctors::var_decl>::generate();
     {
       const auto types = get_tested_types<tested_types::uint>();
@@ -92,7 +92,7 @@ int main(int, char **) {
             ctors::get_init_values_pack<init_val::positive,
                                         init_val::negative>();
         passed &= for_all_combinations<ctors::run_test>(
-            types, dims, contexts, base_values, step_values, queue);
+            types, sizes, contexts, base_values, step_values, queue);
       }
     }
     {
@@ -102,14 +102,14 @@ int main(int, char **) {
         const auto step_values =
             ctors::get_init_values_pack<init_val::positive>();
         passed &= for_all_combinations<ctors::run_test>(
-            types, dims, contexts, base_values, step_values, queue);
+            types, sizes, contexts, base_values, step_values, queue);
       }
       {
         const auto base_values = ctors::get_init_values_pack<init_val::max>();
         const auto step_values =
             ctors::get_init_values_pack<init_val::negative>();
         passed &= for_all_combinations<ctors::run_test>(
-            types, dims, contexts, base_values, step_values, queue);
+            types, sizes, contexts, base_values, step_values, queue);
       }
     }
     {
@@ -119,28 +119,28 @@ int main(int, char **) {
             ctors::get_init_values_pack<init_val::neg_inf>();
         const auto step_values = ctors::get_init_values_pack<init_val::max>();
         passed &= for_all_combinations<ctors::run_test>(
-            types, dims, contexts, base_values, step_values, queue);
+            types, sizes, contexts, base_values, step_values, queue);
       }
       {
         const auto base_values = ctors::get_init_values_pack<init_val::max>();
         const auto step_values =
             ctors::get_init_values_pack<init_val::neg_inf>();
         passed &= for_all_combinations<ctors::run_test>(
-            types, dims, contexts, base_values, step_values, queue);
+            types, sizes, contexts, base_values, step_values, queue);
       }
       {
         const auto base_values = ctors::get_init_values_pack<init_val::nan>();
         const auto step_values =
             ctors::get_init_values_pack<init_val::negative>();
         passed &= for_all_combinations<ctors::run_test>(
-            types, dims, contexts, base_values, step_values, queue);
+            types, sizes, contexts, base_values, step_values, queue);
       }
       {
         const auto base_values =
             ctors::get_init_values_pack<init_val::negative>();
         const auto step_values = ctors::get_init_values_pack<init_val::nan>();
         passed &= for_all_combinations<ctors::run_test>(
-            types, dims, contexts, base_values, step_values, queue);
+            types, sizes, contexts, base_values, step_values, queue);
       }
     }
   }

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd fill constructor for extra fp types.
-// This test uses extra fp data types with different dimensionality, base and
-// step values and different simd constructor invocation contexts.
+// This test uses extra fp data types with different sizes, base and step values
+// and different simd constructor invocation contexts.
 // The test do the following actions:
 //  - construct simd with pre-defined base and step value
 //  - bitwise comparing expected and retrieved values
@@ -32,23 +32,23 @@ int main(int, char **) {
   bool passed = true;
 
   const auto fp_types = get_tested_types<tested_types::fp_extra>();
-  const auto single_dim = get_dimensions<8>();
+  const auto single_size = get_sizes<8>();
   const auto contexts = unnamed_type_pack<ctors::var_decl>::generate();
 
   passed &= for_all_combinations<ctors::run_test>(
-      fp_types, single_dim, contexts,
+      fp_types, single_size, contexts,
       ctors::get_init_values_pack<ctors::init_val::neg_inf>(),
       ctors::get_init_values_pack<ctors::init_val::zero>(), queue);
   passed &= for_all_combinations<ctors::run_test>(
-      fp_types, single_dim, contexts,
+      fp_types, single_size, contexts,
       ctors::get_init_values_pack<ctors::init_val::max>(),
       ctors::get_init_values_pack<ctors::init_val::neg_inf>(), queue);
   passed &= for_all_combinations<ctors::run_test>(
-      fp_types, single_dim, contexts,
+      fp_types, single_size, contexts,
       ctors::get_init_values_pack<ctors::init_val::nan>(),
       ctors::get_init_values_pack<ctors::init_val::negative>(), queue);
   passed &= for_all_combinations<ctors::run_test>(
-      fp_types, single_dim, contexts,
+      fp_types, single_size, contexts,
       ctors::get_init_values_pack<ctors::init_val::zero>(),
       ctors::get_init_values_pack<ctors::init_val::nan>(), queue);
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
@@ -122,10 +122,10 @@ struct overal {
 
 // The main test routine.
 // Using functor class to be able to iterate over the pre-defined data types.
-template <typename DataT, typename DimT, typename TestCaseT,
+template <typename DataT, typename SizeT, typename TestCaseT,
           typename AlignmentT>
 class run_test {
-  static constexpr int NumElems = DimT::value;
+  static constexpr int NumElems = SizeT::value;
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
@@ -217,7 +217,7 @@ int main(int, char **) {
 
   bool passed = true;
   const auto types = get_tested_types<tested_types::core>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
 
   const auto contexts = unnamed_type_pack<initializer, var_decl, rval_in_expr,
                                           const_ref>::generate();
@@ -226,7 +226,7 @@ int main(int, char **) {
                         alignment::overal>::generate();
 
   passed &=
-      for_all_combinations<run_test>(types, dims, contexts, alignments, queue);
+      for_all_combinations<run_test>(types, sizes, contexts, alignments, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_move.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_move.hpp
@@ -83,8 +83,8 @@ public:
 // The core test functionality.
 // Runs a TestCaseT, specific for each C++ context, for a simd<DataT,NumElems>
 // instance
-template <typename DataT, typename DimT, typename TestCaseT> class run_test {
-  static constexpr int NumElems = DimT::value;
+template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
+  static constexpr int NumElems = SizeT::value;
   using KernelName = ctors::Kernel<DataT, NumElems, TestCaseT>;
 
 public:

--- a/SYCL/ESIMD/api/functional/ctors/ctor_move_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_move_core.cpp
@@ -37,7 +37,7 @@ using namespace esimd_test::api::functional;
 int main(int, char **) {
   bool passed = true;
   const auto types = get_tested_types<tested_types::fp_extra>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
@@ -46,7 +46,8 @@ int main(int, char **) {
                     esimd_test::createExceptionHandler());
 
   // Run test for all combinations possible
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_move_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_move_fp_extra.cpp
@@ -31,7 +31,7 @@ using namespace esimd_test::api::functional;
 int main(int, char **) {
   bool passed = true;
   const auto types = get_tested_types<tested_types::fp_extra>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
@@ -40,7 +40,8 @@ int main(int, char **) {
                     esimd_test::createExceptionHandler());
 
   // Run test for all combinations possible
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_vector.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_vector.hpp
@@ -83,8 +83,8 @@ private:
 
 // The main test routine.
 // Using functor class to be able to iterate over the pre-defined data types.
-template <typename DataT, typename DimT, typename TestCaseT> class run_test {
-  static constexpr int NumElems = DimT::value;
+template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
+  static constexpr int NumElems = SizeT::value;
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {

--- a/SYCL/ESIMD/api/functional/ctors/ctor_vector_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_vector_core.cpp
@@ -15,8 +15,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd constructor from vector.
-// This test uses different data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses different data types, sizes and different simd constructor
+// invocation contexts.
 // The test do the following actions:
 //  - call init_simd.data() to retreive vector_type and then provide it to the
 //    simd constructor
@@ -42,13 +42,14 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::core>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
   // Run test for all combinations possible
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/ctors/ctor_vector_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_vector_fp_extra.cpp
@@ -11,17 +11,12 @@
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in
 // "XREQUIRES".
 // UNSUPPORTED: cuda, hip
-// XRUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
-// XRUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: false
-// XFAIL: *
-// TODO The simd can't be constructed with sycl::half data type. The issue was
-// created (https://github.com/intel/llvm/issues/5077) and the test must be
-// enabled when it is resolved.
+// RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
 // Test for simd constructor from vector.
-// This test uses extra fp data types, dimensionality and different simd
-// constructor invocation contexts.
+// This test uses different data types, sizes and different simd constructor
+// invocation contexts.
 // The test do the following actions:
 //  - call init_simd.data() to retreive vector_type and then provide it to the
 //    simd constructor
@@ -38,13 +33,14 @@ int main(int, char **) {
   bool passed = true;
 
   const auto types = get_tested_types<tested_types::fp_extra>();
-  const auto dims = get_all_dimensions();
+  const auto sizes = get_all_sizes();
   const auto contexts =
       unnamed_type_pack<ctors::initializer, ctors::var_decl,
                         ctors::rval_in_expr, ctors::const_ref>::generate();
 
   // Run test for all combinations possible
-  passed &= for_all_combinations<ctors::run_test>(types, dims, contexts, queue);
+  passed &=
+      for_all_combinations<ctors::run_test>(types, sizes, contexts, queue);
 
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;

--- a/SYCL/ESIMD/api/functional/type_coverage.hpp
+++ b/SYCL/ESIMD/api/functional/type_coverage.hpp
@@ -292,13 +292,13 @@ template <int... Values> auto inline get_sizes() {
 auto inline get_all_sizes() { return get_sizes<1, 8, 16, 32>(); }
 
 // It's a deprecated function and it exists only for backward compatibility and
-// it should be deleted in the future.
+// it should be deleted in the future. Use get_all_sizes() instead.
 auto inline get_all_dimensions() { return get_all_sizes(); }
 
 // It's a deprecated function and it exists only for backward compatibility and
-// it should be deleted in the future.
+// it should be deleted in the future. Use get_sizes() instead.
 template <int... Values> auto inline get_dimensions() {
-  return integer_pack<Values...>::generate_unnamed();
+  return get_sizes<Values...>();
 }
 
 } // namespace esimd_test::api::functional

--- a/SYCL/ESIMD/api/functional/type_coverage.hpp
+++ b/SYCL/ESIMD/api/functional/type_coverage.hpp
@@ -133,7 +133,7 @@ template <typename T, T... values> struct value_pack {
   }
 };
 
-// Alias to use mainly for simd vector dimensions; no overhead as alias doesn't
+// Alias to use mainly for simd vector sizes; no overhead as alias doesn't
 // declare a new type
 template <int... values> using integer_pack = value_pack<int, values...>;
 
@@ -282,13 +282,23 @@ template <tested_types required> auto get_tested_types() {
   }
 }
 
-// Syntax sugar to retrieve simd vector dimensions in a consistent way
-template <int... Values> auto inline get_dimensions() {
+// Syntax sugar to retrieve simd vector sizes in a consistent way
+template <int... Values> auto inline get_sizes() {
   return integer_pack<Values...>::generate_unnamed();
 }
 
 // Factory method to retrieve pre-defined values_pack, to have the same
-// default dimensions over the tests
-auto inline get_all_dimensions() { return get_dimensions<1, 8, 16, 32>(); }
+// default sizes over the tests
+auto inline get_all_sizes() { return get_sizes<1, 8, 16, 32>(); }
+
+// It's a deprecated function and it exists only for backward compatibility and
+// it should be deleted in the future.
+auto inline get_all_dimensions() { return get_all_sizes(); }
+
+// It's a deprecated function and it exists only for backward compatibility and
+// it should be deleted in the future.
+template <int... Values> auto inline get_dimensions() {
+  return integer_pack<Values...>::generate_unnamed();
+}
 
 } // namespace esimd_test::api::functional


### PR DESCRIPTION
There is no changes in the tests logic.
There are just changes that are related to replacing "dim" with "size".
Also older `get_dimensions` and `get_all_dimensions` are not deleted yet, they saved for the backward compatibility and will be deleted later.