### PR TITLE
[SYCL] Re-enable SYCL/SubGroupMask/Basic.cpp

### DIFF
--- a/SYCL/SubGroupMask/Basic.cpp
+++ b/SYCL/SubGroupMask/Basic.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // REQUIRES: gpu
-// UNSUPPORTED: hip, windows
+// UNSUPPORTED: hip
 // GroupNonUniformBallot capability is supported on Intel GPU only
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: ze_debug-1,ze_debug4


### PR DESCRIPTION
The failure went away from pre-commit CI (see experiments in #1499 and #1507) after GPU driver update on CI systems.