### PR TITLE
Test load_store.cpp pass with uplift oclcpu to 2022.13.3.0.16

### DIFF
--- a/SYCL/SubGroup/load_store.cpp
+++ b/SYCL/SubGroup/load_store.cpp
@@ -7,9 +7,6 @@
 // AMD
 // XFAIL: hip_amd
 //
-// Missing GroupNonUniformArithmetic capability on CPU RT
-// XFAIL: cpu
-//
 //==----------- load_store.cpp - SYCL sub_group load/store test ------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
Remove XFAIL for oclcpu 2022.13.3.0.16