### PR TITLE
[SYCL][CUDA] enable unoptimized_stream.cpp for CUDA backend

### DIFF
--- a/SYCL/Regression/unoptimized_stream.cpp
+++ b/SYCL/Regression/unoptimized_stream.cpp
@@ -3,14 +3,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda
-// Disable test due to flaky failure on CUDA(issue #387)
-
-// NOTE: The libclc target used by the CUDA backend used to generate atomic load
-//       variants that were unsupported by NVPTX. Even if they were not used
-//       directly, sycl::stream and other operations would keep the invalid
-//       operations in when optimizations were disabled.
-
 #include <sycl/sycl.hpp>
 
 int main() {


### PR DESCRIPTION
The issue this test was disabled due to has been fixed in the meantime. 

Closes https://github.com/intel/llvm-test-suite/issues/387.