### PR TITLE
[SYCL][ESIMD] Replace std::max_align_t with 16 for overaligned

### DIFF
--- a/SYCL/ESIMD/api/functional/ctors/ctor_load.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load.hpp
@@ -104,12 +104,14 @@ struct vector {
 };
 
 struct overal {
-  template <typename, int> static size_t get_size() {
-    return alignof(std::max_align_t);
-  }
-  static constexpr auto get_value() {
-    return esimd::overaligned<alignof(std::max_align_t)>;
-  }
+  // Use 16 instead of std::max_align_t because of the fact that long double is
+  // not a native type in Intel GPUs. So 16 is not driven by any type, but
+  // rather the "oword alignment" requirement for all block loads. In that
+  // sense, std::max_align_t would give wrong idea.
+  static constexpr int oword_align = 16;
+  template <typename, int> static size_t get_size() { return oword_align; }
+
+  static constexpr auto get_value() { return overaligned<oword_align>; }
 };
 
 } // namespace alignment

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load.hpp
@@ -111,7 +111,7 @@ struct overal {
   static constexpr int oword_align = 16;
   template <typename, int> static size_t get_size() { return oword_align; }
 
-  static constexpr auto get_value() { return overaligned<oword_align>; }
+  static constexpr auto get_value() { return esimd::overaligned<oword_align>; }
 };
 
 } // namespace alignment

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
@@ -110,12 +110,13 @@ struct vector {
 };
 
 struct overal {
-  template <typename, int> static size_t get_size() {
-    return alignof(std::max_align_t);
-  }
-  static constexpr auto get_value() {
-    return overaligned<alignof(std::max_align_t)>;
-  }
+  // Use 16 instead of std::max_align_t because of the fact that long double is
+  // not a native type in Intel GPUs. So 16 is not driven by any type, but
+  // rather the "oword alignment" requirement for all block loads. In that
+  // sense, std::max_align_t gives wrong idea.
+  template <typename, int> static size_t get_size() { return alignof(16); }
+
+  static constexpr auto get_value() { return overaligned<alignof(16)>; }
 };
 
 } // namespace alignment

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
@@ -113,7 +113,7 @@ struct overal {
   // Use 16 instead of std::max_align_t because of the fact that long double is
   // not a native type in Intel GPUs. So 16 is not driven by any type, but
   // rather the "oword alignment" requirement for all block loads. In that
-  // sense, std::max_align_t gives wrong idea.
+  // sense, std::max_align_t would give wrong idea.
   template <typename, int> static size_t get_size() { return alignof(16); }
 
   static constexpr auto get_value() { return overaligned<alignof(16)>; }

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_core.cpp
@@ -114,9 +114,10 @@ struct overal {
   // not a native type in Intel GPUs. So 16 is not driven by any type, but
   // rather the "oword alignment" requirement for all block loads. In that
   // sense, std::max_align_t would give wrong idea.
-  template <typename, int> static size_t get_size() { return alignof(16); }
+  static constexpr int oword_align = 16;
+  template <typename, int> static size_t get_size() { return oword_align; }
 
-  static constexpr auto get_value() { return overaligned<alignof(16)>; }
+  static constexpr auto get_value() { return overaligned<oword_align>; }
 };
 
 } // namespace alignment


### PR DESCRIPTION
Because of the fact that long double is
not a native type in Intel GPUs. So 16 is not driven by any type, but
rather the "oword alignment" requirement for all block loads. In that
sense, std::max_align_t gives wrong idea.