### PR TITLE
Set the row major store on B test to xfail on the GPU

### DIFF
--- a/SYCL/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
+++ b/SYCL/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
@@ -11,6 +11,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// XFAIL: gpu
+
 #include <iostream>
 #include <random>
 #include <sycl/sycl.hpp>

--- a/SYCL/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
+++ b/SYCL/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
@@ -11,6 +11,11 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// This test store the matrix B that is VNNIed (packed) in a row major fashion.
+// This is expected to fail on the GPU because the implementation does not
+// support automatic transformation YET, in this case: VNNI to row major in the
+// store.
+
 // XFAIL: gpu
 
 #include <iostream>

--- a/SYCL/Matrix/element_wise_all_ops_int8_packed.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_int8_packed.cpp
@@ -11,6 +11,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// This test store the matrix B that is VNNIed (packed) in a row major fashion.
+// This is expected to fail on the GPU because the implementation does not
+// support automatic transformation YET, in this case: VNNI to row major in the
+// store.
 // XFAIL: gpu
 
 #include <iostream>

--- a/SYCL/Matrix/element_wise_all_ops_int8_packed.cpp
+++ b/SYCL/Matrix/element_wise_all_ops_int8_packed.cpp
@@ -11,6 +11,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
+// XFAIL: gpu
+
 #include <iostream>
 #include <random>
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
This test store the matrix B that is VNNIed (packed) in a row major fashion. This is expected to fail on the GPU because the implementation does not support automatic transformation YET, in this case: VNNI to row major in the store.