### PR TITLE
[SYCL][CUDA] Enable generic atomic tests

### DIFF
--- a/SYCL/AtomicRef/assignment_atomic64_generic.cpp
+++ b/SYCL/AtomicRef/assignment_atomic64_generic.cpp
@@ -3,8 +3,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA backend has had no support for the generic address space yet
-// XFAIL: cuda || hip
+// XFAIL: hip
 
 #include "assignment.h"
 #include <iostream>

--- a/SYCL/AtomicRef/assignment_atomic64_generic.cpp
+++ b/SYCL/AtomicRef/assignment_atomic64_generic.cpp
@@ -3,6 +3,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// HIP backend has had no support for the generic address space yet.
 // XFAIL: hip
 
 #include "assignment.h"

--- a/SYCL/AtomicRef/assignment_generic.cpp
+++ b/SYCL/AtomicRef/assignment_generic.cpp
@@ -3,8 +3,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA backend has had no support for the generic address space yet
-// XFAIL: cuda || hip
+// XFAIL: hip
 
 #include "assignment.h"
 #include <iostream>

--- a/SYCL/AtomicRef/assignment_generic.cpp
+++ b/SYCL/AtomicRef/assignment_generic.cpp
@@ -3,6 +3,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// HIP backend has had no support for the generic address space yet
 // XFAIL: hip
 
 #include "assignment.h"

--- a/SYCL/AtomicRef/compare_exchange_generic.cpp
+++ b/SYCL/AtomicRef/compare_exchange_generic.cpp
@@ -3,8 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// XFAIL: hip
 
 #include "compare_exchange.h"
 

--- a/SYCL/AtomicRef/compare_exchange_generic.cpp
+++ b/SYCL/AtomicRef/compare_exchange_generic.cpp
@@ -3,6 +3,7 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// HIP backend has had no support for the generic address space yet
 // XFAIL: hip
 
 #include "compare_exchange.h"

--- a/SYCL/AtomicRef/compare_exchange_generic_local.cpp
+++ b/SYCL/AtomicRef/compare_exchange_generic_local.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
-// XFAIL: cuda || hip
+// HIP backend has had no support for the generic address space yet.
+// XFAIL: hip
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/load_generic.cpp
+++ b/SYCL/AtomicRef/load_generic.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has had no support for the generic address space yet
+// XFAIL: hip
 
 #include "load.h"
 

--- a/SYCL/AtomicRef/load_generic_local.cpp
+++ b/SYCL/AtomicRef/load_generic_local.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA backend has had no support for the generic address space yet.
-// XFAIL: cuda, hip
+// HIP backend has had no support for the generic address space yet.
+// XFAIL: hip
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/max_generic.cpp
+++ b/SYCL/AtomicRef/max_generic.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has had no support for the generic address space yet
+// XFAIL: hip
 
 #include "max.h"
 

--- a/SYCL/AtomicRef/max_generic_local.cpp
+++ b/SYCL/AtomicRef/max_generic_local.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
-// XFAIL: cuda || hip
+// HIP backend has had no support for the generic address space yet.
+// XFAIL: hip
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/max_generic_local_native_fp.cpp
+++ b/SYCL/AtomicRef/max_generic_local_native_fp.cpp
@@ -3,9 +3,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has had no support for the generic address space yet.
 // HIP dees not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/max_generic_native_fp.cpp
+++ b/SYCL/AtomicRef/max_generic_native_fp.cpp
@@ -3,9 +3,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has had no support for the generic address space yet.
 // HIP does not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/min_generic.cpp
+++ b/SYCL/AtomicRef/min_generic.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet
-// XFAIL: cuda || hip
+// HIP backend has had no support for the generic address space yet
+// XFAIL: hip
 
 #include "min.h"
 

--- a/SYCL/AtomicRef/min_generic_local.cpp
+++ b/SYCL/AtomicRef/min_generic_local.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
-// XFAIL: cuda || hip
+// HIP backend has had no support for the generic address space yet
+// XFAIL: hip
 
 #define TEST_GENERIC_IN_LOCAL 1
 

--- a/SYCL/AtomicRef/min_generic_local_native_fp.cpp
+++ b/SYCL/AtomicRef/min_generic_local_native_fp.cpp
@@ -3,9 +3,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has had no support for the generic address space yet.
 // HIP does not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/min_generic_native_fp.cpp
+++ b/SYCL/AtomicRef/min_generic_native_fp.cpp
@@ -3,9 +3,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have had no support for the generic address space yet.
+// HIP backend has had no support for the generic address space yet.
 // HIP does not support native floating point atomics
-// XFAIL: cuda, hip
+// XFAIL: hip
 
 #define SYCL_USE_NATIVE_FP_ATOMICS
 #define FP_TESTS_ONLY

--- a/SYCL/AtomicRef/store_generic.cpp
+++ b/SYCL/AtomicRef/store_generic.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have no support for the generic address space yet
-// XFAIL: cuda, hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #include "store.h"
 

--- a/SYCL/AtomicRef/store_generic_local.cpp
+++ b/SYCL/AtomicRef/store_generic_local.cpp
@@ -3,8 +3,8 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// CUDA and HIP backends have no support for the generic address space yet.
-// XFAIL: cuda, hip
+// HIP backend has no support for the generic address space yet
+// XFAIL: hip
 
 #define TEST_GENERIC_IN_LOCAL 1
 


### PR DESCRIPTION
Counterpart of https://github.com/intel/llvm/pull/7391

This patch supersedes https://github.com/intel/llvm-test-suite/pull/929