### PR TITLE
Add tests for complex group algorithms

### DIFF
--- a/SYCL/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
@@ -37,18 +37,20 @@ OutputIterator exclusive_scan(InputIterator first, InputIterator last,
 }
 } // namespace emu
 
-template <typename SpecializationKernelName, typename InputContainer,
-          typename OutputContainer, class BinaryOperation>
+template <typename T> bool approx_eq(T a, T b) {
+  return std::abs(a - b) / (0.5 * std::abs(a + b)) < 1e-6;
+}
+
+template <> bool approx_eq<int>(int a, int b) { return a == b; }
+
+template <typename InputContainer, typename OutputContainer,
+          class BinaryOperation>
 void test(queue q, InputContainer input, OutputContainer output,
           BinaryOperation binary_op,
           typename OutputContainer::value_type identity) {
   typedef typename InputContainer::value_type InputT;
   typedef typename OutputContainer::value_type OutputT;
-  typedef class exclusive_scan_kernel<SpecializationKernelName, 0> kernel_name0;
-  typedef class exclusive_scan_kernel<SpecializationKernelName, 1> kernel_name1;
-  typedef class exclusive_scan_kernel<SpecializationKernelName, 2> kernel_name2;
-  typedef class exclusive_scan_kernel<SpecializationKernelName, 3> kernel_name3;
-  OutputT init = 42;
+  OutputT init = OutputT(42);
   size_t N = input.size();
   size_t G = 64;
   std::vector<OutputT> expected(N);
@@ -58,7 +60,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name0>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         int lid = it.get_local_id(0);
         out[lid] = exclusive_scan_over_group(g, in[lid], binary_op);
@@ -67,7 +69,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::exclusive_scan(input.begin(), input.begin() + G, expected.begin(),
                       identity, binary_op);
-  assert(std::equal(output.begin(), output.begin() + G, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + G, expected.begin(),
+                    approx_eq<OutputT>));
 
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -75,7 +78,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name1>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         int lid = it.get_local_id(0);
         out[lid] = exclusive_scan_over_group(g, in[lid], init, binary_op);
@@ -84,7 +87,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::exclusive_scan(input.begin(), input.begin() + G, expected.begin(), init,
                       binary_op);
-  assert(std::equal(output.begin(), output.begin() + G, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + G, expected.begin(),
+                    approx_eq<OutputT>));
 
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -92,7 +96,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name2>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         joint_exclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
                              out.get_pointer(), binary_op);
@@ -101,7 +105,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::exclusive_scan(input.begin(), input.begin() + N, expected.begin(),
                       identity, binary_op);
-  assert(std::equal(output.begin(), output.begin() + N, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + N, expected.begin(),
+                    approx_eq<OutputT>));
 
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -109,7 +114,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name3>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         joint_exclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
                              out.get_pointer(), init, binary_op);
@@ -118,7 +123,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::exclusive_scan(input.begin(), input.begin() + N, expected.begin(), init,
                       binary_op);
