### PR TITLE
[SYCL][ESIMD][EMU] Enabling dpas_test1/2/3 tests

### DIFF
--- a/SYCL/ESIMD/dpas/dpas_test1.cpp
+++ b/SYCL/ESIMD/dpas/dpas_test1.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-dg2
+// REQUIRES: gpu-intel-dg2 || esimd_emulator
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/dpas/dpas_test2.cpp
+++ b/SYCL/ESIMD/dpas/dpas_test2.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc
+// REQUIRES: gpu-intel-pvc || esimd_emulator
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -DESIMD_XE_HPC %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/dpas/dpas_test3.cpp
+++ b/SYCL/ESIMD/dpas/dpas_test3.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc
+// REQUIRES: gpu-intel-pvc || esimd_emulator
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -DESIMD_XE_HPC %s -DVER1 -o %t.out1
 // RUN: %clangxx -fsycl -DESIMD_XE_HPC %s -DVER2 -o %t.out2


### PR DESCRIPTION
- Bringing back of PR#1110 as all dpas tests are passing after PR -
https://github.com/intel/llvm/pull/6475 is merged in intel/llvm:sycl