### PR TITLE
Disable failing tests to fix CI checks

### DIFF
--- a/SYCL/Basic/host_platform_avail.cpp
+++ b/SYCL/Basic/host_platform_avail.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t1.out
 // RUN: env SYCL_DEVICE_FILTER=acc,host %t1.out
 
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero
+
 //==------ host_platform_avail.cpp - Host Platform Availability test -------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/SYCL/Basic/intel-ext-device.cpp
+++ b/SYCL/Basic/intel-ext-device.cpp
@@ -5,6 +5,8 @@
 // REQUIRES: gpu
 // UNSUPPORTED: cuda
 // UNSUPPORTED: hip
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero
 
 //==--------- intel-ext-device.cpp - SYCL device test ------------==//
 //

--- a/SYCL/Basic/interop/get_native_ze.cpp
+++ b/SYCL/Basic/interop/get_native_ze.cpp
@@ -2,6 +2,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %level_zero_options %s -o %t.ze.out
 // RUN: %t.ze.out
 
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero
+
 #include <level_zero/ze_api.h>
 
 #include <sycl/ext/oneapi/backend/level_zero.hpp>

--- a/SYCL/Basic/query_emulate_subdevice.cpp
+++ b/SYCL/Basic/query_emulate_subdevice.cpp
@@ -3,4 +3,6 @@
 // RUN: NEOReadDebugKeys=1 SYCL_DEVICE_FILTER="gpu" %t.out
 
 // UNSUPPORTED: gpu-intel-dg1,cuda,hip
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero
 #include "query.hpp"

--- a/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-default-any.cpp
@@ -21,3 +21,5 @@
 // The test crashed on CUDA CI machines with the latest OpenCL GPU RT
 // (21.19.19792).
 // UNSUPPORTED: cuda || hip
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero

--- a/SYCL/Plugin/sycl-ls-gpu-level-zero.cpp
+++ b/SYCL/Plugin/sycl-ls-gpu-level-zero.cpp
@@ -13,3 +13,5 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero

--- a/SYCL/Plugin/sycl-ls.cpp
+++ b/SYCL/Plugin/sycl-ls.cpp
@@ -12,3 +12,5 @@
 // The test crashed on CUDA CI machines with the latest OpenCL GPU RT
 // (21.19.19792).
 // UNSUPPORTED: cuda
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero

--- a/SYCL/Regression/device_num.cpp
+++ b/SYCL/Regression/device_num.cpp
@@ -8,6 +8,8 @@
 // The test is using all available BEs but CUDA machine in CI does not have
 // functional OpenCL RT
 // UNSUPPORTED: cuda || hip
+// Temporarily disable on L0 due to fails in CI
+// UNSUPPORTED: level_zero
 
 #include <CL/sycl.hpp>
 #include <iostream>


### PR DESCRIPTION
List of failing tests:
SYCL :: Basic/host_platform_avail.cpp
SYCL :: Basic/intel-ext-device.cpp
SYCL :: Basic/interop/get_native_ze.cpp
SYCL :: Basic/query_emulate_subdevice.cpp
SYCL :: Plugin/sycl-ls-gpu-default-any.cpp
SYCL :: Plugin/sycl-ls-gpu-level-zero.cpp
SYCL :: Plugin/sycl-ls.cpp
SYCL :: Regression/device_num.cpp