### PR TITLE
[SYCL][FPGA][NFC] Change AOT tool requirement for FPGA emulator

### DIFF
--- a/SYCL/AOT/accelerator.cpp
+++ b/SYCL/AOT/accelerator.cpp
@@ -1,4 +1,4 @@
-//==--- accelerator.cpp - AOT compilation for fpga devices using aoc ------==//
+//=-- accelerator.cpp - compilation for fpga emulator dev using opencl-aot --=//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===---------------------------------------------------------------------===//
 
-// REQUIRES: aoc, accelerator
+// REQUIRES: opencl-aot, accelerator
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga %S/Inputs/aot.cpp -o %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/AOT/multiple-devices.cpp
+++ b/SYCL/AOT/multiple-devices.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: opencl-aot, ocloc, aoc, cpu, gpu, accelerator
+// REQUIRES: opencl-aot, ocloc, cpu, gpu, accelerator
 // UNSUPPORTED: cuda
 // CUDA is not compatible with SPIR.
 

--- a/SYCL/Basic/context-with-multiple-devices.cpp
+++ b/SYCL/Basic/context-with-multiple-devices.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: accelerator, aoc
+// REQUIRES: accelerator, opencl-aot
 
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-unnamed-lambda %s -o %t2.out
 // RUN: env CL_CONFIG_CPU_EMULATE_DEVICES=2 %t2.out

--- a/SYCL/Basic/fpga_tests/fpga_aocx.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx.cpp
@@ -1,4 +1,4 @@
-//==----- fpga_aocx.cpp - AOT compilation for fpga using aoc with aocx -----==//
+//==---- fpga_aocx.cpp - AOT compilation for fpga emulator dev with aocx ---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aoc, accelerator
+// REQUIRES: opencl-aot, accelerator
 
 /// E2E test for AOCX creation/use/run for FPGA
 // Produce an archive with device (AOCX) image. To avoid appending objects to

--- a/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -1,4 +1,4 @@
-//==--- fpga_aocx_win.cpp - AOT compilation for fpga using aoc with aocx ---==//
+//==- fpga_aocx_win.cpp - AOT compilation for fpga emulator dev with aocx --==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: aoc, accelerator
+// REQUIRES: opencl-aot, accelerator
 // REQUIRES: system-windows
 
 /// E2E test for AOCX creation/use/run for FPGA

--- a/SYCL/Basic/fpga_tests/fpga_dsp_control.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_dsp_control.cpp
@@ -1,6 +1,3 @@
-// REQUIRES: accelerator, aoc
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==---------- fpga_dsp_control.cpp - SYCL FPGA DSP control test -----------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -8,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// REQUIRES: accelerator, opencl-aot
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 

--- a/SYCL/Basic/fpga_tests/fpga_latency_control_lsu.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_latency_control_lsu.cpp
@@ -1,6 +1,3 @@
-// REQUIRES: aoc, accelerator
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==- fpga_latency_control_lsu.cpp - SYCL FPGA latency control on LSU test -==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -8,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// REQUIRES: opencl-aot, accelerator
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 

--- a/SYCL/Basic/fpga_tests/fpga_latency_control_pipe.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_latency_control_pipe.cpp
@@ -1,6 +1,3 @@
-// REQUIRES: aoc, accelerator
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 //== fpga_latency_control_pipe.cpp - SYCL FPGA latency control on pipe test ==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -8,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// REQUIRES: opencl-aot, accelerator
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 

--- a/SYCL/Basic/fpga_tests/fpga_lsu.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_lsu.cpp
@@ -1,12 +1,14 @@
-// REQUIRES: accelerator, aoc
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
 //==----------------- fpga_lsu.cpp - SYCL FPGA LSU test --------------------==//
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// REQUIRES: accelerator, opencl-aot
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/fpga_extensions.hpp>
 

--- a/SYCL/Basic/fpga_tests/global_fpga_device_selector.cpp
+++ b/SYCL/Basic/fpga_tests/global_fpga_device_selector.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aoc, accelerator
+// REQUIRES: opencl-aot, accelerator
 
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/DeviceCodeSplit/aot-accelerator.cpp
+++ b/SYCL/DeviceCodeSplit/aot-accelerator.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aoc, accelerator
+// REQUIRES: opencl-aot, accelerator
 
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_fpga -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp \
 // RUN: -fsycl-dead-args-optimization

--- a/SYCL/DeviceLib/complex-fpga.cpp
+++ b/SYCL/DeviceLib/complex-fpga.cpp
@@ -1,4 +1,4 @@
-//==----- accelerator.cpp - AOT compilation for fpga devices using aoc  ----==//
+//==----- accelerator.cpp - AOT compilation for fpga emulator devices  -----==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===------------------------------------------------------------------------===//
 // UNSUPPORTED: windows
-// REQUIRES: aoc, accelerator
+// REQUIRES: opencl-aot, accelerator
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga %S/std_complex_math_test.cpp -o %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/README.md
+++ b/SYCL/README.md
@@ -146,7 +146,7 @@ unavailable.
  * **cl_options** - CL command line options recognized (or not) by compiler;
  * **opencl_icd** - OpenCL ICD loader availability;
  * **aot_tool** - Ahead-of-time compilation tools availability;
- * **aoc**, **ocloc**, **opencl-aot** - Specific AOT tool availability;
+ * **ocloc**, **opencl-aot** - Specific AOT tool availability;
  * **level_zero_dev_kit** - Level_Zero headers and libraries availability;
  * **gpu-intel-dg1** - Intel GPU DG1 availability;
  * **dump_ir**: - compiler can / cannot dump IR;

--- a/SYCL/SpecConstants/2020/non_native/accelerator.cpp
+++ b/SYCL/SpecConstants/2020/non_native/accelerator.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aoc, accelerator
+// REQUIRES: opencl-aot, accelerator
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga %S/Inputs/common.cpp -o %t.out \
 // RUN:          -fsycl-dead-args-optimization

--- a/SYCL/lit.cfg.py
+++ b/SYCL/lit.cfg.py
@@ -393,7 +393,7 @@ if find_executable('cmc'):
 
 # Device AOT compilation tools aren't part of the SYCL project,
 # so they need to be pre-installed on the machine
-aot_tools = ["ocloc", "aoc", "opencl-aot"]
+aot_tools = ["ocloc", "opencl-aot"]
 
 for aot_tool in aot_tools:
     if find_executable(aot_tool) is not None:


### PR DESCRIPTION
'aoc' tool requires FPGA card and corresponding SDK to compile binaries for
FPGA HW target. However, this test suite supports testing on FPGA emulator
device only. 'opencl-aot' tool is used as backend compiler for that target
instead of 'aoc'.
Remove 'aoc' tool from llvm-test-suite configuration and change AOT compilation
tool requirement for tests that should be executed on FPGA emulator device.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>