-  assert(std::equal(output.begin(), output.begin() + N, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + N, expected.begin(),
+                    approx_eq<OutputT>));
 }
 
 int main() {
@@ -134,24 +140,43 @@ int main() {
   std::iota(input.begin(), input.end(), 0);
   std::fill(output.begin(), output.end(), 0);
 
-  test<class KernelNamePlusV>(q, input, output, sycl::plus<>(), 0);
-  test<class KernelNameMinimumV>(q, input, output, sycl::minimum<>(),
-                                 std::numeric_limits<int>::max());
-  test<class KernelNameMaximumV>(q, input, output, sycl::maximum<>(),
-                                 std::numeric_limits<int>::lowest());
+  test(q, input, output, sycl::plus<>(), 0);
+  test(q, input, output, sycl::minimum<>(), std::numeric_limits<int>::max());
+  test(q, input, output, sycl::maximum<>(), std::numeric_limits<int>::lowest());
 
-  test<class KernelNamePlusI>(q, input, output, sycl::plus<int>(), 0);
-  test<class KernelNameMinimumI>(q, input, output, sycl::minimum<int>(),
-                                 std::numeric_limits<int>::max());
-  test<class KernelNameMaximumI>(q, input, output, sycl::maximum<int>(),
-                                 std::numeric_limits<int>::lowest());
-  test<class KernelName_VzAPutpBRRJrQPB>(q, input, output,
-                                         sycl::multiplies<int>(), 1);
-  test<class KernelName_UXdGbr>(q, input, output, sycl::bit_or<int>(), 0);
-  test<class KernelName_saYaodNyJknrPW>(q, input, output, sycl::bit_xor<int>(),
-                                        0);
-  test<class KernelName_GPcuAlvAOjrDyP>(q, input, output, sycl::bit_and<int>(),
-                                        ~0);
+  test(q, input, output, sycl::plus<int>(), 0);
+  test(q, input, output, sycl::minimum<int>(), std::numeric_limits<int>::max());
+  test(q, input, output, sycl::maximum<int>(),
+       std::numeric_limits<int>::lowest());
+  test(q, input, output, sycl::multiplies<int>(), 1);
+  test(q, input, output, sycl::bit_or<int>(), 0);
+  test(q, input, output, sycl::bit_xor<int>(), 0);
+  test(q, input, output, sycl::bit_and<int>(), ~0);
+
+  std::array<std::complex<float>, N> cf_input;
+  std::array<std::complex<float>, N> cf_output;
+  for (int i = 0; i < N; i++) {
+    cf_input[i] = {(i % 2) + 1.0f, (i % 3) - 1.f};
+  }
+  std::fill(cf_output.begin(), cf_output.end(), 0);
+  test(q, cf_input, cf_output, sycl::multiplies<std::complex<float>>(), 1);
+
+  std::array<std::complex<double>, N> cd_input;
+  std::array<std::complex<double>, N> cd_output;
+  for (int i = 0; i < N; i++) {
+    cd_input[i] = {(i % 2) + 1.0f, (i % 3) - 1.f};
+  }
+  std::fill(cd_output.begin(), cd_output.end(), 0);
+  test(q, cd_input, cd_output, sycl::multiplies<std::complex<double>>(), 1);
+
+  std::array<std::complex<half>, N> ch_input;
+  std::array<std::complex<half>, N> ch_output;
+  for (int i = 0; i < N; i++) {
+    ch_input[i] = {(i % 2) + 1.0f, (i % 3) - 1.f};
+  }
+  std::fill(ch_output.begin(), ch_output.end(), half(0));
+  test(q, ch_input, ch_output, sycl::multiplies<std::complex<half>>(),
+       half(1.f));
 
   std::cout << "Test passed." << std::endl;
 }

--- a/SYCL/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
@@ -10,6 +10,7 @@
 #include "support.h"
 #include <algorithm>
 #include <cassert>
+#include <complex>
 #include <iostream>
 #include <limits>
 #include <numeric>
@@ -37,18 +38,20 @@ OutputIterator inclusive_scan(InputIterator first, InputIterator last,
 }
 } // namespace emu
 
-template <typename SpecializationKernelName, typename InputContainer,
-          typename OutputContainer, class BinaryOperation>
+template <typename T> bool approx_eq(T a, T b) {
+  return std::abs(a - b) / (0.5 * std::abs(a + b)) < 1e-6;
+}
+
+template <> bool approx_eq<int>(int a, int b) { return a == b; }
+
+template <typename InputContainer, typename OutputContainer,
+          class BinaryOperation>
 void test(queue q, InputContainer input, OutputContainer output,
           BinaryOperation binary_op,
           typename OutputContainer::value_type identity) {
   typedef typename InputContainer::value_type InputT;
   typedef typename OutputContainer::value_type OutputT;
-  typedef class inclusive_scan_kernel<SpecializationKernelName, 0> kernel_name0;
-  typedef class inclusive_scan_kernel<SpecializationKernelName, 1> kernel_name1;
-  typedef class inclusive_scan_kernel<SpecializationKernelName, 2> kernel_name2;
-  typedef class inclusive_scan_kernel<SpecializationKernelName, 3> kernel_name3;
-  OutputT init = 42;
+  OutputT init = OutputT(42);
   size_t N = input.size();
   size_t G = 64;
   std::vector<OutputT> expected(N);
@@ -58,7 +61,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name0>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         int lid = it.get_local_id(0);
         out[lid] = inclusive_scan_over_group(g, in[lid], binary_op);
@@ -67,7 +70,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::inclusive_scan(input.begin(), input.begin() + G, expected.begin(),
                       binary_op, identity);
-  assert(std::equal(output.begin(), output.begin() + G, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + G, expected.begin(),
+                    approx_eq<OutputT>));
 
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -75,7 +79,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name1>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         int lid = it.get_local_id(0);
         out[lid] = inclusive_scan_over_group(g, in[lid], binary_op, init);
@@ -84,7 +88,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::inclusive_scan(input.begin(), input.begin() + G, expected.begin(),
                       binary_op, init);
-  assert(std::equal(output.begin(), output.begin() + G, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + G, expected.begin(),
+                    approx_eq<OutputT>));
 
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -92,7 +97,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name2>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         joint_inclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
                              out.get_pointer(), binary_op);
@@ -101,7 +106,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::inclusive_scan(input.begin(), input.begin() + N, expected.begin(),
                       binary_op, identity);
