### PR TITLE
Revert "[SYCL][ESIMD][EMU] LSC Atomic update for emulator backend (#1…

### DIFF
--- a/SYCL/ESIMD/dword_atomic_cmpxchg.cpp
+++ b/SYCL/ESIMD/dword_atomic_cmpxchg.cpp
@@ -9,8 +9,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
-// TODO: esimd_emulator fails due to random timeouts (_XFAIL_: esimd_emulator)
-// UNSUPPORTED: esimd_emulator
+// TODO: esimd_emulator fails due to unsupported __esimd_svm_atomic0/1/2
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/dword_atomic_smoke.cpp
+++ b/SYCL/ESIMD/dword_atomic_smoke.cpp
@@ -9,6 +9,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
 // UNSUPPORTED: cuda || hip
+// TODO: esimd_emulator fails due to unsupported __esimd_svm_atomic0/1/2
+// XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/lsc/Inputs/lsc_surf.hpp
+++ b/SYCL/ESIMD/lsc/Inputs/lsc_surf.hpp
@@ -75,8 +75,8 @@ int main() {
             lsc_atomic_update<atomic_op::inc, int>(access_2, offsets, pred);
             lsc_atomic_update<atomic_op::add, int>(access_3, offsets, add,
                                                    pred);
-            lsc_atomic_update<atomic_op::cmpxchg, int>(access_4, offsets, swap,
-                                                       compare, pred);
+            lsc_atomic_update<atomic_op::cmpxchg, int>(access_4, offsets,
+                                                       compare, swap, pred);
           });
     });
     q.wait();

--- a/SYCL/ESIMD/lsc/lsc_fence.cpp
+++ b/SYCL/ESIMD/lsc/lsc_fence.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || esimd_emulator
+// REQUIRES: gpu-intel-pvc
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/lsc/lsc_slm.cpp
+++ b/SYCL/ESIMD/lsc/lsc_slm.cpp
@@ -81,8 +81,8 @@ int main() {
             lsc_block_store<int, SIMDSize>(access_3, offset, data_3);
 
             lsc_slm_block_store<int, SIMDSize>(offset, data);
-            lsc_slm_atomic_update<atomic_op::cmpxchg, int>(offsets, swap,
-                                                           compare, pred);
+            lsc_slm_atomic_update<atomic_op::cmpxchg, int>(offsets, compare,
+                                                           swap, pred);
             auto data_4 = lsc_slm_block_load<int, SIMDSize>(offset);
             lsc_block_store<int, SIMDSize>(access_4, offset, data_4);
           });

--- a/SYCL/ESIMD/lsc/lsc_usm.cpp
+++ b/SYCL/ESIMD/lsc/lsc_usm.cpp
@@ -69,8 +69,8 @@ int main() {
 
             lsc_atomic_update<atomic_op::inc, int>(vec_2, offsets, pred);
             lsc_atomic_update<atomic_op::add, int>(vec_3, offsets, add, pred);
-            lsc_atomic_update<atomic_op::cmpxchg, int>(vec_4, offsets, swap,
-                                                       compare, pred);
+            lsc_atomic_update<atomic_op::cmpxchg, int>(vec_4, offsets, compare,
+                                                       swap, pred);
           });
     });
     q.wait();


### PR DESCRIPTION
PR#1259 was based on changes applied in https://github.com/intel/llvm/pull/6661 . As the PR#6661 is still under review (as of Sept 14th), changes from PR#1259 causes unexpected failures for the ESIMD_EMULATOR backend for other PRs in intel/llvm, such as PR#6780 in above comment.