### PR TITLE
[SYCL] Disable SYCL/Regression/image_access.cpp on PVC

### DIFF
--- a/SYCL/Regression/image_access.cpp
+++ b/SYCL/Regression/image_access.cpp
@@ -3,7 +3,8 @@
 // RUN: env SYCL_PI_TRACE=2 %GPU_RUN_PLACEHOLDER %t.out 2>&1 %GPU_CHECK_PLACEHOLDER
 // No execution of FPGA because it does not support images
 //
-// UNSUPPORTED: hip
+// PVC doesn't support images.
+// UNSUPPORTED: hip, gpu-intel-pvc
 // CUDA doesn't fully support OpenCL spec conform images.
 
 //==-------------- image_access.cpp - SYCL image accessors test  -----------==//


### PR DESCRIPTION
Images are not supported on that device.