### PR TITLE
[SYCL][HIP] Re-enable aspect::atomic64 tests

### DIFF
--- a/SYCL/AtomicRef/assignment_atomic64.cpp
+++ b/SYCL/AtomicRef/assignment_atomic64.cpp
@@ -4,9 +4,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// XFAIL: hip
-// Expected failure because hip does not have atomic64 check implementation
-
 #include "assignment.h"
 #include <iostream>
 using namespace sycl;

--- a/SYCL/Basic/aspects.cpp
+++ b/SYCL/Basic/aspects.cpp
@@ -4,9 +4,6 @@
 // Hip is missing some of the parameters tested here so it fails with NVIDIA
 // XFAIL: hip_nvidia
 
-// XFAIL: hip
-// Expected failure because hip does not have atomic64 check implementation
-
 //==--------------- aspects.cpp - SYCL device test ------------------------==//
 //
 // Returns the various aspects of a device  and platform.


### PR DESCRIPTION
This patch re-enables the ``aspect::atomic64 tests`` for HIP after the ``PI_DEVICE_INFO_ATOMIC_64`` implementation
in https://github.com/intel/llvm/pull/6429.