### PR TITLE
[SYCL] Enable reduction_nd_n_vars test

### DIFF
--- a/SYCL/Reduction/reduction_nd_N_vars.cpp
+++ b/SYCL/Reduction/reduction_nd_N_vars.cpp
@@ -3,9 +3,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// TODO: The test irregularly reports incorrect.
-// REQUIRES: TEMPORARY_DISABLED
-
 // This test checks handling of parallel_for() accepting nd_range and
 // two or more reductions.
 


### PR DESCRIPTION
Was disabled due to the issue in CPU OpenCL runtime 2021.13.11.0.

Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>