### PR TITLE
[SYCL][ESIMD][EMU] XFAIL for 'SYCL/ESIMD/api/esimd_rgba_smoke.cpp'

### DIFF
--- a/SYCL/ESIMD/api/esimd_rgba_smoke.cpp
+++ b/SYCL/ESIMD/api/esimd_rgba_smoke.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
+// TODO: esimd_emulator fails due to unimplemented 'single_task()' method
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 


### PR DESCRIPTION
- Due to unimplemeted 'single_task()'