### PR TITLE
[SYCL][CUDA] Fixed macro name in failing matrix test

### DIFF
--- a/SYCL/Matrix/element_wise_all_ops_cuda_legacy.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_cuda_legacy.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: cuda
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX=3 %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=3 %s -o %t.out
 // RUN: %t.out
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
@steffenlarsen sorry I missed this mistake of mine previously. I don't know why it didn't fail in the PR CI.

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>