### PR TITLE
[SYCL] Modify event_profiling_info.cpp to test for valid event times

### DIFF
--- a/SYCL/Basic/event_profiling_info.cpp
+++ b/SYCL/Basic/event_profiling_info.cpp
@@ -11,6 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Test might be flaky in level-zero as their clock time might wrap around to
+// zero
 // Flaky with CUDA
 // UNSUPPORTED: cuda
 
@@ -20,6 +22,8 @@
 using namespace sycl;
 
 bool verifyProfiling(event Event) {
+  constexpr long acceptable_diff_nano = (long)10 * 10e9; // 10 seconds
+
   auto Submit =
       Event.get_profiling_info<sycl::info::event_profiling::command_submit>();
   auto Start =
@@ -28,7 +32,12 @@ bool verifyProfiling(event Event) {
       Event.get_profiling_info<sycl::info::event_profiling::command_end>();
 
   assert(Submit <= Start);
+  assert(Start - Submit <= acceptable_diff_nano &&
+         "Event start and submit time difference not within acceptable range");
+
   assert(Start <= End);
+  assert(End - Start <= acceptable_diff_nano &&
+         "Event end and start time difference not within acceptable range");
 
   bool Pass = sycl::info::event_command_status::complete ==
               Event.get_info<sycl::info::event::command_execution_status>();


### PR DESCRIPTION
Previously, event_profiling_info.cpp would falsely pass under level-zero backend even though event submission time would always be zero. In order to make the test more accurate, it's checked whether each of the  adjacent profiling times are within a certain range (10 seconds in this case) of each other.

Signed-off-by: Rauf, Rana <rana.rauf@intel.com>