### PR TITLE
[SYCL][CUDA] Add experimental cuda queue interop test

### DIFF
--- a/SYCL/Plugin/interop-cuda-experimental.cpp
+++ b/SYCL/Plugin/interop-cuda-experimental.cpp
@@ -95,4 +95,31 @@ int main() {
     sycl::queue new_Q(sycl_ctx, sycl::default_selector());
     assert(check_queue(new_Q));
   }
+
+  // Create new queue
+  CUstream cu_queue;
+  CUDA_CHECK(cuCtxSetCurrent(cu_ctx));
+  CUDA_CHECK(cuStreamCreate(&cu_queue, CU_STREAM_DEFAULT));
+
+  auto sycl_queue =
+      sycl::make_queue<sycl::backend::ext_oneapi_cuda>(cu_queue, sycl_ctx);
+  native_queue = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_queue);
+
+  check_type<sycl::queue>(sycl_queue);
+  check_type<CUstream>(native_queue);
+
+  // Submit some work to new queue
+  assert(check_queue(sycl_queue));
+
+  // Create new queue with Q's native type and submit some work
+  {
+    CUstream Q_native_stream =
+        sycl::get_native<sycl::backend::ext_oneapi_cuda>(Q);
+    sycl::queue new_Q = sycl::make_queue<sycl::backend::ext_oneapi_cuda>(
+        Q_native_stream, Q_sycl_ctx);
+    assert(check_queue(new_Q));
+  }
+
+  // Check Q still works
+  assert(check_queue(Q));
 }


### PR DESCRIPTION
This PR add testing of the CUDA backend experimental queue interop.

It checks that valid types are returned and that the created SYCL objects can be used to do work.
It additionally creates a queue from an already existing sycl queue's native handle and makes sure it and the original work.

Depends on: https://github.com/intel/llvm/pull/6290