### PR TITLE
[SYCL][CUDA] Re-enable test for samplers

### DIFF
--- a/SYCL/Sampler/unnormalized-clamp-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clamp-nearest.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-clampedge-nearest.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Sampler/unnormalized-none-nearest.cpp
+++ b/SYCL/Sampler/unnormalized-none-nearest.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: hip || cuda
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %HOST_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This patch re-enables the tests disabled in https://github.com/intel/llvm-test-suite/pull/1052 due to https://github.com/intel/llvm/issues/6285 which is solved by https://github.com/intel/llvm/pull/6335.

Depends on: https://github.com/intel/llvm/pull/6335