### PR TITLE
Explicit namespace reference

### DIFF
--- a/SYCL/ESIMD/BitonicSortKv2.cpp
+++ b/SYCL/ESIMD/BitonicSortKv2.cpp
@@ -617,8 +617,8 @@ int main(int argc, char *argv[]) {
   int size = 1 << LOG2_ELEMENTS;
   cout << "BitonicSort (" << size << ") Start..." << std::endl;
 
-  cl::sycl::property_list props{property::queue::enable_profiling{},
-                                property::queue::in_order()};
+  cl::sycl::property_list props{cl::sycl::property::queue::enable_profiling{},
+                                cl::sycl::property::queue::in_order()};
 
   queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
           props);

--- a/SYCL/ESIMD/histogram_256_slm.cpp
+++ b/SYCL/ESIMD/histogram_256_slm.cpp
@@ -105,7 +105,7 @@ int CheckHistogram(unsigned int *cpu_histogram, unsigned int *gpu_histogram) {
 
 int main() {
   queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
-          property::queue::enable_profiling{});
+          cl::sycl::property::queue::enable_profiling{});
 
   const char *input_file = nullptr;
   unsigned int width = 1024;

--- a/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
+++ b/SYCL/ESIMD/histogram_256_slm_spec_2020.cpp
@@ -105,7 +105,7 @@ class histogram_slm;
 
 int main(int argc, char **argv) {
   queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
-          property::queue::enable_profiling{});
+          cl::sycl::property::queue::enable_profiling{});
   auto dev = q.get_device();
   auto ctxt = q.get_context();
 

--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -109,7 +109,7 @@ int main(int argc, char *argv[]) {
 
   // Allocate Input Buffer
   queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler(),
-          property::queue::enable_profiling{});
+          cl::sycl::property::queue::enable_profiling{});
 
   auto dev = q.get_device();
   auto ctxt = q.get_context();


### PR DESCRIPTION
Sometimes sycl::property are confused with sycl::other_namespace::property, to avoid such confusion, explicitly reference the namespace in the tests.