### PR TITLE
[SYCL] Enable assert_in_simultaneously_multiple_tus back for LevelZero

### DIFF
--- a/SYCL/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/SYCL/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -1,5 +1,3 @@
-// FIXME flaky output on Level Zero
-// UNSUPPORTED: level_zero
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -I %S/Inputs %s %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
 // RUN: %CPU_RUN_PLACEHOLDER %t.out &> %t.txt || true
 // RUN: %CPU_RUN_PLACEHOLDER FileCheck %s --input-file %t.txt


### PR DESCRIPTION
Original issue is fixed by https://github.com/intel/llvm/commit/1f531c060acc5e89476ba576468f1ca13d9d68e9.

Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>