### PR TITLE
[SYCL][CUDA] Enable Basic Image tests

### DIFF
--- a/SYCL/Basic/image/image_array.cpp
+++ b/SYCL/Basic/image/image_array.cpp
@@ -1,5 +1,4 @@
-// UNSUPPORTED: cuda || hip
-// CUDA cannot support SYCL 1.2.1 images.
+// UNSUPPORTED: hip
 //
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUNx: %HOST_RUN_PLACEHOLDER %t.out

--- a/SYCL/Basic/image/image_sample.cpp
+++ b/SYCL/Basic/image/image_sample.cpp
@@ -2,7 +2,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // Temporarily disable test on Windows due to regressions in GPU driver.
-// UNSUPPORTED: cuda || hip, windows
+// UNSUPPORTED: hip, windows
 
 #include <sycl/sycl.hpp>
 

--- a/SYCL/Regression/image_access.cpp
+++ b/SYCL/Regression/image_access.cpp
@@ -4,8 +4,8 @@
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // No execution of FPGA because it does not support images
 //
-// UNSUPPORTED: cuda || hip
-// CUDA cannot support OpenCL spec conform images.
+// UNSUPPORTED: hip
+// CUDA doesn't fully support OpenCL spec conform images.
 
 //==-------------- image_access.cpp - SYCL image accessors test  -----------==//
 //


### PR DESCRIPTION
This patch enables some tests that are now supported by the CUDA backend.

This is related to https://github.com/intel/llvm-test-suite/issues/249.