### PR TITLE
[SYCL] Enable undefined-symbol test for the opencl and gpu

### DIFF
--- a/SYCL/KernelAndProgram/undefined-symbol.cpp
+++ b/SYCL/KernelAndProgram/undefined-symbol.cpp
@@ -1,4 +1,4 @@
-// XFAIL: cuda || hip || (opencl && gpu)
+// XFAIL: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Test become unexpectedly pass, possibly, after the driver update in the https://github.com/intel/llvm/pull/5867
