### PR TITLE
[SYCL][ESIMD] Fix test for simd broadcast constructor

### DIFF
--- a/SYCL/ESIMD/api/functional/ctors/ctor_broadcast.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_broadcast.hpp
@@ -148,7 +148,7 @@ private:
                         const std::string &dst_data_type) {
     shared_vector<DstT> result(NumElems, shared_allocator<DstT>(queue));
     shared_vector<SrcT> shared_ref_data(1, shared_allocator<SrcT>(queue));
-    shared_ref_data.push_back(ref_value);
+    shared_ref_data[0] = ref_value;
 
     queue.submit([&](sycl::handler &cgh) {
       const SrcT *const ref = shared_ref_data.data();

--- a/SYCL/ESIMD/api/functional/ctors/ctor_broadcast_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_broadcast_core.cpp
@@ -13,9 +13,6 @@
 // UNSUPPORTED: cuda, hip
 // XRUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // XRUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: false
-// XFAIL: *
-// TODO The simd filled with unexpected values.
 //
 // Test for simd broadcast constructor.
 // This test uses different data types, sizes and different simd constructor


### PR DESCRIPTION
Assign expected value to the first element