### PR TITLE
Revert "[SYCL] Changing tests to correspond the old backend_return_t for opencl"

### DIFF
--- a/SYCL/Basic/fpga_tests/fpga_queue.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_queue.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl, opencl_icd
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %opencl_lib -DSYCL_GET_NATIVE_BACKEND_OPENCL_RETURN_T_CL_EVENT
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %opencl_lib
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 //==------------- fpga_queue.cpp - SYCL FPGA queues test -------------------==//

--- a/SYCL/Basic/interop/construction_ocl.cpp
+++ b/SYCL/Basic/interop/construction_ocl.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl, opencl_icd
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %opencl_lib %s -o %t.ocl.out -DSYCL_GET_NATIVE_BACKEND_OPENCL_RETURN_T_CL_EVENT
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %opencl_lib %s -o %t.ocl.out
 // RUN: env SYCL_DEVICE_FILTER="opencl" %t.ocl.out
 
 #include <CL/cl.h>

--- a/SYCL/HostInteropTask/interop-task.cpp
+++ b/SYCL/HostInteropTask/interop-task.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %threads_lib %opencl_lib -DSYCL_GET_NATIVE_BACKEND_OPENCL_RETURN_T_CL_EVENT
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %threads_lib %opencl_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Reverts intel/llvm-test-suite#682 due to change of macro meaning.