### PR TITLE
Revert "[SYCL] temporarily disable tests"

### DIFF
--- a/SYCL/Basic/context-with-multiple-devices.cpp
+++ b/SYCL/Basic/context-with-multiple-devices.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: windows || linux
-//   temporarily disabled
-
 // REQUIRES: accelerator, opencl-aot
 
 // RUN: %clangxx -fsycl -fintelfpga -fsycl-unnamed-lambda %s -o %t2.out

--- a/SYCL/Basic/interop/check_carrying_real_kernel_IDs.cpp
+++ b/SYCL/Basic/interop/check_carrying_real_kernel_IDs.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: windows || linux
-//   temporarily disabled
-
 // REQUIRES: opencl, opencl_icd
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %opencl_lib
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/DiscardEvents/invalid_event_exceptions.cpp
+++ b/SYCL/DiscardEvents/invalid_event_exceptions.cpp
@@ -1,6 +1,3 @@
-// UNSUPPORTED: windows || linux
-//   temporarily disabled
-
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 //
 // RUN: %HOST_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
Reverts intel/llvm-test-suite#983
Expect to pass after https://github.com/intel/llvm/pull/6563