### PR TITLE
[SYCL][CUDA] Enable tests for generic atomics

### DIFF
--- a/SYCL/AtomicRef/add_generic.cpp
+++ b/SYCL/AtomicRef/add_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "add.h"
 

--- a/SYCL/AtomicRef/add_generic_local.cpp
+++ b/SYCL/AtomicRef/add_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/add_generic_local_native_fp.cpp
+++ b/SYCL/AtomicRef/add_generic_local_native_fp.cpp
@@ -4,10 +4,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier. HIP does not support native floating point
 // atomics
-// XFAIL: cuda, hip, host
+// XFAIL: hip, host
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/add_generic_native_fp.cpp
+++ b/SYCL/AtomicRef/add_generic_native_fp.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has had no support for the generic address space yet.
 // HIP does not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/and_generic.cpp
+++ b/SYCL/AtomicRef/and_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has had no support for the generic address space yet
+// XFAIL: hip
 
 #include "and.h"
 

--- a/SYCL/AtomicRef/and_generic_local.cpp
+++ b/SYCL/AtomicRef/and_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/assignment_atomic64.cpp
+++ b/SYCL/AtomicRef/assignment_atomic64.cpp
@@ -4,6 +4,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 #include "assignment.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/assignment_atomic64.cpp
+++ b/SYCL/AtomicRef/assignment_atomic64.cpp
@@ -4,9 +4,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// XFAIL: hip
-// Expected failure because hip does not have atomic64 check implementation
-
 #include "assignment.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/AtomicRef/assignment_atomic64_generic.cpp
+++ b/SYCL/AtomicRef/assignment_atomic64_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA backend has had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "assignment.h"
 #include <iostream>

--- a/SYCL/AtomicRef/assignment_generic.cpp
+++ b/SYCL/AtomicRef/assignment_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA backend has had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "assignment.h"
 #include <iostream>

--- a/SYCL/AtomicRef/compare_exchange_generic.cpp
+++ b/SYCL/AtomicRef/compare_exchange_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "compare_exchange.h"
 

--- a/SYCL/AtomicRef/compare_exchange_generic_local.cpp
+++ b/SYCL/AtomicRef/compare_exchange_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/exchange_generic.cpp
+++ b/SYCL/AtomicRef/exchange_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "exchange.h"
 

--- a/SYCL/AtomicRef/exchange_generic_local.cpp
+++ b/SYCL/AtomicRef/exchange_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/load_generic.cpp
+++ b/SYCL/AtomicRef/load_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "load.h"
 

--- a/SYCL/AtomicRef/load_generic_local.cpp
+++ b/SYCL/AtomicRef/load_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA backend has had no support for the generic address space yet. Barrier is
+// HIP backend has no support for the generic address space yet. Barrier is
 // not supported on host.
-// XFAIL: cuda, hip, host
+// XFAIL: hip, host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/max_generic.cpp
+++ b/SYCL/AtomicRef/max_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "max.h"
 

--- a/SYCL/AtomicRef/max_generic_local.cpp
+++ b/SYCL/AtomicRef/max_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/max_generic_local_native_fp.cpp
+++ b/SYCL/AtomicRef/max_generic_local_native_fp.cpp
@@ -4,10 +4,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier. HIP dees not support native floating point
 // atomics
-// XFAIL: cuda, hip, host
+// XFAIL: hip, host
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/max_generic_native_fp.cpp
+++ b/SYCL/AtomicRef/max_generic_native_fp.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // HIP does not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/min_generic.cpp
+++ b/SYCL/AtomicRef/min_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "min.h"
 

--- a/SYCL/AtomicRef/min_generic_local.cpp
+++ b/SYCL/AtomicRef/min_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/min_generic_local_native_fp.cpp
+++ b/SYCL/AtomicRef/min_generic_local_native_fp.cpp
@@ -4,10 +4,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier. HIP does not support native floating point
 // atomics
-// XFAIL: cuda, hip, host
+// XFAIL: hip, host
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/min_generic_native_fp.cpp
+++ b/SYCL/AtomicRef/min_generic_native_fp.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // HIP does not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/or_generic.cpp
+++ b/SYCL/AtomicRef/or_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "or.h"
 

--- a/SYCL/AtomicRef/or_generic_local.cpp
+++ b/SYCL/AtomicRef/or_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/store_generic.cpp
+++ b/SYCL/AtomicRef/store_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have no support for the generic address space yet
-// XFAIL: cuda, hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "store.h"
 

--- a/SYCL/AtomicRef/store_generic_local.cpp
+++ b/SYCL/AtomicRef/store_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Barrier is not supported on host.
-// XFAIL: cuda, hip, host
+// XFAIL: hip, host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/sub_generic.cpp
+++ b/SYCL/AtomicRef/sub_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "sub.h"
 

--- a/SYCL/AtomicRef/sub_generic_local.cpp
+++ b/SYCL/AtomicRef/sub_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 #include "sub.h"

--- a/SYCL/AtomicRef/sub_generic_local_native_fp.cpp
+++ b/SYCL/AtomicRef/sub_generic_local_native_fp.cpp
@@ -4,10 +4,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier. HIP does not support native floating point
 // atomics
-// XFAIL: cuda, hip, host
+// XFAIL: hip, host
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/sub_generic_native_fp.cpp
+++ b/SYCL/AtomicRef/sub_generic_native_fp.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // HIP does not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/xor_generic.cpp
+++ b/SYCL/AtomicRef/xor_generic.cpp
@@ -4,8 +4,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "xor.h"
 

--- a/SYCL/AtomicRef/xor_generic_local.cpp
+++ b/SYCL/AtomicRef/xor_generic_local.cpp
@@ -4,9 +4,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has no support for the generic address space yet.
 // Host does not support barrier.
-// XFAIL: cuda || hip || host
+// XFAIL: hip || host
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/Basic/aspects.cpp
+++ b/SYCL/Basic/aspects.cpp
@@ -4,6 +4,9 @@
 // Hip is missing some of the parameters tested here so it fails with NVIDIA
 // XFAIL: hip_nvidia
 
+// XFAIL: hip
+// Expected failure because hip does not have atomic64 check implementation
+
 //==--------------- aspects.cpp - SYCL device test ------------------------==//
 //
 // Returns the various aspects of a device  and platform.

--- a/SYCL/Basic/aspects.cpp
+++ b/SYCL/Basic/aspects.cpp
@@ -4,9 +4,6 @@
 // Hip is missing some of the parameters tested here so it fails with NVIDIA
 // XFAIL: hip_nvidia
 
-// XFAIL: hip
-// Expected failure because hip does not have atomic64 check implementation
-
 //==--------------- aspects.cpp - SYCL device test ------------------------==//
 //
 // Returns the various aspects of a device  and platform.


### PR DESCRIPTION
Enables tests for generic atomics for CUDA backend.

Tests https://github.com/intel/llvm/pull/5849.

Closes https://github.com/intel/llvm/issues/8807.