### PR TITLE
[SYCL][Level Zero] Don't expect ZE_MEMORY_ADVICE_SET_READ_MOSTLY for read-only USM

### DIFF
--- a/SYCL/USM/shared_read_only.cpp
+++ b/SYCL/USM/shared_read_only.cpp
@@ -11,9 +11,7 @@ int main() {
   auto *p2 = sycl::malloc_shared<float>(42, q);
 
   // CHECK: zeMemAllocShared
-  // TODO: The following has issues in underlying Level Zero RT and thus isn't
-  // used:
-  //   {{zeCommandListAppendMemAdvise.*ZE_MEMORY_ADVICE_SET_READ_MOSTLY}}
+  // TODO: Level Zero doesn't have API to communicate read-only guarantee yet.
   // CHECK: {{zeCommandListAppendMemAdvise.*ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION*}}
   // CHECK: zeMemAllocShared
   // CHECK-NOT: MemAdvise

--- a/SYCL/USM/shared_read_only.cpp
+++ b/SYCL/USM/shared_read_only.cpp
@@ -11,7 +11,9 @@ int main() {
   auto *p2 = sycl::malloc_shared<float>(42, q);
 
   // CHECK: zeMemAllocShared
-  // CHECK: {{zeCommandListAppendMemAdvise.*ZE_MEMORY_ADVICE_SET_READ_MOSTLY}}
+  // TODO: The following has issues in underlying Level Zero RT and thus isn't
+  // used:
+  //   {{zeCommandListAppendMemAdvise.*ZE_MEMORY_ADVICE_SET_READ_MOSTLY}}
   // CHECK: {{zeCommandListAppendMemAdvise.*ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION*}}
   // CHECK: zeMemAllocShared
   // CHECK-NOT: MemAdvise


### PR DESCRIPTION
There are issues in the underlying Level Zero RT causing stability problems. This partially reverts https://github.com/intel/llvm-test-suite/pull/1409 and is needed for https://github.com/intel/llvm/pull/7601.