### PR TITLE
[SYCL] Reduce memory size to reduce test complexity and avoid flaky memory related issues

### DIFF
--- a/SYCL/Plugin/level_zero_batch_event_status.cpp
+++ b/SYCL/Plugin/level_zero_batch_event_status.cpp
@@ -1,5 +1,5 @@
 // See https://github.com/intel/llvm-test-suite/issues/906
-// REQUIRES: gpu, level_zero, TEMPORARY_DISABLE
+// REQUIRES: gpu, level_zero
 
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple  %s -o %t.out
 

--- a/SYCL/Plugin/level_zero_batch_event_status.cpp
+++ b/SYCL/Plugin/level_zero_batch_event_status.cpp
@@ -1,5 +1,5 @@
 // See https://github.com/intel/llvm-test-suite/issues/906
-// REQUIRES: gpu, level_zero
+// REQUIRES: gpu, level_zero, TEMPORARY_DISABLE
 
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple  %s -o %t.out
 

--- a/SYCL/Plugin/level_zero_batch_test_copy_with_compute.cpp
+++ b/SYCL/Plugin/level_zero_batch_test_copy_with_compute.cpp
@@ -246,8 +246,8 @@ void validate(uint32_t *result, uint32_t *expect, size_t n) {
 }
 
 int main(int argc, char *argv[]) {
-  size_t M = 65536;
-  size_t N = 512 / 4;
+  size_t M = 16;
+  size_t N = 4;
   size_t AL = M * N * sizeof(uint32_t);
 
   sycl::queue q(sycl::default_selector{});


### PR DESCRIPTION
This testcase is used to test whether compute and copy commands are handled correctly in an expected way. Size of memory is not important for this test. However, existing testcase makes unnecessary use of large array sizes. This could have been the cause behind some of the flaky test failures seen in testing. This change reduces the memory size and should help to avoid any memory related failures.