### PR TITLE
[SYCL][ESIMD] Eliminate uses of accessor::operator[]

### DIFF
--- a/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
+++ b/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
@@ -57,8 +57,8 @@ bool test(queue q, std::string str, F funcUnderTest) {
          simd<T, VL> va;
          simd<T, VL> vb;
          if constexpr (VL == 1) {
-           va[0] = PA[0];
-           vb[0] = PB[0];
+           va[0] = scalar_load<T>(PA, 0);
+           vb[0] = scalar_load<T>(PB, 0);
          } else {
            va.copy_from(PA, offset);
            vb.copy_from(PB, offset);
@@ -69,7 +69,7 @@ bool test(queue q, std::string str, F funcUnderTest) {
          funcUnderTest(va_view, vb_view);
 
          if constexpr (VL == 1) {
-           PA[0] = va[0];
+           scalar_store<T>(PA, 0, va[0]);
          } else {
            va.copy_to(PA, offset);
          }


### PR DESCRIPTION
Use of this operator in ESIMD context is not supported.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>