### PR TITLE
[SYCL][ESIMD] Fix coverage for operator_decrement_and_increment 

### DIFF
--- a/SYCL/ESIMD/api/functional/ctors/ctor_converting.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_converting.hpp
@@ -191,10 +191,11 @@ private:
             // taking into account the possibility of UB on border values.
             // We don't have a such UB now because we are using 10f as maximum
             // value.
-            if (!((expected + value<DstT>::pos_ulp(expected)) >= retrieved ||
-                  (expected - value<DstT>::pos_ulp(expected)) >= retrieved ||
-                  (expected + value<DstT>::pos_ulp(expected)) <= retrieved ||
-                  (expected - value<DstT>::pos_ulp(expected)) <= retrieved)) {
+            const auto upper =
+                value<DstT>::nextafter(expected, value<DstT>::max());
+            const auto lower =
+                value<DstT>::nextafter(expected, value<DstT>::lowest());
+            if ((retrieved < lower) || (retrieved > upper)) {
               passed = fail_test(i, retrieved, expected, src_data_type,
                                  dst_data_type);
             }

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
@@ -96,8 +96,8 @@ enum class init_val {
   negative,
   denorm,
   inexact,
-  ulp,
-  ulp_half
+  ulp_up,
+  ulp_up_half
 };
 
 // Class used as a kernel ID.
@@ -131,10 +131,10 @@ DataT get_value(DataT base_val = DataT()) {
     return value<DataT>::denorm_min();
   } else if constexpr (Value == init_val::inexact) {
     return 0.1;
-  } else if constexpr (Value == init_val::ulp) {
-    return value<DataT>::pos_ulp(base_val);
-  } else if constexpr (Value == init_val::ulp_half) {
-    return value<DataT>::pos_ulp(base_val) / 2;
+  } else if constexpr (Value == init_val::ulp_up) {
+    return value<DataT>::ulp(base_val, value<DataT>::max());
+  } else if constexpr (Value == init_val::ulp_up_half) {
+    return value<DataT>::ulp(base_val, value<DataT>::max()) / 2;
   } else {
     static_assert(Value != Value, "Unexpected enum value");
   }
@@ -175,11 +175,11 @@ inline std::string init_val_to_string(init_val val) {
   case init_val::inexact:
     return "inexact";
     break;
-  case init_val::ulp:
-    return "ulp";
+  case init_val::ulp_up:
+    return "1 ULP up";
     break;
-  case init_val::ulp_half:
-    return "ulp_half";
+  case init_val::ulp_up_half:
+    return "0.5 ULP up";
     break;
   default:
     assert(false && "Unexpected enum value");

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
@@ -305,8 +305,7 @@ public:
         upper_bound += step_value;
 
         // Enforce strict check for exact zero step
-        if (step_value != 0.)
-        {
+        if (step_value != 0.) {
           lower_bound = value<DataT>::nextafter(lower_bound, lowest);
           upper_bound = value<DataT>::nextafter(upper_bound, max);
         }

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill.hpp
@@ -269,7 +269,7 @@ public:
       //   NaN opcode to be preserved
 
       for (size_t i = 1; i < result.size(); ++i) {
-        const auto& retrieved = result[i];
+        const auto &retrieved = result[i];
         if (!std::isnan(retrieved)) {
           passed = false;
           log::fail(TestDescriptionT(data_type, BaseVal, Step),
@@ -299,13 +299,13 @@ public:
       const auto lowest = value<DataT>::lowest();
 
       for (size_t i = 1; i < result.size(); ++i) {
-        const auto& retrieved = result[i];
+        const auto &retrieved = result[i];
 
         lower_bound += step_value;
         upper_bound += step_value;
 
         // Enforce strict check for exact zero step
-        //if (step_value != 0.)
+        if (step_value != 0.)
         {
           lower_bound = value<DataT>::nextafter(lower_bound, lowest);
           upper_bound = value<DataT>::nextafter(upper_bound, max);
@@ -323,7 +323,7 @@ public:
       // Bitwise check for integral types
       DataT expected = base_value;
       for (size_t i = 1; i < result.size(); ++i) {
-        const auto& retrieved = result[i];
+        const auto &retrieved = result[i];
         expected += step_value;
 
         if (!are_bitwise_equal(retrieved, expected)) {

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
@@ -19,10 +19,10 @@
 // must be enabled when it is resolved.
 //
 // The test verifies that simd fill constructor has no precision differences.
-// The test do the following actions:
-//  - call simd with predefined base and step values
-//  - bitwise comparing that output[0] value is equal to base value and
-//    output[i] is equal to output[i -1] + step_value
+// The test does the following actions:
+//  - calls simd fill constructor with predefined base and step values
+//  - ensures the result values are as expected considering the type precision
+//    and any implementation-defined behaviour
 
 #include "ctor_fill.hpp"
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
@@ -46,7 +46,7 @@ int main(int, char **) {
 #ifdef SIMD_RUN_TEST_WITH_DENORM_INIT_VAL_AND_ULP_STEP
   {
     const auto base_values = ctors::get_init_values_pack<init_val::denorm>();
-    const auto step_values = ctors::get_init_values_pack<init_val::ulp>();
+    const auto step_values = ctors::get_init_values_pack<init_val::ulp_up>();
     passed &= for_all_combinations<ctors::run_test>(
         types, single_size, context, base_values, step_values, queue);
   }
@@ -55,7 +55,7 @@ int main(int, char **) {
     const auto base_values =
         ctors::get_init_values_pack<init_val::inexact, init_val::min>();
     const auto step_values =
-        ctors::get_init_values_pack<init_val::ulp, init_val::ulp_half>();
+        ctors::get_init_values_pack<init_val::ulp_up, init_val::ulp_up_half>();
     passed &= for_all_combinations<ctors::run_test>(
         types, single_size, context, base_values, step_values, queue);
   }

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
@@ -19,10 +19,10 @@
 // must be enabled when it is resolved.
 //
 // The test verifies that simd fill constructor has no precision differences.
-// The test do the following actions:
-//  - call simd with predefined base and step values
-//  - bitwise comparing that output[0] value is equal to base value and
-//    output[i] is equal to output[i -1] + step_value
+// The test does the following actions:
+//  - calls simd fill constructor with predefined base and step values
+//  - ensures the result values are as expected considering the type precision
+//    and any implementation-defined behaviour
 
 #include "ctor_fill.hpp"
 

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
@@ -46,7 +46,7 @@ int main(int, char **) {
     const auto base_values =
         ctors::get_init_values_pack<ctors::init_val::denorm>();
     const auto step_values =
-        ctors::get_init_values_pack<ctors::init_val::ulp>();
+        ctors::get_init_values_pack<ctors::init_val::ulp_up>();
     passed &= for_all_combinations<ctors::run_test>(
         types, single_size, context, base_values, step_values, queue);
   }
@@ -56,8 +56,8 @@ int main(int, char **) {
         ctors::get_init_values_pack<ctors::init_val::inexact,
                                     ctors::init_val::min>();
     const auto step_values =
-        ctors::get_init_values_pack<ctors::init_val::ulp,
-                                    ctors::init_val::ulp_half>();
+        ctors::get_init_values_pack<ctors::init_val::ulp_up,
+                                    ctors::init_val::ulp_up_half>();
     passed &= for_all_combinations<ctors::run_test>(
         types, single_size, context, base_values, step_values, queue);
   }

--- a/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment.hpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment.hpp
@@ -139,19 +139,17 @@ struct fp_accuracy_test {
 
     if constexpr (TestCaseT::is_increment()) {
       ref_data.reserve((NumElems > 1) ? NumElems : 6);
-      ref_data.insert(ref_data.end(),
-                      {inexact, denorm_min, -denorm_min,
-                       value<DataT>::pos_ulp(static_cast<DataT>(-1.0)),
-                       value<DataT>::pos_ulp(min),
-                       value<DataT>::neg_ulp(max - 1)});
+      ref_data.insert(ref_data.end(), {inexact, denorm_min, -denorm_min,
+                                       value<DataT>::nextafter(-1, max),
+                                       value<DataT>::nextafter(min, max),
+                                       value<DataT>::nextafter(max - 1, min)});
 
     } else {
       ref_data.reserve((NumElems > 1) ? NumElems : 6);
-      ref_data.insert(ref_data.end(),
-                      {inexact, denorm_min, -denorm_min,
-                       value<DataT>::neg_ulp(static_cast<DataT>(-1.0)),
-                       value<DataT>::neg_ulp(max),
-                       value<DataT>::pos_ulp(min + 1)});
+      ref_data.insert(ref_data.end(), {inexact, denorm_min, -denorm_min,
+                                       value<DataT>::nextafter(-1, max),
+                                       value<DataT>::nextafter(max, min),
+                                       value<DataT>::nextafter(min + 1, max)});
     }
 
     for (size_t i = ref_data.size(); i < NumElems; ++i) {

--- a/SYCL/ESIMD/api/functional/value.hpp
+++ b/SYCL/ESIMD/api/functional/value.hpp
@@ -141,6 +141,8 @@ template <typename DataT> struct value {
   // Returns a distance to the next representable number up to /p direction
   // inclusive. Return value is always non-negative
   static DataT ulp(DataT base_val, DataT direction) {
+    static_assert(type_traits::is_sycl_floating_point_v<DataT>,
+                  "ULP has meaning only for floating point data types.");
 
     const DataT sign = (base_val > direction) ? -1 : 1;
 
@@ -161,11 +163,8 @@ template <typename DataT> struct value {
       // difference in precision between fp16 and fp32 types
       return static_cast<sycl::half>(
           sign * 8192 * (std::nextafter(base_val, direction) - base_val));
-    } else if constexpr (std::is_floating_point_v<DataT>) {
-      return sign * (std::nextafter(base_val, direction) - base_val);
     } else {
-      assert(false && "ULP has meaning only for floating point data types");
-      return 0;
+      return sign * (std::nextafter(base_val, direction) - base_val);
     }
   }
 

--- a/SYCL/ESIMD/api/functional/value.hpp
+++ b/SYCL/ESIMD/api/functional/value.hpp
@@ -171,11 +171,9 @@ template <typename DataT> struct value {
   // Returns next representable number in a given direction
   static auto nextafter(DataT base_val, DataT direction) {
     // TODO: use sycl::nextafter() once it supports sycl::half
-    if (direction >= base_val) {
-      return base_val + ulp(base_val, max());
-    } else {
-      return base_val - ulp(base_val, lowest());
-    }
+    const DataT sign = (base_val > direction) ? -1 : 1;
+
+    return base_val + sign * ulp(base_val, direction);
   }
 };
 


### PR DESCRIPTION
There was no border values coverage previously.
The `pos_ulp` and `neg_ulp` methods were removed to state exact
values more explicitly.

Signed-off-by: Kochetkov, Yuriy <yuriyx.kochetkov@intel.com>