### PR TITLE
[SYCL] Enable level-zero-link-flags and fix kernel_bundle_api

### DIFF
--- a/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
+++ b/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
@@ -1,8 +1,7 @@
-// Disable fallback assert here until online-support is fixed.
 // Use of per-kernel device code split and linking the bundle with all images
 // involved leads to multiple definition of AssertHappened structure due each
 // device image is statically linked against fallback libdevice.
-// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 //
 // -fsycl-device-code-split is not supported for cuda

--- a/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
+++ b/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
@@ -1,7 +1,7 @@
 // Use of per-kernel device code split and linking the bundle with all images
 // involved leads to multiple definition of AssertHappened structure due each
 // device image is statically linked against fallback libdevice.
-// RUN: %clangxx -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT=1 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 //
 // -fsycl-device-code-split is not supported for cuda

--- a/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
+++ b/SYCL/Basic/kernel_bundle/kernel_bundle_api.cpp
@@ -185,7 +185,7 @@ int main() {
     // CHECK-NEXT: <unknown> : {{.*}}
     // CHECK-NEXT: <unknown> : {{.*}}
     // CHECK-NEXT: <unknown> : {{.*}}
-    // CHECK-NEXT: <nullptr>
+    // CHECK-NEXT: <const char *>:
     // CHECK-NEXT: <unknown> : {{.*}}
     // CHECK-NEXT: <unknown> : {{.*}}
     // CHECK-NEXT: <nullptr>

--- a/SYCL/KernelAndProgram/level-zero-link-flags.cpp
+++ b/SYCL/KernelAndProgram/level-zero-link-flags.cpp
@@ -1,15 +1,6 @@
 // RUN: %clangxx -fsycl -Xsycl-target-linker=spir64 -foo %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // REQUIRES: level_zero
-//
-// This test is disabled because the runtime does not currently pass linker
-// flags from "-Xsycl-target-linker=spir64 <opts>" when the program calls
-// "sycl::link()".  This seems like a bug.  Note that the runtime does pass
-// those "<opts>" to the online linker in other cases when it links device
-// code.
-//
-// XFAIL: level_zero
-//
 //==--- level-zero-link-flags.cpp - Error handling for link flags --==//
 //
 // The Level Zero backend does not accept any online linker options.


### PR DESCRIPTION
This patch enabling KernelAndProgram/level-zero-link-flags.cpp due to https://github.com/intel/llvm/pull/5476