### PR TITLE
[SYCL] Change library loading and fix esimd selector function

### DIFF
--- a/SYCL/Basic/library_loading.cpp
+++ b/SYCL/Basic/library_loading.cpp
@@ -12,6 +12,7 @@ using namespace sycl;
 
 int main() {
   // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_cuda.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_cuda.so)}}
+  // CHECK-NO-FILTER-NOT: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
   // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_hip.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_hip.so)}}
   // CHECK-ESIMD-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
   queue q;

--- a/SYCL/Basic/library_loading.cpp
+++ b/SYCL/Basic/library_loading.cpp
@@ -4,8 +4,8 @@
 // RUN: FileCheck --input-file=%t_trace_no_filter.txt --check-prefix=CHECK-NO-FILTER %s
 // RUN: env SYCL_PI_TRACE=-1 SYCL_DEVICE_FILTER=esimd_emulator %t.out &> %t_trace_esimd_filter.txt || true
 // RUN: FileCheck --input-file=%t_trace_esimd_filter.txt --check-prefix=CHECK-ESIMD-FILTER %s
-
 // Checks pi traces on library loading
+
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/SYCL/Basic/library_loading.cpp
+++ b/SYCL/Basic/library_loading.cpp
@@ -1,9 +1,7 @@
 // REQUIRES: linux
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_PI_TRACE=-1 %t.out &> %t_trace_no_filter.txt || true
-// RUN: FileCheck --input-file=%t_trace_no_filter.txt --check-prefix=CHECK-NO-FILTER %s
-// RUN: env SYCL_PI_TRACE=-1 SYCL_DEVICE_FILTER=esimd_emulator %t.out &> %t_trace_esimd_filter.txt || true
-// RUN: FileCheck --input-file=%t_trace_esimd_filter.txt --check-prefix=CHECK-ESIMD-FILTER %s
+// RUN: env SYCL_PI_TRACE=-1 %t.out &> %t_trace.txt || true
+// RUN: FileCheck --input-file=%t_trace.txt %s
 
 // Checks pi traces on library loading
 #include <sycl/sycl.hpp>
@@ -11,9 +9,9 @@
 using namespace sycl;
 
 int main() {
-  // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_cuda.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_cuda.so)}}
-  // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_hip.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_hip.so)}}
-  // CHECK-ESIMD-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
+  // CHECK: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_cuda.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_cuda.so)}}
+  // CHECK: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_hip.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_hip.so)}}
+  // CHECK: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
   queue q;
   q.submit([&](handler &cgh) {});
 }

--- a/SYCL/Basic/library_loading.cpp
+++ b/SYCL/Basic/library_loading.cpp
@@ -1,7 +1,9 @@
 // REQUIRES: linux
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: env SYCL_PI_TRACE=-1 %t.out &> %t_trace.txt || true
-// RUN: FileCheck --input-file=%t_trace.txt %s
+// RUN: env SYCL_PI_TRACE=-1 %t.out &> %t_trace_no_filter.txt || true
+// RUN: FileCheck --input-file=%t_trace_no_filter.txt --check-prefix=CHECK-NO-FILTER %s
+// RUN: env SYCL_PI_TRACE=-1 SYCL_DEVICE_FILTER=esimd_emulator %t.out &> %t_trace_esimd_filter.txt || true
+// RUN: FileCheck --input-file=%t_trace_esimd_filter.txt --check-prefix=CHECK-ESIMD-FILTER %s
 
 // Checks pi traces on library loading
 #include <sycl/sycl.hpp>
@@ -9,9 +11,9 @@
 using namespace sycl;
 
 int main() {
-  // CHECK: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_cuda.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_cuda.so)}}
-  // CHECK: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_hip.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_hip.so)}}
-  // CHECK: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
+  // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_cuda.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_cuda.so)}}
+  // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_hip.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_hip.so)}}
+  // CHECK-ESIMD-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
   queue q;
   q.submit([&](handler &cgh) {});
 }

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -47,7 +47,7 @@ class ESIMDSelector : public device_selector {
     } else {
       return 0;
     }
-}
+  }
 };
 
 inline auto createExceptionHandler() {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -34,8 +34,8 @@ namespace esimd_test {
 // which '()' returned the highest number, is selected. If a negative number
 // was returned for all devices, then the selection process will cause an
 // exception.
-  // Require GPU device
-int ESIMDSelector(const device &device)  {
+// Require GPU device
+int ESIMDSelector(const device &device) {
   if (device.get_backend() == backend::ext_intel_esimd_emulator) {
     return 1000;
   } else if (device.is_gpu()) {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -37,22 +37,17 @@ namespace esimd_test {
 class ESIMDSelector : public device_selector {
   // Require GPU device
   virtual int operator()(const device &device) const {
-    if (const char *dev_filter = getenv("SYCL_DEVICE_FILTER")) {
-      std::string filter_string(dev_filter);
-      if (filter_string.find("gpu") != std::string::npos)
-        return device.is_gpu() ? 1000 : -1;
-      std::cerr
-          << "Supported 'SYCL_DEVICE_FILTER' env var values is 'gpu' and '"
-          << filter_string << "' does not contain such substrings.\n";
-      return -1;
+    if (device.get_backend() == backend::ext_intel_esimd_emulator) {
+      return 1000;
+    } else if (device.is_gpu()) {
+      // pick gpu device if esimd not available but give it a lower score in
+      // order not to compete with the esimd in environments where both are
+      // present
+      return 900;
+    } else {
+      return 0;
     }
-<<<<<<< HEAD
 }
-=======
-    // If "SYCL_DEVICE_FILTER" not defined, only allow gpu device
-    return device.is_gpu() ? 1000 : -1;
-  }
->>>>>>> parent of ef7bb5c3 (Change library loading and fix esimd selector function)
 };
 
 inline auto createExceptionHandler() {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -26,7 +26,7 @@ using namespace sycl;
 
 namespace esimd_test {
 
-// This is function provided to SYCL runtime by the application to decide
+// This is the class provided to SYCL runtime by the application to decide
 // on which device to run, or whether to run at all.
 // When selecting a device, SYCL runtime first takes (1) a selector provided by
 // the program or a default one and (2) the set of all available devices. Then
@@ -47,7 +47,7 @@ class ESIMDSelector : public device_selector {
     } else {
       return 0;
     }
-}
+  }
 };
 
 inline auto createExceptionHandler() {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -26,7 +26,7 @@ using namespace sycl;
 
 namespace esimd_test {
 
-// This is the class provided to SYCL runtime by the application to decide
+// This is the function provided to SYCL runtime by the application to decide
 // on which device to run, or whether to run at all.
 // When selecting a device, SYCL runtime first takes (1) a selector provided by
 // the program or a default one and (2) the set of all available devices. Then
@@ -34,21 +34,19 @@ namespace esimd_test {
 // which '()' returned the highest number, is selected. If a negative number
 // was returned for all devices, then the selection process will cause an
 // exception.
-class ESIMDSelector : public device_selector {
   // Require GPU device
-  virtual int operator()(const device &device) const {
-    if (device.get_backend() == backend::ext_intel_esimd_emulator) {
-      return 1000;
-    } else if (device.is_gpu()) {
-      // pick gpu device if esimd not available but give it a lower score in
-      // order not to compete with the esimd in environments where both are
-      // present
-      return 900;
-    } else {
-      return 0;
-    }
+int ESIMDSelector(const device &device)  {
+  if (device.get_backend() == backend::ext_intel_esimd_emulator) {
+    return 1000;
+  } else if (device.is_gpu()) {
+    // pick gpu device if esimd not available but give it a lower score in
+    // order not to compete with the esimd in environments where both are
+    // present
+    return 900;
+  } else {
+    return 0;
   }
-};
+}
 
 inline auto createExceptionHandler() {
   return [](exception_list l) {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -37,17 +37,16 @@ namespace esimd_test {
 class ESIMDSelector : public device_selector {
   // Require GPU device
   virtual int operator()(const device &device) const {
-    if (const char *dev_filter = getenv("SYCL_DEVICE_FILTER")) {
-      std::string filter_string(dev_filter);
-      if (filter_string.find("gpu") != std::string::npos)
-        return device.is_gpu() ? 1000 : -1;
-      std::cerr
-          << "Supported 'SYCL_DEVICE_FILTER' env var values is 'gpu' and '"
-          << filter_string << "' does not contain such substrings.\n";
-      return -1;
+    if (device.get_backend() == backend::ext_intel_esimd_emulator) {
+      return 1000;
+    } else if (device.is_gpu()) {
+      // pick gpu device if esimd not available but give it a lower score in
+      // order not to compete with the esimd in environments where both are
+      // present
+      return 900;
+    } else {
+      return 0;
     }
-    // If "SYCL_DEVICE_FILTER" not defined, only allow gpu device
-    return device.is_gpu() ? 1000 : -1;
   }
 };
 

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -37,17 +37,22 @@ namespace esimd_test {
 class ESIMDSelector : public device_selector {
   // Require GPU device
   virtual int operator()(const device &device) const {
-    if (device.get_backend() == backend::ext_intel_esimd_emulator) {
-      return 1000;
-    } else if (device.is_gpu()) {
-      // pick gpu device if esimd not available but give it a lower score in
-      // order not to compete with the esimd in environments where both are
-      // present
-      return 900;
-    } else {
-      return 0;
+    if (const char *dev_filter = getenv("SYCL_DEVICE_FILTER")) {
+      std::string filter_string(dev_filter);
+      if (filter_string.find("gpu") != std::string::npos)
+        return device.is_gpu() ? 1000 : -1;
+      std::cerr
+          << "Supported 'SYCL_DEVICE_FILTER' env var values is 'gpu' and '"
+          << filter_string << "' does not contain such substrings.\n";
+      return -1;
     }
+<<<<<<< HEAD
 }
+=======
+    // If "SYCL_DEVICE_FILTER" not defined, only allow gpu device
+    return device.is_gpu() ? 1000 : -1;
+  }
+>>>>>>> parent of ef7bb5c3 (Change library loading and fix esimd selector function)
 };
 
 inline auto createExceptionHandler() {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -36,11 +36,11 @@ namespace esimd_test {
 // exception.
 // Require GPU device
 inline int ESIMDSelector(const device &device) {
-  std::string intel{"Intel(R) Corporation"};
+  const std::string intel{"Intel(R) Corporation"};
   if (device.get_backend() == backend::ext_intel_esimd_emulator) {
     return 1000;
   } else if (device.is_gpu() &&
-             device.get_info<info::device::vendor>() == intel) {
+             (device.get_info<info::device::vendor>() == intel)) {
     // pick gpu device if esimd not available but give it a lower score in
     // order not to compete with the esimd in environments where both are
     // present

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -44,7 +44,7 @@ inline int ESIMDSelector(const device &device) {
     // present
     return 900;
   } else {
-    return 0;
+    return -1;
   }
 }
 

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -36,10 +36,11 @@ namespace esimd_test {
 // exception.
 // Require GPU device
 inline int ESIMDSelector(const device &device) {
-  std::string intel{ "Intel(R) Corporation" };
+  std::string intel{"Intel(R) Corporation"};
   if (device.get_backend() == backend::ext_intel_esimd_emulator) {
     return 1000;
-  } else if (device.is_gpu() && device.get_info<info::device::vendor>() == intel) {
+  } else if (device.is_gpu() &&
+             device.get_info<info::device::vendor>() == intel) {
     // pick gpu device if esimd not available but give it a lower score in
     // order not to compete with the esimd in environments where both are
     // present

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -35,7 +35,7 @@ namespace esimd_test {
 // was returned for all devices, then the selection process will cause an
 // exception.
 // Require GPU device
-int ESIMDSelector(const device &device) {
+inline int ESIMDSelector(const device &device) {
   if (device.get_backend() == backend::ext_intel_esimd_emulator) {
     return 1000;
   } else if (device.is_gpu()) {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -47,7 +47,7 @@ class ESIMDSelector : public device_selector {
     } else {
       return 0;
     }
-  }
+}
 };
 
 inline auto createExceptionHandler() {

--- a/SYCL/ESIMD/esimd_test_utils.hpp
+++ b/SYCL/ESIMD/esimd_test_utils.hpp
@@ -36,9 +36,10 @@ namespace esimd_test {
 // exception.
 // Require GPU device
 inline int ESIMDSelector(const device &device) {
+  std::string intel{ "Intel(R) Corporation" };
   if (device.get_backend() == backend::ext_intel_esimd_emulator) {
     return 1000;
-  } else if (device.is_gpu()) {
+  } else if (device.is_gpu() && device.get_info<info::device::vendor>() == intel) {
     // pick gpu device if esimd not available but give it a lower score in
     // order not to compete with the esimd in environments where both are
     // present

--- a/SYCL/ESIMD/sycl_esimd_mix.cpp
+++ b/SYCL/ESIMD/sycl_esimd_mix.cpp
@@ -63,7 +63,7 @@ int main(void) {
     // We need that many threads in each group
     sycl::range<1> LocalRange{1};
 
-    queue q(gpu_selector{}, esimd_test::createExceptionHandler());
+    queue q(gpu_selector_v, esimd_test::createExceptionHandler());
 
     auto dev = q.get_device();
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
@@ -94,7 +94,7 @@ int main(void) {
     // We need that many threads in each group
     sycl::range<1> LocalRange{1};
 
-    queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
+    queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
 
     auto dev = q.get_device();
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";

--- a/SYCL/ESIMD/sycl_esimd_mix.cpp
+++ b/SYCL/ESIMD/sycl_esimd_mix.cpp
@@ -63,7 +63,7 @@ int main(void) {
     // We need that many threads in each group
     sycl::range<1> LocalRange{1};
 
-    queue q(gpu_selector_v, esimd_test::createExceptionHandler());
+    queue q(gpu_selector{}, esimd_test::createExceptionHandler());
 
     auto dev = q.get_device();
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
@@ -94,7 +94,7 @@ int main(void) {
     // We need that many threads in each group
     sycl::range<1> LocalRange{1};
 
-    queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+    queue q(esimd_test::ESIMDSelector{}, esimd_test::createExceptionHandler());
 
     auto dev = q.get_device();
     std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";


### PR DESCRIPTION
The esimd_test_utils.hpp file has been changed to provide a correct esimd_emulator selector and the library_loading.cpp has been changed to only check for esimd_emulator loading if the filter is set to esimd_emulator. This checks the functionality introduced in the following PR: https://github.com/intel/llvm/pull/6870.
Thanks to @steffenlarsen for his help!