### PR TITLE
[SYCL] Stop using non-standard vec aliases in tests

### DIFF
--- a/SYCL/DeviceLib/built-ins/nan.cpp
+++ b/SYCL/DeviceLib/built-ins/nan.cpp
@@ -45,7 +45,7 @@ int main() {
   test_nan_call<s::ushort2, s::half2>();
   test_nan_call<s::uint2, s::float2>();
   test_nan_call<s::ulong2, s::double2>();
-  test_nan_call<s::ulonglong2, s::double2>();
+  test_nan_call<s::vec<unsigned long long, 2>, s::double2>();
 
   s::queue Queue([](sycl::exception_list ExceptionList) {
     for (std::exception_ptr ExceptionPtr : ExceptionList) {

--- a/SYCL/DeviceLib/built-ins/vector_integer.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_integer.cpp
@@ -70,14 +70,15 @@ int main() {
 
   // max (longlong2)
   {
-    s::longlong2 r{0};
+    using longlong2 = s::vec<long long, 2>;
+    longlong2 r{0};
     {
-      s::buffer<s::longlong2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<longlong2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxSLL2SLL1>([=]() {
-          AccR[0] = s::max(s::longlong2{5, 3}, s::longlong{2});
+          AccR[0] = s::max(longlong2{5, 3}, s::longlong{2});
         });
       });
     }
@@ -108,14 +109,15 @@ int main() {
 
   // max (ulonglong2)
   {
-    s::ulonglong2 r{0};
+    using ulonglong2 = s::vec<unsigned long long, 2>;
+    ulonglong2 r{0};
     {
-      s::buffer<s::ulonglong2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<ulonglong2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxULL2ULL1>([=]() {
-          AccR[0] = s::max(s::ulonglong2{5, 3}, s::ulonglong{2});
+          AccR[0] = s::max(ulonglong2{5, 3}, s::ulonglong{2});
         });
       });
     }
@@ -222,14 +224,16 @@ int main() {
 
   // abs (longlong)
   {
-    s::ulonglong2 r{0};
+    using ulonglong2 = s::vec<unsigned long long, 2>;
+    using longlong2 = s::vec<long long, 2>;
+    ulonglong2 r{0};
     {
-      s::buffer<s::ulonglong2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<ulonglong2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class absSL2>([=]() {
-          AccR[0] = s::abs(s::longlong2{-5, -2});
+          AccR[0] = s::abs(longlong2{-5, -2});
         });
       });
     }

--- a/SYCL/Regression/mad_sat.cpp
+++ b/SYCL/Regression/mad_sat.cpp
@@ -8,18 +8,23 @@
 int main() {
   sycl::queue testQueue;
 
+  using longlong3 = sycl::vec<long long, 3>;
+  using longlong4 = sycl::vec<long long, 4>;
+  using longlong8 = sycl::vec<long long, 8>;
+  using longlong16 = sycl::vec<long long, 16>;
+
   {
-    const sycl::longlong3 verification3(
-        9223372036854775807LL, 9223372036854775807LL, -9223372036854775808LL);
+    const longlong3 verification3(9223372036854775807LL, 9223372036854775807LL,
+                                  -9223372036854775808LL);
 
-    sycl::longlong3 inputData_0(1152105081885725616LL, 8383539663869980295LL,
-                                -3013159033463244495LL);
-    sycl::longlong3 inputData_1(9169239286331099647LL, 8545168655265359544LL,
-                                69290337040907021LL);
-    sycl::longlong3 inputData_2(-5670250901301018333LL, 216462155376518854LL,
-                                -7910909987096217335LL);
+    longlong3 inputData_0(1152105081885725616LL, 8383539663869980295LL,
+                          -3013159033463244495LL);
+    longlong3 inputData_1(9169239286331099647LL, 8545168655265359544LL,
+                          69290337040907021LL);
+    longlong3 inputData_2(-5670250901301018333LL, 216462155376518854LL,
+                          -7910909987096217335LL);
 
-    sycl::buffer<sycl::longlong3, 1> buffer(1);
+    sycl::buffer<longlong3, 1> buffer(1);
 
     testQueue.submit([&](sycl::handler &h) {
       auto resultPtr = buffer.template get_access<sycl::access::mode::write>(h);
@@ -32,18 +37,18 @@ int main() {
       assert((HostAccessor[0][i] == verification3[i]) && "Incorrect result");
   }
   {
-    const sycl::longlong4 verification4(
-        9223372036854775807LL, 9223372036854775807LL, -9223372036854775808LL,
-        9223372036854775807LL);
+    const longlong4 verification4(9223372036854775807LL, 9223372036854775807LL,
+                                  -9223372036854775808LL,
+                                  9223372036854775807LL);
 
-    sycl::longlong4 inputData_0(-4713774672458165250LL, 7161321293740295698LL,
-                                -7560042360032818022LL, 1712118953348815386LL);
-    sycl::longlong4 inputData_1(-5256951628950351348LL, 3094294642897896981LL,
-                                4183324171724765944LL, 1726930751531248453LL);
-    sycl::longlong4 inputData_2(-614349234816759997LL, -7793620271163345724LL,
-                                5480991826433743823LL, -3977840325478979484LL);
+    longlong4 inputData_0(-4713774672458165250LL, 7161321293740295698LL,
+                          -7560042360032818022LL, 1712118953348815386LL);
+    longlong4 inputData_1(-5256951628950351348LL, 3094294642897896981LL,
+                          4183324171724765944LL, 1726930751531248453LL);
+    longlong4 inputData_2(-614349234816759997LL, -7793620271163345724LL,
+                          5480991826433743823LL, -3977840325478979484LL);
 
-    sycl::buffer<sycl::longlong4, 1> buffer(1);
+    sycl::buffer<longlong4, 1> buffer(1);
 
     testQueue.submit([&](sycl::handler &h) {
       auto resultPtr = buffer.template get_access<sycl::access::mode::write>(h);
@@ -56,25 +61,25 @@ int main() {
       assert((HostAccessor[0][i] == verification4[i]) && "Incorrect result");
   }
   {
-    const sycl::longlong8 verification8(
+    const longlong8 verification8(
         9223372036854775807LL, 9223372036854775807LL, -9223372036854775808LL,
         -9223372036854775808LL, 9223372036854775807LL, 9223372036854775807LL,
         -9223372036854775808LL, -9223372036854775808LL);
 
-    sycl::longlong8 inputData_0(3002837817109371705LL, -6132505093056073745LL,
-                                -2677806413031023542LL, -3906932152445696896LL,
-                                -5966911996430888011LL, 487233493241732294LL,
-                                8234534527416862935LL, 8302379558520488989LL);
-    sycl::longlong8 inputData_1(3895748400226584336LL, -3171989754828069475LL,
-                                6135091761884568657LL, 3449810579449494485LL,
-                                -5153085649597103327LL, 2036067225828737775LL,
-                                -2456339276147680058LL, -2321401317481120691LL);
-    sycl::longlong8 inputData_2(5847800471474896191LL, 6421268696360310080LL,
-                                426131359031594004LL, 3388848179800138438LL,
-                                9095634920776267157LL, 3909069092545608647LL,
-                                -6551917618131929798LL, -5283018165188606431LL);
+    longlong8 inputData_0(3002837817109371705LL, -6132505093056073745LL,
+                          -2677806413031023542LL, -3906932152445696896LL,
+                          -5966911996430888011LL, 487233493241732294LL,
+                          8234534527416862935LL, 8302379558520488989LL);
+    longlong8 inputData_1(3895748400226584336LL, -3171989754828069475LL,
+                          6135091761884568657LL, 3449810579449494485LL,
+                          -5153085649597103327LL, 2036067225828737775LL,
+                          -2456339276147680058LL, -2321401317481120691LL);
+    longlong8 inputData_2(5847800471474896191LL, 6421268696360310080LL,
+                          426131359031594004LL, 3388848179800138438LL,
+                          9095634920776267157LL, 3909069092545608647LL,
+                          -6551917618131929798LL, -5283018165188606431LL);
 
-    sycl::buffer<sycl::longlong8, 1> buffer(1);
+    sycl::buffer<longlong8, 1> buffer(1);
 
     testQueue.submit([&](sycl::handler &h) {
       auto resultPtr = buffer.template get_access<sycl::access::mode::write>(h);
@@ -87,7 +92,7 @@ int main() {
       assert((HostAccessor[0][i] == verification8[i]) && "Incorrect result");
   }
   {
-    const sycl::longlong16 verification16(
+    const longlong16 verification16(
         -9223372036854775808LL, 9223372036854775807LL, 9223372036854775807LL,
         -9223372036854775808LL, 9223372036854775807LL, 9223372036854775807LL,
         9223372036854775807LL, 9223372036854775807LL, 9223372036854775807LL,
@@ -95,21 +100,21 @@ int main() {
         -9223372036854775808LL, 9223372036854775807LL, -9223372036854775808LL,
         -9223372036854775808LL);
 
-    sycl::longlong16 inputData_0(
+    longlong16 inputData_0(
         4711072418277000515LL, -8205098172692021203LL, -7385016145788992368LL,
         5953521028589173909LL, -5219240995491769312LL, 8710496141913755416LL,
         -6685846261491268433LL, 4193173269411595542LL, -8540195959022520771LL,
         -4715465363106336895LL, -1020086937442724783LL, 4496316677230042947LL,
         1321442475247578017LL, -7374746170855359764LL, -3206370806055241163LL,
         -2175226063524462053LL);
-    sycl::longlong16 inputData_1(
+    longlong16 inputData_1(
         -9126728881985856159LL, -8235441378758843293LL, -3529617622861997052LL,
         -4696495345590499183LL, -2446014787831249326LL, 3966377959819902357LL,
         -8707315735766590681LL, 4940281453308003965LL, -4008494233289413829LL,
         -1007875458987895243LL, 8007184939842565626LL, 7006363475270750393LL,
         -3126435375497361798LL, -2666957213164527889LL, 3425215156535282625LL,
         5057359883753713949LL);
-    sycl::longlong16 inputData_2(
+    longlong16 inputData_2(
         -5792361016316836568LL, 1155364222481085809LL, 7552404711758320408LL,
         -9123476257323872288LL, -924920183965907175LL, 1921314238201973170LL,
         3462681782260196063LL, 7822120358287768333LL, -3130033938219713817LL,
@@ -117,7 +122,7 @@ int main() {
         4207763935319579681LL, 1564279736903158695LL, 3722632463806041635LL,
         939009161285897285LL);
 
-    sycl::buffer<sycl::longlong16, 1> buffer(1);
+    sycl::buffer<longlong16, 1> buffer(1);
 
     testQueue.submit([&](sycl::handler &h) {
       auto resultPtr = buffer.template get_access<sycl::access::mode::write>(h);


### PR DESCRIPTION
According to 4.14.2.2. Aliases of SYCL 2020 specification, revision 6, `longlong{N}` aliases do not exists.

There is corresponding PR to remove them from the implementation: intel/llvm#7889