### PR TITLE
[SYCL][HIP] Disable flaky HIP test

### DIFF
--- a/SYCL/Assert/assert_in_simultaneous_kernels.cpp
+++ b/SYCL/Assert/assert_in_simultaneous_kernels.cpp
@@ -1,4 +1,6 @@
 // REQUIRES: linux
+// FIXME: Flaky on HIP
+// UNSUPPORTED: hip
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %threads_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt


### PR DESCRIPTION
This test was re-enabled as it passed locally but unfortunately it seems that it is flaky on the CI, so revert it to unsupported for now.

See ticket https://github.com/intel/llvm/issues/6520 for further investigations.