### PR TITLE
[SYCL][CUDA] Fix compile command in gpu.cpp

### DIFF
--- a/SYCL/Regression/commandlist/gpu.cpp
+++ b/SYCL/Regression/commandlist/gpu.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: gpu, linux
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 // UNSUPPORTED: ze_debug-1,ze_debug4
 //
-// RUN: %clangxx -fsycl %S/Inputs/FindPrimesSYCL.cpp %S/Inputs/main.cpp -o %t.out -lpthread
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %S/Inputs/FindPrimesSYCL.cpp %S/Inputs/main.cpp -o %t.out -lpthread
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Fixes compile command in `gpu.hpp`, fixing the test for CUDA backend.