### PR TITLE
[SYCL][ESIMD][EMU] Correction : Number of threads - esimd_merge.cpp

### DIFF
--- a/SYCL/ESIMD/api/esimd_merge.cpp
+++ b/SYCL/ESIMD/api/esimd_merge.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to memory corruption error from piextUSMFree
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
@@ -34,10 +32,11 @@ template <class T> void prn(T *arr, int size, const char *title) {
 }
 
 int main(void) {
+  constexpr unsigned NUM_THREADS = 2;
   constexpr unsigned VL = 16;
   constexpr unsigned FACTOR = 2;
   constexpr unsigned SUB_VL = VL / FACTOR / FACTOR;
-  constexpr unsigned Size = VL * 2;
+  constexpr unsigned Size = VL * NUM_THREADS;
 
   queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
 
@@ -66,7 +65,7 @@ int main(void) {
 
   try {
     auto e = q.submit([&](handler &cgh) {
-      cgh.parallel_for<class Test>(Size, [=](id<1> i) SYCL_ESIMD_KERNEL {
+      cgh.parallel_for<class Test>(NUM_THREADS, [=](id<1> i) SYCL_ESIMD_KERNEL {
         simd<int, VL> va(A + i * VL);
         simd<int, VL> vb(B + i * VL);
         simd_mask<SUB_VL> m(M + i * VL);


### PR DESCRIPTION
- 'XFAIL' marking is removed for esimd_emulator backend