### PR TITLE
[SYCL][ESIMD][EMU] Removing XFAIL for test enabled with memory intrinsic updates

### DIFF
--- a/SYCL/ESIMD/accessor_gather_scatter.cpp
+++ b/SYCL/ESIMD/accessor_gather_scatter.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated memory intrinsic
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/accessor_load_store.cpp
+++ b/SYCL/ESIMD/accessor_load_store.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated memory intrinsic
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/esimd_pack_unpack_mask.cpp
+++ b/SYCL/ESIMD/api/esimd_pack_unpack_mask.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to a bug in __esimd_pack_mask() intrinsic
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //

--- a/SYCL/ESIMD/api/simd_copy_to_from.cpp
+++ b/SYCL/ESIMD/api/simd_copy_to_from.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to unimplemented 'half' type
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 


### PR DESCRIPTION
- intel/llvm PR#5727 enables memory intrinsic implemtations using
4-byte promoted vector arguments and fixes bug in
__esimd_pack/unpack_mask()