### PR TITLE
[SYCL][CUDA] Explicitly adding extension headers in tests.

### DIFF
--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -6,13 +6,13 @@
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend --cuda-gpu-arch=sm_80
 // RUN: %t.out
-#include <sycl/ext/oneapi/experimental/bfloat16.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include <cmath>
 #include <vector>
 
-using namespace cl::sycl;
+using namespace sycl;
 using namespace sycl::ext::oneapi::experimental;
 
 constexpr int N = 60; // divisible by all tested array sizes

--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -6,8 +6,8 @@
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend --cuda-gpu-arch=sm_80
 // RUN: %t.out
-#include <sycl/sycl.hpp>
 #include <sycl/ext/oneapi/experimental/bfloat16.hpp>
+#include <sycl/sycl.hpp>
 
 #include <cmath>
 #include <vector>

--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -6,14 +6,14 @@
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend --cuda-gpu-arch=sm_80
 // RUN: %t.out
-
 #include <sycl/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/bfloat16.hpp>
 
 #include <cmath>
 #include <vector>
 
 using namespace cl::sycl;
-using sycl::ext::oneapi::experimental::bfloat16;
+using namespace sycl::ext::oneapi::experimental;
 
 constexpr int N = 60; // divisible by all tested array sizes
 constexpr float bf16_eps = 0.00390625;

--- a/SYCL/DeviceLib/built-ins/ext_native_math.cpp
+++ b/SYCL/DeviceLib/built-ins/ext_native_math.cpp
@@ -7,9 +7,9 @@
 // OpenCL CPU driver does not support cl_khr_fp16 extension for this reason this
 // test is compiled with the -fsycl-device-code-split flag
 
+#include <cassert>
 #include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
-#include <cassert>
 
 template <typename T> void assert_out_of_bound(T val, T lower, T upper) {
   assert(sycl::all(lower < val && val < upper));

--- a/SYCL/DeviceLib/built-ins/ext_native_math.cpp
+++ b/SYCL/DeviceLib/built-ins/ext_native_math.cpp
@@ -7,7 +7,8 @@
 // OpenCL CPU driver does not support cl_khr_fp16 extension for this reason this
 // test is compiled with the -fsycl-device-code-split flag
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 #include <cassert>
 
 template <typename T> void assert_out_of_bound(T val, T lower, T upper) {

--- a/SYCL/Matrix/element_wise_all_ops_cuda.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_cuda.cpp
@@ -9,7 +9,7 @@
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3 %s -o %t.out
 // RUN: %t.out
-#include <sycl/ext/oneapi/experimental/bfloat16.hpp>
+
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/SYCL/Matrix/element_wise_all_ops_cuda.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_cuda.cpp
@@ -9,8 +9,8 @@
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3 %s -o %t.out
 // RUN: %t.out
-#include <sycl/sycl.hpp>
 #include <sycl/ext/oneapi/experimental/bfloat16.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/SYCL/Matrix/element_wise_all_ops_cuda.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_cuda.cpp
@@ -9,8 +9,8 @@
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3 %s -o %t.out
 // RUN: %t.out
-
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/bfloat16.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/SYCL/Matrix/element_wise_wi_marray.cpp
+++ b/SYCL/Matrix/element_wise_wi_marray.cpp
@@ -10,6 +10,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3 %s -o %t.out
 // RUN: %t.out
 
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/SYCL/Matrix/element_wise_wi_marray.cpp
+++ b/SYCL/Matrix/element_wise_wi_marray.cpp
@@ -13,8 +13,8 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using sycl::ext::oneapi::experimental::bfloat16;
 
 #define SG_SZ 32
 

--- a/SYCL/Matrix/joint_matrix_tensorcore.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore.cpp
@@ -6,7 +6,7 @@
 // for the Nvidia case.  DPC++ JIT compilation is not
 // supported for the Nvidia matrix extension, although some JIT optimizations
 // are performed at the level of the PTX assembly code.
-#include <sycl/ext/oneapi/experimental/bfloat16.hpp>
+
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/SYCL/Matrix/joint_matrix_tensorcore.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore.cpp
@@ -6,12 +6,12 @@
 // for the Nvidia case.  DPC++ JIT compilation is not
 // supported for the Nvidia matrix extension, although some JIT optimizations
 // are performed at the level of the PTX assembly code.
-
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/bfloat16.hpp>
 
 using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using sycl::ext::oneapi::experimental::bfloat16;
 constexpr float bf16_eps = 0.00390625;
 
 // Example usage of Nvidia matrix multiply.

--- a/SYCL/Matrix/joint_matrix_tensorcore.cpp
+++ b/SYCL/Matrix/joint_matrix_tensorcore.cpp
@@ -6,8 +6,8 @@
 // for the Nvidia case.  DPC++ JIT compilation is not
 // supported for the Nvidia matrix extension, although some JIT optimizations
 // are performed at the level of the PTX assembly code.
-#include <sycl/sycl.hpp>
 #include <sycl/ext/oneapi/experimental/bfloat16.hpp>
+#include <sycl/sycl.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental;

--- a/SYCL/Printf/char.cpp
+++ b/SYCL/Printf/char.cpp
@@ -25,7 +25,8 @@
 // CHECK: literal strings: s=Hello World!
 // CHECK_DISABLED: non-literal strings: s=Hello, World! ls=
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include <cstring>
 

--- a/SYCL/Printf/double.cpp
+++ b/SYCL/Printf/double.cpp
@@ -28,7 +28,8 @@
 
 #include <iostream>
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include "helper.hpp"
 

--- a/SYCL/Printf/float.cpp
+++ b/SYCL/Printf/float.cpp
@@ -31,7 +31,8 @@
 
 #include <iostream>
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include "helper.hpp"
 

--- a/SYCL/Printf/int.cpp
+++ b/SYCL/Printf/int.cpp
@@ -20,7 +20,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.constant.out %GPU_CHECK_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.constant.out %ACC_CHECK_PLACEHOLDER
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include "helper.hpp"
 

--- a/SYCL/Printf/long.cpp
+++ b/SYCL/Printf/long.cpp
@@ -20,7 +20,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.constant.out %GPU_CHECK_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.constant.out %ACC_CHECK_PLACEHOLDER
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include "helper.hpp"
 

--- a/SYCL/Printf/mixed-address-space.cpp
+++ b/SYCL/Printf/mixed-address-space.cpp
@@ -12,7 +12,8 @@
 // CHECK: Constant addrspace literal
 // CHECK: Generic addrspace literal
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include "helper.hpp"
 

--- a/SYCL/Printf/percent-symbol.cpp
+++ b/SYCL/Printf/percent-symbol.cpp
@@ -23,7 +23,8 @@
 // CHECK: %c %s %d %i %o %x %X %u
 // CHECK-NEXT: %f %F %e %E %a %A %g %G %n %p
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include <cstring>
 


### PR DESCRIPTION
Explicitly including the extension headers since tests are complaining about missing extension functions/classes in : https://github.com/intel/llvm-test-suite/pull/975#issuecomment-1171407048.

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>