### PR TITLE
[SYCL][HIP] Fix assert tests

### DIFF
--- a/SYCL/Assert/assert_in_kernels.cpp
+++ b/SYCL/Assert/assert_in_kernels.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: linux
-// FIXME unsupported on HIP until fallback libdevice becomes available
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_kernels_ndebug.cpp
+++ b/SYCL/Assert/assert_in_kernels_ndebug.cpp
@@ -1,5 +1,3 @@
-// FIXME unsupported on HIP until fallback libdevice becomes available
-// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DNDEBUG %S/assert_in_kernels.cpp -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out %CPU_CHECK_PLACEHOLDER
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %GPU_CHECK_PLACEHOLDER

--- a/SYCL/Assert/assert_in_kernels_win.cpp
+++ b/SYCL/Assert/assert_in_kernels_win.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_multiple_tus.cpp
+++ b/SYCL/Assert/assert_in_multiple_tus.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: linux
-// FIXME unsupported on HIP until fallback libdevice becomes available
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -I %S/Inputs %s %S/Inputs/kernels_in_file2.cpp -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_multiple_tus_one_ndebug.cpp
+++ b/SYCL/Assert/assert_in_multiple_tus_one_ndebug.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: linux
-// FIXME unsupported on HIP until fallback libdevice becomes available
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
+++ b/SYCL/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_multiple_tus_win.cpp
+++ b/SYCL/Assert/assert_in_multiple_tus_win.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -I %S/Inputs %s %S/Inputs/kernels_in_file2.cpp -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_one_kernel.cpp
+++ b/SYCL/Assert/assert_in_one_kernel.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: linux
-// FIXME unsupported on HIP until fallback libdevice becomes available
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_one_kernel_win.cpp
+++ b/SYCL/Assert/assert_in_one_kernel_win.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_simultaneous_kernels.cpp
+++ b/SYCL/Assert/assert_in_simultaneous_kernels.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: linux
-// FIXME unsupported on HIP until fallback libdevice becomes available
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %threads_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_simultaneous_kernels_win.cpp
+++ b/SYCL/Assert/assert_in_simultaneous_kernels_win.cpp
@@ -1,5 +1,4 @@
 // REQUIRES: windows
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %threads_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/SYCL/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -1,6 +1,5 @@
-// FIXME unsupported on HIP until fallback libdevice becomes available
 // FIXME flaky output on Level Zero
-// UNSUPPORTED: hip || level_zero
+// UNSUPPORTED: level_zero
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -I %S/Inputs %s %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
+++ b/SYCL/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
@@ -1,5 +1,3 @@
-// FIXME unsupported on HIP until fallback libdevice becomes available
-// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_simultaneously_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt

--- a/SYCL/Regression/kernel_bundle_ignore_sycl_external.cpp
+++ b/SYCL/Regression/kernel_bundle_ignore_sycl_external.cpp
@@ -3,7 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 //
-// XFAIL: cuda || hip_nvidia
+// XFAIL: cuda || hip
 
 #include <CL/sycl.hpp>
 

--- a/SYCL/SeparateCompile/sycl-external.cpp
+++ b/SYCL/SeparateCompile/sycl-external.cpp
@@ -15,9 +15,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.exe
 // RUN: %GPU_RUN_PLACEHOLDER %t.exe
 // RUN: %ACC_RUN_PLACEHOLDER %t.exe
-//
-// Linking issues with HIP AMD
-// XFAIL: hip_amd
 
 #include <CL/sycl.hpp>
 #include <iostream>


### PR DESCRIPTION
Assert is now implemented for HIP.

Additionally fixing the assert multiple tus tests led to fixing the
`sycl-external.cpp` test. It turns out that the AMDGPU llvm backend was
running some dead code elimination and deleting `SYCL_EXTERNAL`
functions, this is also why `kernel_bundle_ignore_sycl_external.cpp`
worked on AMD, not because it was behaving correctly but because the DCE
was deleting the `SYCL_EXTERNAL` function so it looked "ignored" from
the kernel bundle, this test is now marked as failing again.

The tests in this PR are fixed by https://github.com/intel/llvm/pull/6424