### PR TITLE
[SYCL] Enable parallel indexers for AMD, after adding global offset

### DIFF
--- a/SYCL/Basic/parallel_for_indexers.cpp
+++ b/SYCL/Basic/parallel_for_indexers.cpp
@@ -5,9 +5,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t2.out
 // RUN: %GPU_RUN_PLACEHOLDER %t2.out
 // RUN: %ACC_RUN_PLACEHOLDER %t2.out
-//
-// Incorrect results with hip on AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
Must be reapplied after https://github.com/intel/llvm/pull/5855