### PR TITLE
Remove incorrect XFAIL

### DIFF
--- a/SYCL/AtomicRef/device_has_aspect_atomic64_cuda_and_hip.cpp
+++ b/SYCL/AtomicRef/device_has_aspect_atomic64_cuda_and_hip.cpp
@@ -2,9 +2,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// XFAIL: hip
-// Expected failure because hip does not have atomic64 check implementation
-
 #include <CL/sycl.hpp>
 #include <iostream>
 


### PR DESCRIPTION
Support for atomic64 aspect query on HIP was added in:

```
commit cb190fc25d56f42b3283a3a31c13ead47be46f60
Author: pgorlani <92453485+pgorlani@users.noreply.github.com>
Date:   Fri Aug 12 18:54:29 2022 +0100

    [SYCL][HIP] Implement PI_DEVICE_INFO_ATOMIC_64 for HIP (intel/llvm#6429)
```