### PR TITLE
Revert "[SYCL] Disable test assert_in_simultaneous_kernels due to flaky failures (#935)

### DIFF
--- a/SYCL/Assert/assert_in_simultaneous_kernels.cpp
+++ b/SYCL/Assert/assert_in_simultaneous_kernels.cpp
@@ -1,6 +1,4 @@
-// Temporary disabled due to falky failures on level_zero with segmentation
-// fault
-// REQUIRES: linux, TEMPORARY_DISABLED
+// REQUIRES: linux
 // FIXME unsupported on CUDA and HIP until fallback libdevice becomes available
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %threads_lib


### PR DESCRIPTION


This reverts commit 03a9bca272950f4e200d940b2f5f74842cae6b98.