### PR TITLE
[SYCL] Enable reduction tests with ZE_DEBUG set

### DIFF
--- a/SYCL/Reduction/reduction_big_data.cpp
+++ b/SYCL/Reduction/reduction_big_data.cpp
@@ -8,7 +8,6 @@
 // `Group algorithms are not supported on host device` on Nvidia.
 // XFAIL: hip_nvidia
 //
-// UNSUPPORTED: ze_debug-1,ze_debug4
 
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out
 // TODO: Enable the test for HOST when it supports ext::oneapi::reduce() and

--- a/SYCL/Reduction/reduction_nd_ext_double.cpp
+++ b/SYCL/Reduction/reduction_nd_ext_double.cpp
@@ -8,7 +8,6 @@
 // work group size not bigger than 1` on Nvidia.
 
 // XFAIL: hip_nvidia
-// UNSUPPORTED: ze_debug-1,ze_debug4
 
 // TODO: Enable the test for HOST when it supports intel::reduce() and barrier()
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/Reduction/reduction_nd_ext_half.cpp
+++ b/SYCL/Reduction/reduction_nd_ext_half.cpp
@@ -7,7 +7,6 @@
 // message `The implementation handling parallel_for with reduction requires
 // work group size not bigger than 1` on Nvidia.
 // XFAIL: hip_amd || hip_nvidia
-// UNSUPPORTED: ze_debug-1,ze_debug4
 
 // TODO: Enable the test for HOST when it supports intel::reduce() and barrier()
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/Reduction/reduction_nd_lambda.cpp
+++ b/SYCL/Reduction/reduction_nd_lambda.cpp
@@ -1,5 +1,5 @@
 // Test disabled due to sporadic failure
-// REQUIRES: TEMPORARILY_DISABLED
+// EQUIRES: TEMPORARILY_DISABLED
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
@@ -9,7 +9,6 @@
 // Inconsistently fails on HIP AMD, error message `Barrier is not supported on
 // the host device yet.` on HIP Nvidia.
 // UNSUPPORTED: hip_amd || hip_nvidia
-// UNSUPPORTED: ze_debug-1,ze_debug4
 
 // This test performs basic checks of parallel_for(nd_range, reduction, lambda)
 

--- a/SYCL/Reduction/reduction_nd_lambda.cpp
+++ b/SYCL/Reduction/reduction_nd_lambda.cpp
@@ -1,5 +1,5 @@
 // Test disabled due to sporadic failure
-// EQUIRES: TEMPORARILY_DISABLED
+// REQUIRES: TEMPORARILY_DISABLED
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Reduction/reduction_placeholder.cpp
+++ b/SYCL/Reduction/reduction_placeholder.cpp
@@ -5,8 +5,6 @@
 //
 // `Group algorithms are not supported on host device.` on Nvidia.
 // XFAIL: hip_nvidia
-//
-// UNSUPPORTED: ze_debug-1,ze_debug4
 
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out
 // TODO: Enable the test for HOST when it supports ext::oneapi::reduce() and

--- a/SYCL/Reduction/reduction_range_lambda.cpp
+++ b/SYCL/Reduction/reduction_range_lambda.cpp
@@ -2,7 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// UNSUPPORTED: ze_debug-1,ze_debug4
 
 // This test performs basic checks of parallel_for(range, reduction, lambda)
 // with reductions initialized with 1-dimensional accessor accessing

--- a/SYCL/Reduction/reduction_reducer_op_eq.cpp
+++ b/SYCL/Reduction/reduction_reducer_op_eq.cpp
@@ -5,7 +5,6 @@
 //
 // On nvidia a reduction appears to be unexpectedly executed via the host.
 // XFAIL: hip_nvidia
-// UNSUPPORTED: ze_debug-1,ze_debug4
 
 // This test checks that operators ++, +=, *=, |=, &=, ^= are supported
 // whent the corresponding std::plus<>, std::multiplies, etc are defined.


### PR DESCRIPTION
PR https://github.com/intel/llvm/pull/5653 fixed memory leaks when ZE_DEBUG=4 is set

Signed-off-by: Byoungro So <byoungro.so@intel.com>