### PR TITLE
[SYCL]Update tests for half operator

### DIFF
--- a/SYCL/ESIMD/ext_math.cpp
+++ b/SYCL/ESIMD/ext_math.cpp
@@ -28,7 +28,6 @@
 
 using namespace cl::sycl;
 using namespace sycl::ext::intel;
-using namespace sycl::ext::intel::esimd;
 
 // --- Data initialization functions
 
@@ -150,12 +149,13 @@ DEFINE_HOST_BIN_OP(pow, std::pow(X, Y));
 
 #define DEFINE_ESIMD_DEVICE_OP(Op)                                             \
   template <class T, int N> struct ESIMDf<T, N, MathOp::Op, AllVec> {          \
-    simd<T, N> operator()(simd<T, N> X) const SYCL_ESIMD_FUNCTION {            \
+    esimd::simd<T, N>                                                          \
+    operator()(esimd::simd<T, N> X) const SYCL_ESIMD_FUNCTION {                \
       return esimd::Op<T, N>(X);                                               \
     }                                                                          \
   };                                                                           \
   template <class T, int N> struct ESIMDf<T, N, MathOp::Op, AllSca> {          \
-    simd<T, N> operator()(T X) const SYCL_ESIMD_FUNCTION {                     \
+    esimd::simd<T, N> operator()(T X) const SYCL_ESIMD_FUNCTION {              \
       return esimd::Op<T, N>(X);                                               \
     }                                                                          \
   };
@@ -176,25 +176,26 @@ DEFINE_ESIMD_DEVICE_OP(log2);
 
 #define DEFINE_ESIMD_DEVICE_BIN_OP(Op)                                         \
   template <class T, int N> struct BinESIMDf<T, N, MathOp::Op, AllSca> {       \
-    simd<T, N> operator()(T X,                                                 \
-                           T Y) const SYCL_ESIMD_FUNCTION {                    \
+    esimd::simd<T, N> operator()(T X, T Y) const SYCL_ESIMD_FUNCTION {         \
       return esimd::Op<T, N>(X, Y);                                            \
     }                                                                          \
   };                                                                           \
   template <class T, int N> struct BinESIMDf<T, N, MathOp::Op, AllVec> {       \
-    simd<T, N> operator()(simd<T, N>X,                                         \
-                           simd<T, N>Y) const SYCL_ESIMD_FUNCTION {            \
+    esimd::simd<T, N>                                                          \
+    operator()(esimd::simd<T, N> X,                                            \
+               esimd::simd<T, N> Y) const SYCL_ESIMD_FUNCTION {                \
       return esimd::Op<T, N>(X, Y);                                            \
     }                                                                          \
   };                                                                           \
   template <class T, int N> struct BinESIMDf<T, N, MathOp::Op, Sca1Vec2> {     \
-    simd<T, N> operator()(T X, simd<T, N> Y) const SYCL_ESIMD_FUNCTION {       \
+    esimd::simd<T, N>                                                          \
+    operator()(T X, esimd::simd<T, N> Y) const SYCL_ESIMD_FUNCTION {           \
       return esimd::Op<T, N>(X, Y);                                            \
     }                                                                          \
   };                                                                           \
   template <class T, int N> struct BinESIMDf<T, N, MathOp::Op, Sca2Vec1> {     \
-    simd<T, N> operator()(simd<T, N>X,                                         \
-                           T Y) const SYCL_ESIMD_FUNCTION {                    \
+    esimd::simd<T, N> operator()(esimd::simd<T, N> X,                          \
+                                 T Y) const SYCL_ESIMD_FUNCTION {              \
       return esimd::Op<T, N>(X, Y);                                            \
     }                                                                          \
   };
@@ -204,13 +205,14 @@ DEFINE_ESIMD_DEVICE_BIN_OP(pow);
 
 #define DEFINE_SYCL_DEVICE_OP(Op)                                              \
   template <class T, int N> struct SYCLf<T, N, MathOp::Op, AllVec> {           \
-    simd<T, N> operator()(simd<T, N>X) const SYCL_ESIMD_FUNCTION {             \
+    esimd::simd<T, N>                                                          \
+    operator()(esimd::simd<T, N> X) const SYCL_ESIMD_FUNCTION {                \
       /* T must be float for SYCL, so not a template parameter for sycl::Op*/  \
       return sycl::Op<N>(X);                                                   \
     }                                                                          \
   };                                                                           \
   template <class T, int N> struct SYCLf<T, N, MathOp::Op, AllSca> {           \
-    simd<T, N> operator()(T X) const SYCL_ESIMD_FUNCTION {                     \
+    esimd::simd<T, N> operator()(T X) const SYCL_ESIMD_FUNCTION {              \
       return sycl::Op<N>(X);                                                   \
     }                                                                          \
   };
@@ -233,14 +235,14 @@ struct UnaryDeviceFunc {
 
   void operator()(id<1> I) const SYCL_ESIMD_KERNEL {
     unsigned int Offset = I * N * sizeof(T);
-    simd<T, N> Vx;
+    esimd::simd<T, N> Vx;
     Vx.copy_from(In, Offset);
 
     if (I.get(0) % 2 == 0) {
       for (int J = 0; J < N; J++) {
         Kernel<T, N, Op, AllSca> DevF{};
         T Val = Vx[J];
-        simd<T, N> V = DevF(Val); // scalar arg
+        esimd::simd<T, N> V = DevF(Val); // scalar arg
         Vx[J] = V[J];
       }
     } else {
@@ -264,23 +266,23 @@ struct BinaryDeviceFunc {
 
   void operator()(id<1> I) const SYCL_ESIMD_KERNEL {
     unsigned int Offset = I * N * sizeof(T);
-    simd<T, N> V1(In1, Offset);
-    simd<T, N> V2(In2, Offset);
-    simd<T, N> V;
+    esimd::simd<T, N> V1(In1, Offset);
+    esimd::simd<T, N> V2(In2, Offset);
+    esimd::simd<T, N> V;
 
     if (I.get(0) % 2 == 0) {
       int Ind = 0;
       {
         Kernel<T, N, Op, AllSca> DevF{};
         T Val2 = V2[Ind];
-        simd<T, N> Vv = DevF(V1[Ind], Val2); // both arguments are scalar
+        esimd::simd<T, N> Vv = DevF(V1[Ind], Val2); // both arguments are scalar
         V[Ind] = Vv[Ind];
       }
       Ind++;
       {
         Kernel<T, N, Op, Sca1Vec2> DevF{};
         T Val1 = V1[Ind];
-        simd<T, N> Vv = DevF(Val1, V2); // scalar, vector
+        esimd::simd<T, N> Vv = DevF(Val1, V2); // scalar, vector
         V[Ind] = Vv[Ind];
       }
       Ind++;
@@ -288,7 +290,7 @@ struct BinaryDeviceFunc {
         for (int J = Ind; J < N; ++J) {
           Kernel<T, N, Op, Sca2Vec1> DevF{};
           T Val2 = V2[J];
-          simd<T, N> Vv = DevF(V1, Val2); // scalar 2nd arg
+          esimd::simd<T, N> Vv = DevF(V1, Val2); // scalar 2nd arg
           V[J] = Vv[J];
         }
       }

--- a/SYCL/SubGroup/helper.hpp
+++ b/SYCL/SubGroup/helper.hpp
@@ -146,7 +146,7 @@ template <typename T> void exit_if_not_equal(T *val, T *ref, const char *name) {
 template <> void exit_if_not_equal(half val, half ref, const char *name) {
   int16_t cmp_val = reinterpret_cast<int16_t &>(val);
   int16_t cmp_ref = reinterpret_cast<int16_t &>(ref);
-  if (std::abs(cmp_val - cmp_ref) > 1) {
+  if (std::abs(cmp_val - cmp_ref) > 2) {
     std::cout << "Unexpected result for " << name << ": " << (float)val
               << " expected value: " << (float)ref << std::endl;
     exit(1);


### PR DESCRIPTION
This PR makes some small changes due to the introduction of some missing operators.
It changes the namespaces in `ext_math.cpp` as it was ambiguous as to if the `sycl::abs()` or `sycl::ext::intel::esimd::abs()` function should be used.

There is also an adjustment of the load store's check tolerance. The checks tolerance is slightly increased, as previously these operations would have been performed as 32-bit floats.

Depends on: https://github.com/intel/llvm/pull/6061
