### PR TITLE
[SYCL][ESIMD] Add verifications that device has necessary aspects

### DIFF
--- a/SYCL/ESIMD/api/functional/common.hpp
+++ b/SYCL/ESIMD/api/functional/common.hpp
@@ -55,6 +55,24 @@ using shared_allocator = sycl::usm_allocator<DataT, sycl::usm::alloc::shared>;
 template <typename DataT>
 using shared_vector = std::vector<DataT, shared_allocator<DataT>>;
 
+template <typename T>
+constexpr bool should_run_test_with_current_datatype(sycl::device &&device) {
+  if constexpr (std::is_same_v<T, sycl::half>) {
+    if (!device.has(sycl::aspect::fp16)) {
+      log::note(
+          "Device does not support half precision floating point operations");
+      return false;
+    }
+  } else if constexpr (std::is_same_v<T, double>) {
+    if (!device.has(sycl::aspect::fp64)) {
+      log::note(
+          "Device does not support double precision floating point operations");
+      return false;
+    }
+  }
+  return true;
+}
+
 // A wrapper to speed-up bitwise comparison
 template <typename T> bool are_bitwise_equal(T lhs, T rhs) {
   // We are safe to compare unsigned integral types using `==` operator.

--- a/SYCL/ESIMD/api/functional/common.hpp
+++ b/SYCL/ESIMD/api/functional/common.hpp
@@ -55,22 +55,38 @@ using shared_allocator = sycl::usm_allocator<DataT, sycl::usm::alloc::shared>;
 template <typename DataT>
 using shared_vector = std::vector<DataT, shared_allocator<DataT>>;
 
+// Provides verification that provided device has necessary aspects to interact
+// with current data type.
+//
+// Usage example:
+//
+// sycl::device device = queue.get_device();
+// if (should_skip_test_with(device)) {
+//   return true;
+// }
+//
+// ** do test actions **
+//
 template <typename T>
-constexpr bool should_run_test_with_current_datatype(sycl::device &&device) {
+inline bool should_skip_test_with(const sycl::device &device) {
   if constexpr (std::is_same_v<T, sycl::half>) {
     if (!device.has(sycl::aspect::fp16)) {
       log::note(
           "Device does not support half precision floating point operations");
-      return false;
+      return true;
     }
   } else if constexpr (std::is_same_v<T, double>) {
     if (!device.has(sycl::aspect::fp64)) {
       log::note(
           "Device does not support double precision floating point operations");
-      return false;
+      return true;
     }
+  } else {
+    // Suppress compilation warnings
+    static_cast<void>(device);
   }
-  return true;
+
+  return false;
 }
 
 // A wrapper to speed-up bitwise comparison

--- a/SYCL/ESIMD/api/functional/common.hpp
+++ b/SYCL/ESIMD/api/functional/common.hpp
@@ -57,16 +57,6 @@ using shared_vector = std::vector<DataT, shared_allocator<DataT>>;
 
 // Provides verification that provided device has necessary aspects to interact
 // with current data type.
-//
-// Usage example:
-//
-// sycl::device device = queue.get_device();
-// if (should_skip_test_with(device)) {
-//   return true;
-// }
-//
-// ** do test actions **
-//
 template <typename T>
 inline bool should_skip_test_with(const sycl::device &device) {
   if constexpr (std::is_same_v<T, sycl::half>) {

--- a/SYCL/ESIMD/api/functional/ctors/ctor_array.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_array.hpp
@@ -96,6 +96,9 @@ template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (!should_run_test_with_current_datatype<DataT>(queue.get_device())) {
+      return true;
+    }
 
     bool passed = true;
     const std::vector<DataT> ref_data = generate_ref_data<DataT, NumElems>();

--- a/SYCL/ESIMD/api/functional/ctors/ctor_array.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_array.hpp
@@ -96,7 +96,7 @@ template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
-    if (!should_run_test_with_current_datatype<DataT>(queue.get_device())) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
       return true;
     }
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_copy.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_copy.hpp
@@ -93,6 +93,10 @@ template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
+      return true;
+    }
+
     bool passed = true;
     const std::vector<DataT> ref_data = generate_ref_data<DataT, NumElems>();
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
@@ -80,6 +80,10 @@ template <typename DataT, typename SizeT, typename TestCaseT> struct run_test {
   static constexpr int NumElems = SizeT::value;
 
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
+      return true;
+    }
+
     bool passed = true;
     DataT default_val{};
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
@@ -205,6 +205,10 @@ class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
+      return true;
+    }
+
     shared_vector<DataT> result(NumElems, shared_allocator<DataT>(queue));
 
     const auto base_value = get_value<DataT, BaseVal>();

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
@@ -129,6 +129,10 @@ class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
+      return true;
+    }
+
     bool passed = true;
     const std::vector<DataT> ref_data = generate_ref_data<DataT, NumElems>();
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_move.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_move.hpp
@@ -89,6 +89,10 @@ template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
+      return true;
+    }
+
     bool passed = true;
     bool was_moved = false;
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_vector.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_vector.hpp
@@ -88,6 +88,10 @@ template <typename DataT, typename SizeT, typename TestCaseT> class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
+      return true;
+    }
+
     bool passed = true;
     const std::vector<DataT> ref_data = generate_ref_data<DataT, NumElems>();
 

--- a/SYCL/ESIMD/api/functional/operators/operator_assignment.hpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_assignment.hpp
@@ -29,6 +29,10 @@ template <typename DataT, typename DimT, typename TestCaseT> class run_test {
 
 public:
   bool operator()(sycl::queue &queue, const std::string &data_type) {
+    if (should_skip_test_with<DataT>(queue.get_device())) {
+      return true;
+    }
+
     bool passed = true;
     const std::vector<DataT> ref_data = generate_ref_data<DataT, NumElems>();
 


### PR DESCRIPTION
Provide verifications that device has necessary aspects to interact with `double` or `sycl::half` data types, if device doesn't has necessary aspects such data type will be skipped during runtime