### PR TITLE
[SYCL][HIP] Disable device_num.cpp

### DIFF
--- a/SYCL/Regression/device_num.cpp
+++ b/SYCL/Regression/device_num.cpp
@@ -5,8 +5,8 @@
 // RUN: env SYCL_DEVICE_FILTER=2 env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
 // RUN: env SYCL_DEVICE_FILTER=3 env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
 
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero
+// Temporarily disable on L0 and HIP due to fails in CI
+// UNSUPPORTED: level_zero, hip
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Disables `device_num.cpp`, which was enabled recently in https://github.com/intel/llvm-test-suite/pull/1081 and despite working locally fails on CI.