### PR TITLE
Revert "[SYCL][HIP] Mark reduction_span_pack.cpp unsupported on hip/amd (#1079)"

### DIFF
--- a/SYCL/Reduction/reduction_span_pack.cpp
+++ b/SYCL/Reduction/reduction_span_pack.cpp
@@ -6,11 +6,6 @@
 // `Group algorithms are not supported on host device.` on Nvidia.
 // XFAIL: hip_nvidia
 
-// Disable this test on HIP/AMD until this issue has been fixed:
-// https://github.com/intel/llvm/issues/6409
-//
-// UNSUPPORTED: hip
-
 // This test performs basic checks of reductions initialized with a pack
 // containing at least one sycl::span
 


### PR DESCRIPTION
This reverts commit d970da893115b3872963e368f91c2779f980e990.

@zjin-lcf has reported that this test seems to be working again on RX-series GPUs in intel/llvm#6409