### PR TITLE
[SYCL] Check for device::has(aspect::image) in tests using images

### DIFF
--- a/SYCL/Basic/image/image.cpp
+++ b/SYCL/Basic/image/image.cpp
@@ -35,6 +35,10 @@ int main() {
     sycl::image<2> Img1(Img1HostData.data(), ChanOrder, ChanType, Img1Size);
     sycl::image<2> Img2(Img2HostData.data(), ChanOrder, ChanType, Img2Size);
     TestQueue Q{sycl::default_selector_v};
+    if (!Q.get_device().has(sycl::aspect::image)) {
+      std::cout << "Skipped due to no image support on the device" << std::endl;
+      return 0;
+    }
     Q.submit([&](sycl::handler &CGH) {
       auto Img1Acc = Img1.get_access<sycl::float4, SYCLRead>(CGH);
       auto Img2Acc = Img2.get_access<sycl::float4, SYCLWrite>(CGH);

--- a/SYCL/Basic/image/image_accessor_range.cpp
+++ b/SYCL/Basic/image/image_accessor_range.cpp
@@ -112,6 +112,10 @@ void try_3D(queue &Q) {
 
 int main() {
   queue Q;
+  if (!Q.get_device().has(aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
 
   try_1D(Q);
   try_2D(Q);

--- a/SYCL/Basic/image/image_accessor_readsampler.cpp
+++ b/SYCL/Basic/image/image_accessor_readsampler.cpp
@@ -61,6 +61,11 @@ void checkReadSampler(char *host_ptr, s::sampler Sampler, s::cl_float4 Coord,
     s::image<3> Img(host_ptr, s::image_channel_order::rgba,
                     s::image_channel_type::snorm_int8, s::range<3>{2, 3, 4});
     s::queue myQueue;
+    if (!myQueue.get_device().has(s::aspect::image)) {
+      std::cout << "Skipped device checks due to no image support on the device"
+                << std::endl;
+      return;
+    }
     s::buffer<s::cl_float4, 1> ReadDataBuf(&ReadData, s::range<1>(1));
     myQueue.submit([&](s::handler &cgh) {
       auto ReadAcc = Img.get_access<s::cl_float4, s::access::mode::read>(cgh);

--- a/SYCL/Basic/image/image_accessor_readwrite.cpp
+++ b/SYCL/Basic/image/image_accessor_readwrite.cpp
@@ -268,6 +268,10 @@ template <> void check<s::cl_float4>(char *HostPtr) {
 };
 
 int main() {
+  if (!s::device{}.has(s::aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
   // Checking only for dimension=1.
   // 4 datatypes possible: s::cl_uint4, s::cl_int4, s::cl_float4, s::cl_half4.
   // half4 datatype is checked in a different test case.
@@ -279,4 +283,5 @@ int main() {
   check<s::cl_int4>(HostPtr);
   check<s::cl_uint4>(HostPtr);
   check<s::cl_float4>(HostPtr);
+  return 0;
 }

--- a/SYCL/Basic/image/image_accessor_readwrite_half.cpp
+++ b/SYCL/Basic/image/image_accessor_readwrite_half.cpp
@@ -153,6 +153,10 @@ int main() {
               << std::endl;
     return 0;
   }
+  if (!Dev.has(s::aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
   // Checking only for dimension=1.
   // create image:
   char HostPtr[100];

--- a/SYCL/Basic/image/image_max_size.cpp
+++ b/SYCL/Basic/image/image_max_size.cpp
@@ -108,6 +108,10 @@ int main() {
 
   queue Q;
   device Dev = Q.get_device();
+  if (!Dev.has(aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
   std::cout << "Running on " << Dev.get_info<info::device::name>()
             << ", Driver: " << Dev.get_info<info::device::driver_version>()
             << std::endl;

--- a/SYCL/Basic/image/image_read.cpp
+++ b/SYCL/Basic/image/image_read.cpp
@@ -8,6 +8,10 @@
 int main() {
 
   s::queue myQueue(s::default_selector_v);
+  if (!myQueue.get_device().has(s::aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
 
   bool passed = true;
 

--- a/SYCL/Basic/image/image_read_fp16.cpp
+++ b/SYCL/Basic/image/image_read_fp16.cpp
@@ -7,10 +7,15 @@
 
 int main() {
   s::queue myQueue(s::default_selector_v);
+  s::device d = myQueue.get_device();
 
   // Device doesn't support cl_khr_fp16 extension - skip.
-  if (!myQueue.get_device().has(sycl::aspect::fp16))
+  if (!d.has(sycl::aspect::fp16))
     return 0;
+  if (!d.has(s::aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
 
   // Half image
   if (!test<s::half4, s::image_channel_type::fp16>(myQueue))

--- a/SYCL/Basic/image/image_sample.cpp
+++ b/SYCL/Basic/image/image_sample.cpp
@@ -170,6 +170,10 @@ bool test3d(coordT coord, dataT expectedResult) {
 }
 
 int main() {
+  if (!sycl::device{}.has(s::aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
 
   bool passed = true;
 

--- a/SYCL/Basic/image/image_write.cpp
+++ b/SYCL/Basic/image/image_write.cpp
@@ -12,6 +12,10 @@
 int main() {
 
   s::queue myQueue(s::default_selector_v);
+  if (!myQueue.get_device().has(s::aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
 
   bool passed = true;
 

--- a/SYCL/Basic/image/image_write_fp16.cpp
+++ b/SYCL/Basic/image/image_write_fp16.cpp
@@ -7,10 +7,15 @@
 
 int main() {
   s::queue myQueue(s::default_selector_v);
+  s::device d = myQueue.get_device();
 
   // Device doesn't support cl_khr_fp16 extension - skip.
-  if (!myQueue.get_device().has(sycl::aspect::fp16))
+  if (!d.has(sycl::aspect::fp16))
     return 0;
+  if (!d.has(s::aspect::image)) {
+    std::cout << "Skipped due to no image support on the device" << std::endl;
+    return 0;
+  }
 
   // Half image
   if (!test<s::half4, s::image_channel_type::fp16>(myQueue))

--- a/SYCL/Regression/image_access.cpp
+++ b/SYCL/Regression/image_access.cpp
@@ -24,6 +24,13 @@ int main() {
     sycl::image<1> Image(Data.data(), sycl::image_channel_order::rgba,
                          sycl::image_channel_type::fp32, Range);
     sycl::queue Queue;
+    if (!Queue.get_device().has(sycl::aspect::image)) {
+      std::cout << "Skipped due to no image support on the device" << std::endl;
+      // Make FileCheck happy as well.
+      std::cout << "---> piMemImageCreate" << std::endl;
+      std::cout << "---> piEnqueueMemImageRead" << std::endl;
+      return 0;
+    }
 
     Queue.submit([&](sycl::handler &CGH) {
       sycl::accessor<sycl::cl_int4, 1, sycl::access::mode::read,

--- a/SYCL/Tracing/image_printers.cpp
+++ b/SYCL/Tracing/image_printers.cpp
@@ -31,6 +31,17 @@ int main() {
   {
     sycl::image<2> Img(ImgHostData.data(), ChanOrder, ChanType, ImgSize);
     queue Q;
+    if (!Q.get_device().has(sycl::aspect::image)) {
+      std::cout << "Skipped due to no image support on the device" << std::endl;
+      // Make FileCheck happy as well.
+      std::cout << "---> piMemImageCreate" << std::endl;
+      std::cout << "image_desc w/h/d : 4 / 4 / 1  --  arrSz/row/slice : 0 / 64 / 256  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337" << std::endl;
+      std::cout << "---> piEnqueueMemImageRead" << std::endl;
+      std::cout << "pi_image_offset x/y/z : 0/0/0" << std::endl;
+      std::cout << "pi_image_region width/height/depth : 4/4/1" << std::endl;
+      return 0;
+
+    }
     Q.submit([&](sycl::handler &CGH) {
       auto ImgAcc = Img.get_access<sycl::float4, SYCLWrite>(CGH);
 


### PR DESCRIPTION
They currently have "UNSUPPORTED: gpu-intel-pvc" markup but that's not auto-detected and might be missing when running the suite manually. Ensure we have runtime check as well to guard the interactive (i.e., non-CI) usage of the test-suite.