### PR TITLE
[SYCL][HIP] Expect failure of some tests that have 'has(aspect::atomic64)'

### DIFF
--- a/SYCL/AtomicRef/add_atomic64.cpp
+++ b/SYCL/AtomicRef/add_atomic64.cpp
@@ -5,6 +5,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "add.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/assignment_atomic64.cpp
+++ b/SYCL/AtomicRef/assignment_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "assignment.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/compare_exchange_atomic64.cpp
+++ b/SYCL/AtomicRef/compare_exchange_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "compare_exchange.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/exchange_atomic64.cpp
+++ b/SYCL/AtomicRef/exchange_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "exchange.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/load_atomic64.cpp
+++ b/SYCL/AtomicRef/load_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "load.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/max_atomic64.cpp
+++ b/SYCL/AtomicRef/max_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "max.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/min_atomic64.cpp
+++ b/SYCL/AtomicRef/min_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "min.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/store_atomic64.cpp
+++ b/SYCL/AtomicRef/store_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "store.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/sub_atomic64.cpp
+++ b/SYCL/AtomicRef/sub_atomic64.cpp
@@ -5,6 +5,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "sub.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/Basic/aspects.cpp
+++ b/SYCL/Basic/aspects.cpp
@@ -4,6 +4,9 @@
 // Hip is missing some of the parameters tested here so it fails with NVIDIA
 // XFAIL: hip_nvidia
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 //==--------------- aspects.cpp - SYCL device test ------------------------==//
 //
 // Returns the various aspects of a device  and platform.


### PR DESCRIPTION
Expect failure of some tests that have 'has(aspect::atomic64)' because hip backend does not have such check implementation