### PR TITLE
[SYCL][ESIMD][EMU] XFAIL for kernel using unimplemented 'single_task'

### DIFF
--- a/SYCL/ESIMD/api/simd_view_select_2d.cpp
+++ b/SYCL/ESIMD/api/simd_view_select_2d.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
+// TODO: esimd_emulator fails due to unimplemented 'single_task()' method
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //


### PR DESCRIPTION
- for recently added 'simd_view_select_2d' test.