### PR TITLE
[SYCL][CUDA] Revert experimental/builtins.hpp includes

### DIFF
--- a/SYCL/BFloat16/bfloat16_builtins.cpp
+++ b/SYCL/BFloat16/bfloat16_builtins.cpp
@@ -6,7 +6,6 @@
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend --cuda-gpu-arch=sm_80
 // RUN: %t.out
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include <cmath>

--- a/SYCL/DeviceLib/built-ins/ext_native_math.cpp
+++ b/SYCL/DeviceLib/built-ins/ext_native_math.cpp
@@ -8,7 +8,6 @@
 // test is compiled with the -fsycl-device-code-split flag
 
 #include <cassert>
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 template <typename T> void assert_out_of_bound(T val, T lower, T upper) {

--- a/SYCL/DeviceLib/built-ins/printf.cpp
+++ b/SYCL/DeviceLib/built-ins/printf.cpp
@@ -7,7 +7,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.out %ACC_CHECK_PLACEHOLDER
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include <cstdint>

--- a/SYCL/ESIMD/printf.cpp
+++ b/SYCL/ESIMD/printf.cpp
@@ -21,7 +21,6 @@
 #include "esimd_test_utils.hpp"
 
 #include <sycl/ext/intel/esimd.hpp>
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include <cstdint>

--- a/SYCL/Matrix/element_wise_wi_marray.cpp
+++ b/SYCL/Matrix/element_wise_wi_marray.cpp
@@ -10,7 +10,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3 %s -o %t.out
 // RUN: %t.out
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/SYCL/Printf/char.cpp
+++ b/SYCL/Printf/char.cpp
@@ -25,7 +25,6 @@
 // CHECK: literal strings: s=Hello World!
 // CHECK_DISABLED: non-literal strings: s=Hello, World! ls=
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include <cstring>

--- a/SYCL/Printf/double.cpp
+++ b/SYCL/Printf/double.cpp
@@ -28,7 +28,6 @@
 
 #include <iostream>
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include "helper.hpp"

--- a/SYCL/Printf/float.cpp
+++ b/SYCL/Printf/float.cpp
@@ -31,7 +31,6 @@
 
 #include <iostream>
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include "helper.hpp"

--- a/SYCL/Printf/int.cpp
+++ b/SYCL/Printf/int.cpp
@@ -20,7 +20,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.constant.out %GPU_CHECK_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.constant.out %ACC_CHECK_PLACEHOLDER
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include "helper.hpp"

--- a/SYCL/Printf/long.cpp
+++ b/SYCL/Printf/long.cpp
@@ -20,7 +20,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.constant.out %GPU_CHECK_PLACEHOLDER
 // RUN: %ACC_RUN_PLACEHOLDER %t.constant.out %ACC_CHECK_PLACEHOLDER
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include "helper.hpp"

--- a/SYCL/Printf/mixed-address-space.cpp
+++ b/SYCL/Printf/mixed-address-space.cpp
@@ -12,7 +12,6 @@
 // CHECK: Constant addrspace literal
 // CHECK: Generic addrspace literal
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include "helper.hpp"

--- a/SYCL/Printf/percent-symbol.cpp
+++ b/SYCL/Printf/percent-symbol.cpp
@@ -23,7 +23,6 @@
 // CHECK: %c %s %d %i %o %x %X %u
 // CHECK-NEXT: %f %F %e %E %a %A %g %G %n %p
 
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/sycl.hpp>
 
 #include <cstring>


### PR DESCRIPTION
Reverts experimental/builtins.hpp includes added in https://github.com/intel/llvm-test-suite/pull/1072 and https://github.com/intel/llvm-test-suite/pull/1075.

Requires: https://github.com/intel/llvm/pull/6400