### PR TITLE
[SYCL][ESIMD][EMU] XFAIL marking for 'esimd_merge.cpp' test

### DIFF
--- a/SYCL/ESIMD/api/esimd_merge.cpp
+++ b/SYCL/ESIMD/api/esimd_merge.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
+// TODO: esimd_emulator fails due to memory corruption error from piextUSMFree
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 


### PR DESCRIPTION
- due to memory corruption failure from piextUSMFree