### PR TITLE
[SYCL][HIP] Mark more AtomicRef tests unsupported

### DIFF
--- a/SYCL/AtomicRef/add_local.cpp
+++ b/SYCL/AtomicRef/add_local.cpp
@@ -1,3 +1,6 @@
+// See https://github.com/intel/llvm-test-suite/issues/867 for detailed status
+// UNSUPPORTED: hip
+
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/AtomicRef/min_local.cpp
+++ b/SYCL/AtomicRef/min_local.cpp
@@ -1,3 +1,6 @@
+// See https://github.com/intel/llvm-test-suite/issues/867 for detailed status
+// UNSUPPORTED: hip
+
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/AtomicRef/sub_local.cpp
+++ b/SYCL/AtomicRef/sub_local.cpp
@@ -1,3 +1,6 @@
+// See https://github.com/intel/llvm-test-suite/issues/867 for detailed status
+// UNSUPPORTED: hip
+
 // RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
These tests occasionally fail on the CI on unrelated PRs:

* https://github.com/intel/llvm/pull/6965
* https://github.com/intel/llvm/actions/runs/3206559152/jobs/5262344410

It may be related to the issue linked below as the failures also can't be replicated on gfx908 or gfx906:

* https://github.com/intel/llvm/issues/8804