### PR TITLE
[SYCL] Add tests for some half builtins

### DIFF
--- a/SYCL/Basic/half_builtins.cpp
+++ b/SYCL/Basic/half_builtins.cpp
@@ -9,7 +9,6 @@
 
 #include <sycl/sycl.hpp>
 
-
 #include <cmath>
 #include <limits>
 

--- a/SYCL/Basic/half_builtins.cpp
+++ b/SYCL/Basic/half_builtins.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// OpenCL CPU driver does not support cl_khr_fp16 extension
+// UNSUPPORTED: cpu && opencl
+
 #include <CL/sycl.hpp>
 
 #include <cmath>
@@ -210,6 +213,8 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
   TEST_BUILTIN_3_VEC_IMPL(NAME, 16)
 
 int main() {
+
+
   queue q;
   std::vector<half> a(N), b(N), c(N), d(N);
   for (int i = 0; i < N; i++) {

--- a/SYCL/Basic/half_builtins.cpp
+++ b/SYCL/Basic/half_builtins.cpp
@@ -213,8 +213,6 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
   TEST_BUILTIN_3_VEC_IMPL(NAME, 16)
 
 int main() {
-
-
   queue q;
   std::vector<half> a(N), b(N), c(N), d(N);
   for (int i = 0; i < N; i++) {

--- a/SYCL/Basic/half_builtins.cpp
+++ b/SYCL/Basic/half_builtins.cpp
@@ -7,7 +7,8 @@
 // OpenCL CPU driver does not support cl_khr_fp16 extension
 // UNSUPPORTED: cpu && opencl
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
+
 
 #include <cmath>
 #include <limits>

--- a/SYCL/Basic/half_builtins.cpp
+++ b/SYCL/Basic/half_builtins.cpp
@@ -18,7 +18,8 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
 
 bool check(half a, half b) {
   return fabs(2 * (a - b) / (a + b)) <
-         std::numeric_limits<cl::sycl::half>::epsilon() || a < std::numeric_limits<cl::sycl::half>::min();
+             std::numeric_limits<cl::sycl::half>::epsilon() ||
+         a < std::numeric_limits<cl::sycl::half>::min();
 }
 
 #define TEST_BUILTIN_1_VEC_IMPL(NAME, SZ)                                      \

--- a/SYCL/Basic/half_builtins.cpp
+++ b/SYCL/Basic/half_builtins.cpp
@@ -1,0 +1,227 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %HOST_RUN_PLACEHOLDER %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <CL/sycl.hpp>
+
+#include <cmath>
+#include <unordered_set>
+
+using namespace cl::sycl;
+
+constexpr int N = 16 * 3; // divisible by all vector sizes
+
+#define TEST_BUILTIN_1_VEC_IMPL(NAME, SZ)                                      \
+  {                                                                            \
+    buffer<half##SZ> a_buf((half##SZ *)&a[0], N / SZ);                         \
+    buffer<half##SZ> d_buf((half##SZ *)&d[0], N / SZ);                         \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(N / SZ,                                                 \
+                       [=](id<1> index) { D[index] = NAME(A[index]); });       \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    assert(fabs(d[i] - NAME(a[i])) <                                           \
+           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+  }
+
+// vectors of size 3 need separate test, as they actually have the size of 4
+// halfs
+#define TEST_BUILTIN_1_VEC3_IMPL(NAME)                                         \
+  {                                                                            \
+    buffer<half3> a_buf((half3 *)&a[0], N / 4);                                \
+    buffer<half3> d_buf((half3 *)&d[0], N / 4);                                \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(N / 4,                                                  \
+                       [=](id<1> index) { D[index] = NAME(A[index]); });       \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    if (i % 4 != 3) {                                                          \
+      assert(fabs(d[i] - NAME(a[i])) <                                         \
+             std::numeric_limits<cl::sycl::half>::epsilon());                  \
+    }                                                                          \
+  }
+
+#define TEST_BUILTIN_1_SCAL_IMPL(NAME)                                         \
+  {                                                                            \
+    buffer<half> a_buf(&a[0], N);                                              \
+    buffer<half> d_buf(&d[0], N);                                              \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(N, [=](id<1> index) { D[index] = NAME(A[index]); });    \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    assert(fabs(d[i] - NAME(a[i])) <                                           \
+           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+  }
+
+#define TEST_BUILTIN_1(NAME)                                                   \
+  TEST_BUILTIN_1_SCAL_IMPL(NAME)                                               \
+  TEST_BUILTIN_1_VEC_IMPL(NAME, 2)                                             \
+  TEST_BUILTIN_1_VEC3_IMPL(NAME)                                               \
+  TEST_BUILTIN_1_VEC_IMPL(NAME, 4)                                             \
+  TEST_BUILTIN_1_VEC_IMPL(NAME, 8)                                             \
+  TEST_BUILTIN_1_VEC_IMPL(NAME, 16)
+
+#define TEST_BUILTIN_2_VEC_IMPL(NAME, SZ)                                      \
+  {                                                                            \
+    buffer<half##SZ> a_buf((half##SZ *)&a[0], N / SZ);                         \
+    buffer<half##SZ> b_buf((half##SZ *)&b[0], N / SZ);                         \
+    buffer<half##SZ> d_buf((half##SZ *)&d[0], N / SZ);                         \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto B = b_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(                                                        \
+          N / SZ, [=](id<1> index) { D[index] = NAME(A[index], B[index]); });  \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    assert(fabs(d[i] - NAME(a[i], b[i])) <                                     \
+           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+  }
+
+#define TEST_BUILTIN_2_VEC3_IMPL(NAME)                                         \
+  {                                                                            \
+    buffer<half3> a_buf((half3 *)&a[0], N / 4);                                \
+    buffer<half3> b_buf((half3 *)&b[0], N / 4);                                \
+    buffer<half3> d_buf((half3 *)&d[0], N / 4);                                \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto B = b_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(                                                        \
+          N / 4, [=](id<1> index) { D[index] = NAME(A[index], B[index]); });   \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    if (i % 4 != 3) {                                                          \
+      assert(fabs(d[i] - NAME(a[i], b[i])) <                                   \
+             std::numeric_limits<cl::sycl::half>::epsilon());                  \
+    }                                                                          \
+  }
+
+#define TEST_BUILTIN_2_SCAL_IMPL(NAME)                                         \
+  {                                                                            \
+    buffer<half> a_buf(&a[0], N);                                              \
+    buffer<half> b_buf(&b[0], N);                                              \
+    buffer<half> d_buf(&d[0], N);                                              \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto B = b_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(                                                        \
+          N, [=](id<1> index) { D[index] = NAME(A[index], B[index]); });       \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    assert(fabs(d[i] - NAME(a[i], b[i])) <                                     \
+           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+  }
+
+#define TEST_BUILTIN_2(NAME)                                                   \
+  TEST_BUILTIN_2_SCAL_IMPL(NAME)                                               \
+  TEST_BUILTIN_2_VEC_IMPL(NAME, 2)                                             \
+  TEST_BUILTIN_2_VEC3_IMPL(NAME)                                               \
+  TEST_BUILTIN_2_VEC_IMPL(NAME, 4)                                             \
+  TEST_BUILTIN_2_VEC_IMPL(NAME, 8)                                             \
+  TEST_BUILTIN_2_VEC_IMPL(NAME, 16)
+
+#define TEST_BUILTIN_3_VEC_IMPL(NAME, SZ)                                      \
+  {                                                                            \
+    buffer<half##SZ> a_buf((half##SZ *)&a[0], N / SZ);                         \
+    buffer<half##SZ> b_buf((half##SZ *)&b[0], N / SZ);                         \
+    buffer<half##SZ> c_buf((half##SZ *)&c[0], N / SZ);                         \
+    buffer<half##SZ> d_buf((half##SZ *)&d[0], N / SZ);                         \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto B = b_buf.get_access<access::mode::read>(cgh);                      \
+      auto C = c_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(N / SZ, [=](id<1> index) {                              \
+        D[index] = NAME(A[index], B[index], C[index]);                         \
+      });                                                                      \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    assert(fabs(d[i] - NAME(a[i], b[i], c[i])) <                               \
+           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+  }
+
+#define TEST_BUILTIN_3_VEC3_IMPL(NAME)                                         \
+  {                                                                            \
+    buffer<half3> a_buf((half3 *)&a[0], N / 4);                                \
+    buffer<half3> b_buf((half3 *)&b[0], N / 4);                                \
+    buffer<half3> c_buf((half3 *)&c[0], N / 4);                                \
+    buffer<half3> d_buf((half3 *)&d[0], N / 4);                                \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto B = b_buf.get_access<access::mode::read>(cgh);                      \
+      auto C = c_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(N / 4, [=](id<1> index) {                               \
+        D[index] = NAME(A[index], B[index], C[index]);                         \
+      });                                                                      \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    if (i % 4 != 3) {                                                          \
+      assert(fabs(d[i] - NAME(a[i], b[i], c[i])) <                             \
+             std::numeric_limits<cl::sycl::half>::epsilon());                  \
+    }                                                                          \
+  }
+
+#define TEST_BUILTIN_3_SCAL_IMPL(NAME)                                         \
+  {                                                                            \
+    buffer<half> a_buf(&a[0], N);                                              \
+    buffer<half> b_buf(&b[0], N);                                              \
+    buffer<half> c_buf(&c[0], N);                                              \
+    buffer<half> d_buf(&d[0], N);                                              \
+    q.submit([&](handler &cgh) {                                               \
+      auto A = a_buf.get_access<access::mode::read>(cgh);                      \
+      auto B = b_buf.get_access<access::mode::read>(cgh);                      \
+      auto C = c_buf.get_access<access::mode::read>(cgh);                      \
+      auto D = d_buf.get_access<access::mode::write>(cgh);                     \
+      cgh.parallel_for(N, [=](id<1> index) {                                   \
+        D[index] = NAME(A[index], B[index], C[index]);                         \
+      });                                                                      \
+    });                                                                        \
+  }                                                                            \
+  for (int i = 0; i < N; i++) {                                                \
+    assert(fabs(d[i] - NAME(a[i], b[i], c[i])) <                               \
+           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+  }
+
+#define TEST_BUILTIN_3(NAME)                                                   \
+  TEST_BUILTIN_3_SCAL_IMPL(NAME)                                               \
+  TEST_BUILTIN_3_VEC_IMPL(NAME, 2)                                             \
+  TEST_BUILTIN_3_VEC3_IMPL(NAME)                                               \
+  TEST_BUILTIN_3_VEC_IMPL(NAME, 4)                                             \
+  TEST_BUILTIN_3_VEC_IMPL(NAME, 8)                                             \
+  TEST_BUILTIN_3_VEC_IMPL(NAME, 16)
+
+int main() {
+  queue q;
+  std::vector<half> a(N), b(N), c(N), d(N);
+  for (int i = 0; i < N; i++) {
+    a[i] = i / (half)N;
+    b[i] = (N - i) / (half)N;
+    c[i] = (half)(3 * i);
+  }
+
+  TEST_BUILTIN_1(fabs);
+  TEST_BUILTIN_2(fmin);
+  TEST_BUILTIN_2(fmax);
+  TEST_BUILTIN_3(fma);
+
+  return 0;
+}

--- a/SYCL/Basic/half_builtins.cpp
+++ b/SYCL/Basic/half_builtins.cpp
@@ -16,6 +16,11 @@ using namespace cl::sycl;
 
 constexpr int N = 16 * 3; // divisible by all vector sizes
 
+bool check(half a, half b) {
+  return fabs(2 * (a - b) / (a + b)) <
+         std::numeric_limits<cl::sycl::half>::epsilon() || a < std::numeric_limits<cl::sycl::half>::min();
+}
+
 #define TEST_BUILTIN_1_VEC_IMPL(NAME, SZ)                                      \
   {                                                                            \
     buffer<half##SZ> a_buf((half##SZ *)&a[0], N / SZ);                         \
@@ -28,8 +33,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
     });                                                                        \
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
-    assert(fabs(d[i] - NAME(a[i])) <                                           \
-           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+    assert(check(d[i], NAME(a[i])));                                           \
   }
 
 // vectors of size 3 need separate test, as they actually have the size of 4
@@ -47,8 +51,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
     if (i % 4 != 3) {                                                          \
-      assert(fabs(d[i] - NAME(a[i])) <                                         \
-             std::numeric_limits<cl::sycl::half>::epsilon());                  \
+      assert(check(d[i], NAME(a[i])));                                         \
     }                                                                          \
   }
 
@@ -63,8 +66,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
     });                                                                        \
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
-    assert(fabs(d[i] - NAME(a[i])) <                                           \
-           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+    assert(check(d[i], NAME(a[i])));                                           \
   }
 
 #define TEST_BUILTIN_1(NAME)                                                   \
@@ -89,8 +91,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
     });                                                                        \
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
-    assert(fabs(d[i] - NAME(a[i], b[i])) <                                     \
-           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+    assert(check(d[i], NAME(a[i], b[i])));                                     \
   }
 
 #define TEST_BUILTIN_2_VEC3_IMPL(NAME)                                         \
@@ -108,8 +109,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
     if (i % 4 != 3) {                                                          \
-      assert(fabs(d[i] - NAME(a[i], b[i])) <                                   \
-             std::numeric_limits<cl::sycl::half>::epsilon());                  \
+      assert(check(d[i], NAME(a[i], b[i])));                                   \
     }                                                                          \
   }
 
@@ -127,8 +127,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
     });                                                                        \
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
-    assert(fabs(d[i] - NAME(a[i], b[i])) <                                     \
-           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+    assert(check(d[i], NAME(a[i], b[i])));                                     \
   }
 
 #define TEST_BUILTIN_2(NAME)                                                   \
