### PR TITLE
[SYCL][CUDA] fp19 matrix mad test update

### DIFF
--- a/SYCL/Matrix/joint_matrix_tensorcore.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore.cpp
@@ -152,8 +152,8 @@ void test() {
     range<2> GlobalRange = {Sub_Tiles_M, Sub_Tiles_N * N_THREADS_PER_MATRIX_OP};
 
     cgh.parallel_for<KernelName<T1, T2, M, K, N>>(
-        nd_range<2>(GlobalRange, LocalRange), [=
-    ](nd_item<2> item) [[sycl::reqd_work_group_size(1, 1, 32)]] {
+        nd_range<2>(GlobalRange, LocalRange),
+        [=](nd_item<2> item) [[sycl::reqd_work_group_size(1, 1, 32)]] {
           auto sg = item.get_sub_group();
           auto Group = item.get_group();
           const auto m = Group.get_group_id()[0];

--- a/SYCL/Matrix/joint_matrix_tensorcore.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore.cpp
@@ -56,13 +56,13 @@ uint16_t make_bf16(float x) {
   return (uint16_t)*res;
 }
 
-uint32_t make_tf32(float const &x) {
+uint32_t make_fp19(float const &x) {
   uint32_t res = reinterpret_cast<uint32_t const &>(x);
   res += 0x1000u;
   return res;
 }
 
-float tf32_to_fp32(uint32_t x) {
+float fp19_to_fp32(uint32_t x) {
   uint32_t bits = (x & ~0x1fffu);
   return reinterpret_cast<float const &>(bits);
 }
@@ -76,7 +76,7 @@ T2 matrix_ref_mn(const int &m, const int &n, T1 *A, T1 *B, T2 *C) {
       res += make_fp32(A[m * Big_K + k]) * make_fp32(B[k * Big_N + n]);
   } else if constexpr (std::is_same<T1, uint32_t>::value) {
     for (int k = 0; k < Big_K; k++)
-      res += tf32_to_fp32(A[m * Big_K + k]) * tf32_to_fp32(B[k * Big_N + n]);
+      res += fp19_to_fp32(A[m * Big_K + k]) * fp19_to_fp32(B[k * Big_N + n]);
   } else {
     for (int k = 0; k < Big_K; k++)
       res +=
@@ -120,11 +120,11 @@ void test() {
     }
   } else if constexpr (std::is_same<T1, uint32_t>::value) {
     for (int i = 0; i < Big_M * Big_K; i++) {
-      A[i] = make_tf32(1.0f * (i % 10));
+      A[i] = make_fp19(1.0f * (i % 10));
     }
 
     for (int i = 0; i < Big_K * Big_N; i++) {
-      B[i] = make_tf32(1.0f * (i % 10));
+      B[i] = make_fp19(1.0f * (i % 10));
     }
   } else {
     for (int i = 0; i < Big_M * Big_K; i++) {

--- a/SYCL/Matrix/joint_matrix_tensorcore.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore.cpp
@@ -43,29 +43,27 @@ class TypeHelper;
 template <typename T1, typename T2, size_t M, size_t K, size_t N>
 using KernelName = class TypeHelper<T1, T2, M, K, N>;
 
-float make_fp32(short x) {
-  unsigned int y = x;
+float make_fp32(uint16_t x) {
+  uint32_t y = x;
   y = y << 16;
   float *res = reinterpret_cast<float *>(&y);
   return *res;
 }
 
-unsigned short make_bf16(float x) {
-  int *res = reinterpret_cast<int *>(&x);
+uint16_t make_bf16(float x) {
+  uint32_t *res = reinterpret_cast<uint32_t *>(&x);
   *res = *res >> 16;
-  return (unsigned short)*res;
+  return (uint16_t)*res;
 }
 
 uint32_t make_tf32(float const &x) {
   uint32_t res = reinterpret_cast<uint32_t const &>(x);
-
   res += 0x1000u;
   return res;
 }
 
 float tf32_to_fp32(uint32_t x) {
-
-  unsigned bits = (x & ~0x1fffu);
+  uint32_t bits = (x & ~0x1fffu);
   return reinterpret_cast<float const &>(bits);
 }
 
@@ -231,7 +229,7 @@ int main() {
   test<uint16_t, float, SUB_TILES_M, SUB_TILES_K, SUB_TILES_N, 8, 16, 32>();
   test<uint16_t, float, SUB_TILES_M, SUB_TILES_K, SUB_TILES_N, 32, 16, 8>();
 
-  // A/B fp19/tf32 (using the fp19 storage type uint32_t directly)
+  // A/B fp19 (aka tf32) (using the fp19 storage type uint32_t directly)
   test<uint32_t, float, SUB_TILES_M, SUB_TILES_K, SUB_TILES_N, 16, 8, 16>();
 
   return 0;


### PR DESCRIPTION
Added a test for the fp19 case using the 32 bit integer storage type directly.

This test requires: https://github.com/intel/llvm/pull/5709