### PR TITLE
[SYCL] Added test for ext_intel_device_id

### DIFF
--- a/SYCL/Basic/intel-ext-device.cpp
+++ b/SYCL/Basic/intel-ext-device.cpp
@@ -124,10 +124,9 @@ int main(int argc, char **argv) {
             }
             if (SYCL_EXT_INTEL_DEVICE_INFO >= 5 &&
                 dev.has(aspect::ext_intel_device_id)) {
-              int deviceID = dev.get_info<
-                  ext::intel::info::device::device_id>();
-              std::cout << "Device ID = " << deviceID
-                        << std::endl;
+              int deviceID =
+                  dev.get_info<ext::intel::info::device::device_id>();
+              std::cout << "Device ID = " << deviceID << std::endl;
             }
           } // SYCL_EXT_INTEL_DEVICE_INFO
         }

--- a/SYCL/Basic/intel-ext-device.cpp
+++ b/SYCL/Basic/intel-ext-device.cpp
@@ -122,6 +122,13 @@ int main(int argc, char **argv) {
               }
               std::cout << "\n";
             }
+            if (SYCL_EXT_INTEL_DEVICE_INFO >= 5 &&
+                dev.has(aspect::ext_intel_device_id)) {
+              int deviceID = dev.get_info<
+                  ext::intel::info::device::device_id>();
+              std::cout << "Device ID = " << deviceID
+                        << std::endl;
+            }
           } // SYCL_EXT_INTEL_DEVICE_INFO
         }
 


### PR DESCRIPTION
This commit adds test for `ext_intel_device_id` introduced in https://github.com/intel/llvm/pull/7010