### PR TITLE
[SYCL][ESIMD][EMU] Removing XFAIL for mandelbrot.cpp

### DIFF
--- a/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
@@ -8,8 +8,6 @@
 
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to outdated __esimd_media_st
-// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %T/output.ppm %S/golden_hw.ppm
 


### PR DESCRIPTION
- As error tolerance is applied in correctness check, mandelbrot
passes.