### PR TITLE
[SYCL][ESIMD] Change logic for tests on simd default constructor

### DIFF
--- a/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
@@ -82,7 +82,7 @@ template <typename DataT, typename SizeT, typename TestCaseT> struct run_test {
   bool operator()(sycl::queue &queue, const std::string &data_type) {
     bool passed = true;
 
-    // We leave this dou to avoiding empty functions optimisation, we do not
+    // We use it to avoid empty functions being optimized out by compiler
     // checking the result of the simd calling because values of the constructed
     // object's elements are undefined.
     shared_vector<DataT> result(NumElems, shared_allocator<DataT>(queue));

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
@@ -86,6 +86,8 @@ template <typename DataT, typename SizeT, typename TestCaseT> struct run_test {
     // checking the result of the simd calling because values of the constructed
     // object's elements are undefined.
     shared_vector<DataT> result(NumElems, shared_allocator<DataT>(queue));
+    // We do not re-throw an exception to test all combinations of types and
+    // vector sizes.
     try {
       queue.submit([&](sycl::handler &cgh) {
         DataT *const out = result.data();

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default.hpp
@@ -99,8 +99,10 @@ template <typename DataT, typename SizeT, typename TestCaseT> struct run_test {
       queue.wait_and_throw();
     } catch (const sycl::exception &e) {
       passed = false;
-      std::string error_msg =
-          "a SYCL exception was caught: " + std::string(e.what());
+      std::string error_msg("A SYCL exception was caught:");
+      error_msg += std::string(e.what());
+      error_msg += " for simd<" + data_type;
+      error_msg += ", " + std::to_string(NumElems) + ">";
       error_msg += ", with context: " + TestCaseT::get_description();
       log::note(error_msg);
     }


### PR DESCRIPTION
The documentation for simd default constructor has been changed and now
values of the constructed object's elements are undefined.