### PR TITLE
[SYCL][CUDA] enable cuda bfloat16 test to make clear it is supported

### DIFF
--- a/SYCL/BFloat16/bfloat16_type.cpp
+++ b/SYCL/BFloat16/bfloat16_type.cpp
@@ -1,4 +1,6 @@
 // UNSUPPORTED: cuda || hip
+// Note: cuda is supported and tested in bfloat16_type_cuda.cpp.
+//       cuda compilation requires specifying the sm version.
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // TODO currently the feature isn't supported on most of the devices
 //      need to enable the test when the aspect and device_if feature are

--- a/SYCL/BFloat16/bfloat16_type.cpp
+++ b/SYCL/BFloat16/bfloat16_type.cpp
@@ -1,7 +1,5 @@
-// UNSUPPORTED: cuda || hip
-// Note: cuda is supported and tested in bfloat16_type_cuda.cpp.
-//       cuda compilation requires specifying the sm version.
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// UNSUPPORTED: hip
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %if cuda %{-Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
 // TODO currently the feature isn't supported on most of the devices
 //      need to enable the test when the aspect and device_if feature are
 //      introduced


### PR DESCRIPTION
bfloat16_type.cpp marks cuda as unsupported but the same test called in bfloat16_type.cpp runs on cuda in bfloat16_type_cuda.cpp. I added a note to bfloat16_type.cpp explaining this.