-  assert(std::equal(output.begin(), output.begin() + N, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + N, expected.begin(),
+                    approx_eq<OutputT>));
 
   {
     buffer<InputT> in_buf(input.data(), input.size());
@@ -109,7 +115,7 @@ void test(queue q, InputContainer input, OutputContainer output,
     q.submit([&](handler &cgh) {
       accessor in{in_buf, cgh, sycl::read_only};
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
-      cgh.parallel_for<kernel_name3>(nd_range<1>(G, G), [=](nd_item<1> it) {
+      cgh.parallel_for(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
         joint_inclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
                              out.get_pointer(), binary_op, init);
@@ -118,7 +124,8 @@ void test(queue q, InputContainer input, OutputContainer output,
   }
   emu::inclusive_scan(input.begin(), input.begin() + N, expected.begin(),
                       binary_op, init);
-  assert(std::equal(output.begin(), output.begin() + N, expected.begin()));
+  assert(std::equal(output.begin(), output.begin() + N, expected.begin(),
+                    approx_eq<OutputT>));
 }
 
 int main() {
@@ -134,25 +141,43 @@ int main() {
   std::iota(input.begin(), input.end(), 0);
   std::fill(output.begin(), output.end(), 0);
 
-  test<class KernelNamePlusV>(q, input, output, sycl::plus<>(), 0);
-  test<class KernelNameMinimumV>(q, input, output, sycl::minimum<>(),
-                                 std::numeric_limits<int>::max());
-  test<class KernelNameMaximumV>(q, input, output, sycl::maximum<>(),
-                                 std::numeric_limits<int>::lowest());
+  test(q, input, output, sycl::plus<>(), 0);
+  test(q, input, output, sycl::minimum<>(), std::numeric_limits<int>::max());
+  test(q, input, output, sycl::maximum<>(), std::numeric_limits<int>::lowest());
 
-  test<class KernelNamePlusI>(q, input, output, sycl::plus<int>(), 0);
-  test<class KernelNameMinimumI>(q, input, output, sycl::minimum<int>(),
-                                 std::numeric_limits<int>::max());
-  test<class KernelNameMaximumI>(q, input, output, sycl::maximum<int>(),
-                                 std::numeric_limits<int>::lowest());
-  test<class KernelName_zMyjxUrBgeUGoxmDwhvJ>(q, input, output,
-                                              sycl::multiplies<int>(), 1);
-  test<class KernelName_SljjtroxNRaAXoVnT>(q, input, output,
-                                           sycl::bit_or<int>(), 0);
-  test<class KernelName_yXIZfjwjxQGiPeQAnc>(q, input, output,
-                                            sycl::bit_xor<int>(), 0);
-  test<class KernelName_xGnAnMYHvqekCk>(q, input, output, sycl::bit_and<int>(),
-                                        ~0);
+  test(q, input, output, sycl::plus<int>(), 0);
+  test(q, input, output, sycl::minimum<int>(), std::numeric_limits<int>::max());
+  test(q, input, output, sycl::maximum<int>(),
+       std::numeric_limits<int>::lowest());
+  test(q, input, output, sycl::multiplies<int>(), 1);
+  test(q, input, output, sycl::bit_or<int>(), 0);
+  test(q, input, output, sycl::bit_xor<int>(), 0);
+  test(q, input, output, sycl::bit_and<int>(), ~0);
+
+  std::array<std::complex<float>, N> cf_input;
+  std::array<std::complex<float>, N> cf_output;
+  for (int i = 0; i < N; i++) {
+    cf_input[i] = {(i % 2) + 1.0f, (i % 3) - 1.f};
+  }
+  std::fill(cf_output.begin(), cf_output.end(), 0);
+  test(q, cf_input, cf_output, sycl::multiplies<std::complex<float>>(), 1);
+
+  std::array<std::complex<double>, N> cd_input;
+  std::array<std::complex<double>, N> cd_output;
+  for (int i = 0; i < N; i++) {
+    cd_input[i] = {(i % 2) + 1.0f, (i % 3) - 1.f};
+  }
+  std::fill(cd_output.begin(), cd_output.end(), 0);
+  test(q, cd_input, cd_output, sycl::multiplies<std::complex<double>>(), 1);
+
+  std::array<std::complex<half>, N> ch_input;
+  std::array<std::complex<half>, N> ch_output;
+  for (int i = 0; i < N; i++) {
+    ch_input[i] = {(i % 2) + 1.0f, (i % 3) - 1.f};
+  }
+  std::fill(ch_output.begin(), ch_output.end(), half(0));
+  test(q, ch_input, ch_output, sycl::multiplies<std::complex<half>>(),
+       half(1.f));
 
   std::cout << "Test passed." << std::endl;
 }


### PR DESCRIPTION
These tests exercise the functionality added in https://github.com/intel/llvm/pull/7120 which deals with group algorithms for complex numbers:

inclusive_scan, inclusive_scan, and reduction
