### PR TITLE
[SYCL] Disable Basic/buffer/buffer_migrate.cpp

### DIFF
--- a/SYCL/Basic/buffer/buffer_migrate.cpp
+++ b/SYCL/Basic/buffer/buffer_migrate.cpp
@@ -1,3 +1,5 @@
+// The test is flaky, disable until investigated/fixed.
+// REQUIRES: TEMPORARILY_DISABLED
 // REQUIRES: gpu
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -7,6 +9,7 @@
 // Test for buffer use in a context with multiple devices (all found
 // root-devices)
 //
+
 
 #include <iostream>
 #include <sycl/sycl.hpp>

--- a/SYCL/Basic/buffer/buffer_migrate.cpp
+++ b/SYCL/Basic/buffer/buffer_migrate.cpp
@@ -10,7 +10,6 @@
 // root-devices)
 //
 
-
 #include <iostream>
 #include <sycl/sycl.hpp>
 using namespace sycl;


### PR DESCRIPTION
It is flaky (at least on local systems) and should be disabled until the behavior is fixed.