@@ -156,8 +155,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
     });                                                                        \
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
-    assert(fabs(d[i] - NAME(a[i], b[i], c[i])) <                               \
-           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+    assert(check(d[i], NAME(a[i], b[i], c[i])));                               \
   }
 
 #define TEST_BUILTIN_3_VEC3_IMPL(NAME)                                         \
@@ -178,8 +176,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
     if (i % 4 != 3) {                                                          \
-      assert(fabs(d[i] - NAME(a[i], b[i], c[i])) <                             \
-             std::numeric_limits<cl::sycl::half>::epsilon());                  \
+      assert(check(d[i], NAME(a[i], b[i], c[i])));                             \
     }                                                                          \
   }
 
@@ -200,8 +197,7 @@ constexpr int N = 16 * 3; // divisible by all vector sizes
     });                                                                        \
   }                                                                            \
   for (int i = 0; i < N; i++) {                                                \
-    assert(fabs(d[i] - NAME(a[i], b[i], c[i])) <                               \
-           std::numeric_limits<cl::sycl::half>::epsilon());                    \
+    assert(check(d[i], NAME(a[i], b[i], c[i])));                               \
   }
 
 #define TEST_BUILTIN_3(NAME)                                                   \


### PR DESCRIPTION
Added tests for some libclc builtins that work on halfs. We will be making some changes to those, but the tests for them can be merged ahead of time.

Tests some of the changes in https://github.com/intel/llvm/pull/5724