### PR TITLE
[SYCL][L0] Fix has_aspect_atomic64 test and reenable it

### DIFF
--- a/SYCL/AtomicRef/device_has_aspect_atomic64_level_zero.cpp
+++ b/SYCL/AtomicRef/device_has_aspect_atomic64_level_zero.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, level_zero_dev_kit, TEMPORARY_DISABLED
+// REQUIRES: level_zero, level_zero_dev_kit
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out %level_zero_options
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
@@ -11,7 +11,7 @@ int main() {
   queue Queue;
   device Dev = Queue.get_device();
   bool Result;
-  ze_device_module_properties_t Properties;
+  ze_device_module_properties_t Properties{};
   zeDeviceGetModuleProperties(get_native<backend::ext_oneapi_level_zero>(Dev),
                               &Properties);
   if (Properties.flags & ZE_DEVICE_MODULE_FLAG_INT64_ATOMICS)


### PR DESCRIPTION
[zeDeviceGetModuleProperties ](https://spec.oneapi.io/level-zero/latest/core/api.html#_CPPv427zeDeviceGetModuleProperties18ze_device_handle_tP29ze_device_module_properties_t) parameter [ze_device_module_properties_t](https://spec.oneapi.io/level-zero/latest/core/api.html#_CPPv429ze_device_module_properties_t) is an in/out parameter. It has void [*pNext](https://spec.oneapi.io/level-zero/latest/core/api.html#_CPPv4N29ze_device_module_properties_t5pNextE) field where you can attach extensions to be filled too. So we should initialize the structure to not confuse backend by trash in the pNext pointer field that may lead either to hang or seg fault.

Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>