### PR TITLE
[SYCL] Change device preference to acknowledge ESIMD_EMULATOR

### DIFF
--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -37,17 +37,12 @@ namespace esimd_test {
 class ESIMDSelector : public device_selector {
   // Require GPU device
   virtual int operator()(const device &device) const {
-    if (const char *dev_filter = getenv("SYCL_DEVICE_FILTER")) {
-      std::string filter_string(dev_filter);
-      if (filter_string.find("gpu") != std::string::npos)
-        return device.is_gpu() ? 1000 : -1;
-      std::cerr
-          << "Supported 'SYCL_DEVICE_FILTER' env var values is 'gpu' and '"
-          << filter_string << "' does not contain such substrings.\n";
-      return -1;
+    std::string name = device.get_info<info::device::name>();
+    if (name.find("ESIMD_EMULATOR") != std::string::npos) {
+      return 1000;
+    } else { 
+        return 0; 
     }
-    // If "SYCL_DEVICE_FILTER" not defined, only allow gpu device
-    return device.is_gpu() ? 1000 : -1;
   }
 };
 

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -39,13 +39,12 @@ class ESIMDSelector : public device_selector {
   virtual int operator()(const device &device) const {
     if (device.get_backend() == backend::ext_intel_esimd_emulator) {
       return 1000;
-    } 
-    else if (device.is_gpu()) {
-      // pick gpu device if esimd not available but give it a lower score in order not to compete with the esimd
-      // in environments where both are present
+    } else if (device.is_gpu()) {
+      // pick gpu device if esimd not available but give it a lower score in
+      // order not to compete with the esimd in environments where both are
+      // present
       return 900;
-    }
-    else {
+    } else {
       return 0;
     }
   }

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -39,7 +39,13 @@ class ESIMDSelector : public device_selector {
   virtual int operator()(const device &device) const {
     if (device.get_backend() == backend::ext_intel_esimd_emulator) {
       return 1000;
-    } else {
+    } 
+    else if (device.is_gpu()) {
+      // pick gpu device if esimd not available but give it a lower score in order not to compete with the esimd
+      // in environments where both are present
+      return 900;
+    }
+    else {
       return 0;
     }
   }

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -38,7 +38,7 @@ class ESIMDSelector : public device_selector {
   // Require GPU device
   virtual int operator()(const device &device) const {
     std::string name = device.get_info<info::device::name>();
-    if (name.find("ESIMD_EMULATOR") != std::string::npos) {
+    if (device.get_backend() == backend::ext_intel_esimd_emulator) {
       return 1000;
     } else {
       return 0;

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -39,6 +39,9 @@ class ESIMDSelector : public device_selector {
   virtual int operator()(const device &device) const {
     if (device.get_backend() == backend::ext_intel_esimd_emulator) {
       return 1000;
+    } else if (device.is_gpu()) {
+      // ideally, here should be a check that device's vendor is Intel
+      return 1000;
     } else {
       return 0;
     }

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -40,8 +40,8 @@ class ESIMDSelector : public device_selector {
     std::string name = device.get_info<info::device::name>();
     if (name.find("ESIMD_EMULATOR") != std::string::npos) {
       return 1000;
-    } else { 
-        return 0; 
+    } else {
+      return 0;
     }
   }
 };

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -37,7 +37,6 @@ namespace esimd_test {
 class ESIMDSelector : public device_selector {
   // Require GPU device
   virtual int operator()(const device &device) const {
-    std::string name = device.get_info<info::device::name>();
     if (device.get_backend() == backend::ext_intel_esimd_emulator) {
       return 1000;
     } else {

--- a/SYCL/Regression/device_num.cpp
+++ b/SYCL/Regression/device_num.cpp
@@ -4,6 +4,7 @@
 // RUN: env SYCL_DEVICE_FILTER=1 env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
 // RUN: env SYCL_DEVICE_FILTER=2 env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
 // RUN: env SYCL_DEVICE_FILTER=3 env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
+
 // Temporarily disable on L0 and HIP due to fails in CI
 // UNSUPPORTED: level_zero, hip
 

--- a/SYCL/Regression/device_num.cpp
+++ b/SYCL/Regression/device_num.cpp
@@ -134,9 +134,12 @@ int GetPreferredDeviceIndex(const std::vector<device> &devices,
       index = i;
     }
   }
-  if (index >= 0 && devices[index].get_backend() == backend::ext_intel_esimd_emulator && eligible_devices > 1) {
-    // if we chose ESIMD_EMULATOR, then must only return it if there are no other suitable devices in the system.
-    // Otherwise, we return the runner up device.
+  if (index >= 0 &&
+      devices[index].get_backend() == backend::ext_intel_esimd_emulator &&
+      eligible_devices > 1) {
+    // if we chose ESIMD_EMULATOR, then must only return it if there are no
+    // other suitable devices in the system. Otherwise, we return the runner up
+    // device.
     return runnerup_index;
   }
   return index;


### PR DESCRIPTION
This change affects file device_num.cpp in SYCL/Regression. The test has been modified to reflect the presence of ESIMD_EMULATOR when calculating device preferences for the selectors. In particular, it has been changed to prefer the ESIMD device if and only if there are no other suitable devices because running SYCL kernels on ESIMD devices will crash the program. Also, the esimd emulator class in file SYCL/ESIMD/esimd_test_utils.hpp has been changed to actually prefer the ESIMD device. Previously it was just selecting a normal gpu device.