### PR TITLE
[SYCL] disable esimd_preemption on dg2

### DIFF
--- a/SYCL/ESIMD/preemption.cpp
+++ b/SYCL/ESIMD/preemption.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && linux
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: esimd_emulator
+// UNSUPPORTED: esimd_emulator, gpu-intel-dg2
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER IGC_DumpToCustomDir=%t.dump IGC_ShaderDumpEnable=1 %t.out
 // RUN: grep enablePreemption %t.dump/*.asm


### PR DESCRIPTION
Mid-thread preemption is not supported on DG2. See IGC-3240 for more info.