### PR TITLE
[SYCL][CUDA] Enable working tests

### DIFF
--- a/SYCL/Assert/assert_in_kernels_ndebug.cpp
+++ b/SYCL/Assert/assert_in_kernels_ndebug.cpp
@@ -1,5 +1,5 @@
-// FIXME unsupported on CUDA and HIP until fallback libdevice becomes available
-// UNSUPPORTED: cuda || hip
+// FIXME unsupported on HIP until fallback libdevice becomes available
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DNDEBUG %S/assert_in_kernels.cpp -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER

--- a/SYCL/GroupAlgorithm/exclusive_scan_over_group.cpp
+++ b/SYCL/GroupAlgorithm/exclusive_scan_over_group.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: ze_debug4,ze_debug-1

--- a/SYCL/GroupAlgorithm/exclusive_scan_sycl2020.cpp
+++ b/SYCL/GroupAlgorithm/exclusive_scan_sycl2020.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_kernel %s -I . -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/GroupAlgorithm/inclusive_scan_sycl2020.cpp
+++ b/SYCL/GroupAlgorithm/inclusive_scan_sycl2020.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_kernel %s -I . -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/GroupAlgorithm/reduce_sycl2020.cpp
+++ b/SYCL/GroupAlgorithm/reduce_sycl2020.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_kernel %s -I . -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/SpecConstants/2020/handler-api.cpp
+++ b/SYCL/SpecConstants/2020/handler-api.cpp
@@ -13,8 +13,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // FIXME: ACC devices use emulation path, which is not yet supported
-// FIXME: CUDA uses emulation path, which is not yet supported
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 
 #include <cstdlib>
 #include <iostream>

--- a/SYCL/SpecConstants/2020/host_apis.cpp
+++ b/SYCL/SpecConstants/2020/host_apis.cpp
@@ -2,7 +2,6 @@
 // RUN:          -fsycl-dead-args-optimization
 // RUN: %BE_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda
 // UNSUPPORTED: hip
 
 #include <sycl/sycl.hpp>

--- a/SYCL/SpecConstants/2020/kernel-bundle-api.cpp
+++ b/SYCL/SpecConstants/2020/kernel-bundle-api.cpp
@@ -13,8 +13,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // FIXME: ACC devices use emulation path, which is not yet supported
-// FIXME: CUDA uses emulation path, which is not yet supported
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 
 #include <cstdlib>
 #include <iostream>

--- a/SYCL/SpecConstants/2020/non_native/cuda.cpp
+++ b/SYCL/SpecConstants/2020/non_native/cuda.cpp
@@ -3,8 +3,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda %S/Inputs/common.cpp -o %t.out
 // RUN: env SYCL_DEVICE_FILTER=cuda %t.out
 
-// TODO: enable this test then compile-time error in sycl-post-link is fixed
-// UNSUPPORTED: cuda
-
 // This test checks correctness of SYCL2020 non-native specialization constants
 // on CUDA device

--- a/SYCL/SpecConstants/2020/vector-convolution-demo.cpp
+++ b/SYCL/SpecConstants/2020/vector-convolution-demo.cpp
@@ -2,7 +2,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 
 // This test checks the spenario of using specialization constants with an
 // 'array of array' as well as a 'stuct with an array of array' types for


### PR DESCRIPTION
Enables tests that were marked with `UNSUPPORTED: cuda`, but are in fact passing.

Result of work on https://github.com/intel/llvm-test-suite/issues/249