### PR TITLE
[SYCL] Re-enable L0 batch test

### DIFF
--- a/SYCL/Plugin/level_zero_batch_event_status.cpp
+++ b/SYCL/Plugin/level_zero_batch_event_status.cpp
@@ -1,5 +1,5 @@
 // See https://github.com/intel/llvm-test-suite/issues/906
-// REQUIRES: gpu, level_zero, TEMPORARY_DISABLE
+// REQUIRES: gpu, level_zero
 
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple  %s -o %t.out
 


### PR DESCRIPTION
This test was sporadically failing. I was not able to reproduce using latest tools and on multiple runs. Re-enabling it.