### PR TITLE
[SYCL] [FPGA] Update latency control E2E tests

### DIFF
--- a/SYCL/Basic/fpga_tests/fpga_latency_control_lsu.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_latency_control_lsu.cpp
@@ -40,11 +40,16 @@ int test_latency_control(queue Queue) {
         auto in_ptr = input_accessor.get_pointer();
         auto out_ptr = output_accessor.get_pointer();
 
-        float value = PrefetchingLSU::load<
-            ext::intel::experimental::latency_anchor_id<0>>(in_ptr);
+        float value = PrefetchingLSU::load(
+            in_ptr, ext::oneapi::experimental::properties(
+                        ext::oneapi::experimental::latency_anchor_id<0>));
 
-        BurstCoalescedLSU::store<ext::intel::experimental::latency_constraint<
-            0, ext::intel::experimental::type::exact, 5>>(out_ptr, value);
+        BurstCoalescedLSU::store(
+            out_ptr, value,
+            ext::oneapi::experimental::properties(
+                ext::oneapi::experimental::latency_constraint<
+                    0, ext::oneapi::experimental::latency_control_type::exact,
+                    5>));
       });
     });
   }

--- a/SYCL/Basic/fpga_tests/fpga_latency_control_lsu.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_latency_control_lsu.cpp
@@ -42,13 +42,13 @@ int test_latency_control(queue Queue) {
 
         float value = PrefetchingLSU::load(
             in_ptr, ext::oneapi::experimental::properties(
-                        ext::oneapi::experimental::latency_anchor_id<0>));
+                        ext::intel::experimental::latency_anchor_id<0>));
 
         BurstCoalescedLSU::store(
             out_ptr, value,
             ext::oneapi::experimental::properties(
-                ext::oneapi::experimental::latency_constraint<
-                    0, ext::oneapi::experimental::latency_control_type::exact,
+                ext::intel::experimental::latency_constraint<
+                    0, ext::intel::experimental::latency_control_type::exact,
                     5>));
       });
     });

--- a/SYCL/Basic/fpga_tests/fpga_latency_control_pipe.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_latency_control_pipe.cpp
@@ -34,12 +34,16 @@ int test_latency_control(queue Queue) {
       cgh.single_task<class kernel>([=] {
         Pipe1::write(input_accessor[0]);
 
-        int value =
-            Pipe1::read<ext::intel::experimental::latency_anchor_id<0>>();
+        int value = Pipe1::read(ext::oneapi::experimental::properties(
+            ext::oneapi::experimental::latency_anchor_id<0>));
 
-        Pipe2::write<ext::intel::experimental::latency_anchor_id<1>,
-                     ext::intel::experimental::latency_constraint<
-                         0, ext::intel::experimental::type::exact, 2>>(value);
+        Pipe2::write(
+            value,
+            ext::oneapi::experimental::properties(
+                ext::oneapi::experimental::latency_anchor_id<1>,
+                ext::oneapi::experimental::latency_constraint<
+                    0, ext::oneapi::experimental::latency_control_type::exact,
+                    2>));
 
         output_accessor[0] = Pipe2::read();
       });

--- a/SYCL/Basic/fpga_tests/fpga_latency_control_pipe.cpp
+++ b/SYCL/Basic/fpga_tests/fpga_latency_control_pipe.cpp
@@ -35,14 +35,14 @@ int test_latency_control(queue Queue) {
         Pipe1::write(input_accessor[0]);
 
         int value = Pipe1::read(ext::oneapi::experimental::properties(
-            ext::oneapi::experimental::latency_anchor_id<0>));
+            ext::intel::experimental::latency_anchor_id<0>));
 
         Pipe2::write(
             value,
             ext::oneapi::experimental::properties(
-                ext::oneapi::experimental::latency_anchor_id<1>,
-                ext::oneapi::experimental::latency_constraint<
-                    0, ext::oneapi::experimental::latency_control_type::exact,
+                ext::intel::experimental::latency_anchor_id<1>,
+                ext::intel::experimental::latency_constraint<
+                    0, ext::intel::experimental::latency_control_type::exact,
                     2>));
 
         output_accessor[0] = Pipe2::read();


### PR DESCRIPTION
Update latency control E2E tests to use property list in the API.

The corresponding SYCL PR: https://github.com/intel/llvm/pull/5993