### PR TITLE
[SYCL][ESIMD][EMU] ESIMD test updates for esimd_emulator backend

### DIFF
--- a/SYCL/ESIMD/BitonicSortK.cpp
+++ b/SYCL/ESIMD/BitonicSortK.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/BitonicSortK.cpp
+++ b/SYCL/ESIMD/BitonicSortK.cpp
@@ -602,6 +602,12 @@ int BitonicSort::Solve(uint32_t *pInputs, uint32_t *pOutputs, uint32_t size) {
   double kernel_times = 0;
   unsigned num_iters = 10;
 
+  // Reducing number of iterations for esimd_emulator backend in order
+  // to avoid timeout failure
+  if (pQueue_->get_backend() == cl::sycl::backend::ext_intel_esimd_emulator) {
+    num_iters = 2;
+  }
+
   // num_iters + 1, iteration#0 is for warmup
   for (int iter = 0; iter <= num_iters; ++iter) {
     try {

--- a/SYCL/ESIMD/BitonicSortKv2.cpp
+++ b/SYCL/ESIMD/BitonicSortKv2.cpp
@@ -521,6 +521,12 @@ int BitonicSort::Solve(uint32_t *pInputs, uint32_t *pOutputs, uint32_t size) {
   double kernel_times = 0;
   unsigned num_iters = 10;
 
+  // Reducing number of iterations for esimd_emulator backend in order
+  // to avoid timeout failure
+  if (pQueue_->get_backend() == cl::sycl::backend::ext_intel_esimd_emulator) {
+    num_iters = 2;
+  }
+
   // num_iters + 1, iteration#0 is for warmup
   for (int iter = 0; iter <= num_iters; ++iter) {
     // enqueue sort265 kernel

--- a/SYCL/ESIMD/accessor.cpp
+++ b/SYCL/ESIMD/accessor.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl -D_CRT_SECURE_NO_WARNINGS=1 %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/aot_mixed.cpp
+++ b/SYCL/ESIMD/aot_mixed.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
+// UNSUPPORTED: esimd_emulator
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device gen9" -o %t.sycl.out -DENABLE_SYCL=0 %s
 // RUN: %GPU_RUN_PLACEHOLDER %t.sycl.out
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device gen9" -o %t.out %s

--- a/SYCL/ESIMD/api/ballot.cpp
+++ b/SYCL/ESIMD/api/ballot.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated memory intrinsic
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/api/esimd_merge.cpp
+++ b/SYCL/ESIMD/api/esimd_merge.cpp
@@ -8,8 +8,7 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
 // TODO: esimd_emulator fails due to SEGFAULT error from __esimd_svm_scatter
-//       Marked as 'UNSUPPORTED' as test is stuck at SEGFAULT exception
-// UNSUPPORTED: esimd_emulator
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/api/esimd_merge.cpp
+++ b/SYCL/ESIMD/api/esimd_merge.cpp
@@ -7,8 +7,9 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to memory corruption error from piextUSMFree
-// XFAIL: esimd_emulator
+// TODO: esimd_emulator fails due to SEGFAULT error from __esimd_svm_scatter
+//       Marked as 'UNSUPPORTED' as test is stuck at SEGFAULT exception
+// UNSUPPORTED: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/api/simd_binop_integer_promotion.cpp
+++ b/SYCL/ESIMD/api/simd_binop_integer_promotion.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated memory intrinsic
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_negation_operator.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_subscript_operator.cpp
+++ b/SYCL/ESIMD/api/simd_subscript_operator.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
+// TODO: esimd_emulator fails due to unimplemented 'half' type
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_subscript_operator.cpp
+++ b/SYCL/ESIMD/api/simd_subscript_operator.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented 'half' type
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_subscript_operator.cpp
+++ b/SYCL/ESIMD/api/simd_subscript_operator.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated memory intrinsic
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_view_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_view_negation_operator.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_view_subscript_operator.cpp
+++ b/SYCL/ESIMD/api/simd_view_subscript_operator.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/slm_gather_scatter.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter.cpp
@@ -1,7 +1,5 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_scatter_scaled
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
@@ -1,7 +1,5 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_scatter_scaled
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/fp_in_phi.cpp
+++ b/SYCL/ESIMD/fp_in_phi.cpp
@@ -14,8 +14,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug-1,ze_debug4
-// TODO: esimd_emulator fails due to unimplemented __esimd_scatter_scaled
-// XFAIL: esimd_emulator
 //
 // The test checks that ESIMD kernels correctly handle function pointers as
 // arguments of LLVM's PHI function.

--- a/SYCL/ESIMD/histogram.cpp
+++ b/SYCL/ESIMD/histogram.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated __esimd_media_ld
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/histogram_256_slm.cpp
+++ b/SYCL/ESIMD/histogram_256_slm.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_scatter_scaled
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/histogram_2d.cpp
+++ b/SYCL/ESIMD/histogram_2d.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated __esimd_media_ld
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -9,8 +9,6 @@
 // REQUIRES: gpu
 // UNSUPPORTED: gpu-intel-dg1,cuda,hip
 // UNSUPPORTED: ze_debug-1,ze_debug4
-// TODO: esimd_emulator fails due to outdated __esimd_media_ld
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/linear/linear.cpp
+++ b/SYCL/ESIMD/linear/linear.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated __esimd_media_ld
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp
 

--- a/SYCL/ESIMD/preemption.cpp
+++ b/SYCL/ESIMD/preemption.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && linux
 // UNSUPPORTED: cuda || hip
+// UNSUPPORTED: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER IGC_DumpToCustomDir=%t.dump IGC_ShaderDumpEnable=1 %t.out
 // RUN: grep enablePreemption %t.dump/*.asm

--- a/SYCL/ESIMD/regression/operator_decrement.cpp
+++ b/SYCL/ESIMD/regression/operator_decrement.cpp
@@ -9,8 +9,6 @@
 //
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/regression/unused_load.cpp
+++ b/SYCL/ESIMD/regression/unused_load.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/regression/variable_gather_mask.cpp
+++ b/SYCL/ESIMD/regression/variable_gather_mask.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
+// TODO: esimd_emulator fails due to unimplemented 'single_task()' method
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/regression/variable_gather_mask.cpp
+++ b/SYCL/ESIMD/regression/variable_gather_mask.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
   std::cout << "MaskedLane=" << MASKED_LANE << "\n";
 
-  bool passed = true;
+  bool passed = false;
 
   passed &= test("accessor", q, [&](int *B) {
     sycl::buffer<int, 1> Bbuf(B, range<1>(VL));
@@ -157,6 +157,6 @@ int main(int argc, char **argv) {
     });
   });
 
-  std::cout << (passed ? "Test passed\n" : "Test FAILED\n");
+  std::cout << (passed ? "Test FAILED\n" : "Test passed\n");
   return passed ? 0 : 1;
 }

--- a/SYCL/ESIMD/regression/variable_gather_mask.cpp
+++ b/SYCL/ESIMD/regression/variable_gather_mask.cpp
@@ -138,7 +138,7 @@ int main(int argc, char **argv) {
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
   std::cout << "MaskedLane=" << MASKED_LANE << "\n";
 
-  bool passed = false;
+  bool passed = true;
 
   passed &= test("accessor", q, [&](int *B) {
     sycl::buffer<int, 1> Bbuf(B, range<1>(VL));
@@ -157,6 +157,6 @@ int main(int argc, char **argv) {
     });
   });
 
-  std::cout << (passed ? "Test FAILED\n" : "Test passed\n");
+  std::cout << (passed ? "Test passed\n" : "Test FAILED\n");
   return passed ? 0 : 1;
 }

--- a/SYCL/ESIMD/slm_barrier.cpp
+++ b/SYCL/ESIMD/slm_barrier.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_scatter_scaled4
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/slm_split_barrier.cpp
+++ b/SYCL/ESIMD/slm_split_barrier.cpp
@@ -9,8 +9,6 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_scatter4_scaled
-// XFAIL: esimd_emulator
 
 #include "esimd_test_utils.hpp"
 

--- a/SYCL/ESIMD/vadd_1d.cpp
+++ b/SYCL/ESIMD/vadd_1d.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/vadd_2d.cpp
+++ b/SYCL/ESIMD/vadd_2d.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated __esimd_media_ld
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/vadd_2d_acc.cpp
+++ b/SYCL/ESIMD/vadd_2d_acc.cpp
@@ -10,8 +10,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented __esimd_oword_ld_unaligned
-// XFAIL: esimd_emulator
 
 // The test checks that 2D workitem addressing works correctly with SIMD
 // kernels.


### PR DESCRIPTION
- Reducing number of iterations / Limiting matrix size in order to avoid timeout failure
- Removing 'XFAIL' from passing tests
