### PR TITLE
[SYCL][CUDA] Check make_device doesn't create duplicate sycl::device.

### DIFF
--- a/SYCL/Plugin/interop-cuda-experimental.cpp
+++ b/SYCL/Plugin/interop-cuda-experimental.cpp
@@ -67,10 +67,12 @@ int main() {
   CUDA_CHECK(cuDeviceGet(&cu_dev, 0));
   auto sycl_dev = sycl::make_device<sycl::backend::ext_oneapi_cuda>(cu_dev);
   auto native_dev = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_dev);
+  auto sycl_dev2 = sycl::make_device<sycl::backend::ext_oneapi_cuda>(native_dev);
 
   check_type<sycl::device>(sycl_dev);
   check_type<CUdevice>(native_dev);
   assert(native_dev == cu_dev);
+  assert(sycl_dev == sycl_dev2);
 
   // Create sycl queue with new device and submit some work
   {

--- a/SYCL/Plugin/interop-cuda-experimental.cpp
+++ b/SYCL/Plugin/interop-cuda-experimental.cpp
@@ -67,7 +67,8 @@ int main() {
   CUDA_CHECK(cuDeviceGet(&cu_dev, 0));
   auto sycl_dev = sycl::make_device<sycl::backend::ext_oneapi_cuda>(cu_dev);
   auto native_dev = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_dev);
-  auto sycl_dev2 = sycl::make_device<sycl::backend::ext_oneapi_cuda>(native_dev);
+  auto sycl_dev2 =
+      sycl::make_device<sycl::backend::ext_oneapi_cuda>(native_dev);
 
   check_type<sycl::device>(sycl_dev);
   check_type<CUdevice>(native_dev);


### PR DESCRIPTION
Tests https://github.com/intel/llvm/pull/7550. Checks that make_device doesn't return a duplicate sycl::device if one already exists.

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>