### PR TITLE
[SYCL] Rework of pi tracing test

### DIFF
--- a/SYCL/Tracing/pi_tracing_test.cpp
+++ b/SYCL/Tracing/pi_tracing_test.cpp
@@ -40,7 +40,7 @@
 //
 // CHECK: ---> piEventsWait(
 // CHECK-NEXT:  <unknown> : 1
-// CHECK-NEXT:  {{(const |\[out\]|)}}pi_event * : {{0[xX]?[0-9a-fA-F]*}}
+// CHECK-NEXT:  {{(const |\[out\])?}}pi_event * : {{0[xX]?[0-9a-fA-F]*}}
 // CHECK-SAME:  [ {{0[xX]?[0-9a-fA-F]*}} ... ]
 // CHECK-NEXT: ) ---> 	pi_result : PI_SUCCESS
 

--- a/SYCL/Tracing/pi_tracing_test.cpp
+++ b/SYCL/Tracing/pi_tracing_test.cpp
@@ -40,7 +40,7 @@
 //
 // CHECK: ---> piEventsWait(
 // CHECK-NEXT:  <unknown> : 1
-// CHECK-NEXT:  const pi_event * : {{0[xX]?[0-9a-fA-F]*}}
+// CHECK-NEXT:  {{(const |\[out\]|)}}pi_event * : {{0[xX]?[0-9a-fA-F]*}}
 // CHECK-SAME:  [ {{0[xX]?[0-9a-fA-F]*}} ... ]
 // CHECK-NEXT: ) ---> 	pi_result : PI_SUCCESS
 


### PR DESCRIPTION
Reworked check statement, so it does not requires 'const' specifier, as it is not working properly with reworked event and event_impl classes, which are now supporting lazy init with get_native for the exemplars constructed with default constructor.