### PR TITLE
[SYC] Disable SYCL/AtomicRef/max_local.cpp on HIP

### DIFF
--- a/SYCL/AtomicRef/max_local.cpp
+++ b/SYCL/AtomicRef/max_local.cpp
@@ -4,7 +4,7 @@
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 // HIP does not support floating point atomics.
-// XFAIL: hip
+// UNSUPPORTED: hip
 
 #include "max.h"
 


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/7604.