### PR TITLE
[SYCL] Update sycl complex testing

### DIFF
--- a/SYCL/Complex/sycl_complex_helper.hpp
+++ b/SYCL/Complex/sycl_complex_helper.hpp
@@ -34,6 +34,7 @@ template <> const char *get_typename<float>() { return "float"; }
 template <> const char *get_typename<sycl::half>() { return "sycl::half"; }
 
 // Helper to test each complex specilization
+// Overload for cplx_test_cases
 template <template <typename> typename action, typename... argsT>
 bool test_valid_types(sycl::queue &Q, argsT... args) {
   bool test_passes = true;
@@ -51,6 +52,29 @@ bool test_valid_types(sycl::queue &Q, argsT... args) {
   if (Q.get_device().has(sycl::aspect::fp16)) {
     action<sycl::half> test;
     test_passes &= test(Q, args...);
+  }
+
+  return test_passes;
+}
+
+// Overload for deci_test_cases
+template <template <typename, typename> typename action, typename... argsT>
+bool test_valid_types(sycl::queue &Q, argsT... args) {
+  bool test_passes = true;
+
+  if (Q.get_device().has(sycl::aspect::fp64)) {
+    test_passes &= action<double, bool>{}(Q, args ...);
+    test_passes &= action<double, char>{}(Q, args ...);
+    test_passes &= action<double, int>{}(Q, args ...);
+    test_passes &= action<double, double>{}(Q, args ...);
+  }
+
+  {
+    test_passes &= action<float, float>{}(Q, args ...);
+  }
+
+  if (Q.get_device().has(sycl::aspect::fp16)) {
+    test_passes &= action<sycl::half, sycl::half>{}(Q, args ...);
   }
 
   return test_passes;

--- a/SYCL/Complex/sycl_complex_helper.hpp
+++ b/SYCL/Complex/sycl_complex_helper.hpp
@@ -63,18 +63,16 @@ bool test_valid_types(sycl::queue &Q, argsT... args) {
   bool test_passes = true;
 
   if (Q.get_device().has(sycl::aspect::fp64)) {
-    test_passes &= action<double, bool>{}(Q, args ...);
-    test_passes &= action<double, char>{}(Q, args ...);
-    test_passes &= action<double, int>{}(Q, args ...);
-    test_passes &= action<double, double>{}(Q, args ...);
+    test_passes &= action<double, bool>{}(Q, args...);
+    test_passes &= action<double, char>{}(Q, args...);
+    test_passes &= action<double, int>{}(Q, args...);
+    test_passes &= action<double, double>{}(Q, args...);
   }
 
-  {
-    test_passes &= action<float, float>{}(Q, args ...);
-  }
+  { test_passes &= action<float, float>{}(Q, args...); }
 
   if (Q.get_device().has(sycl::aspect::fp16)) {
-    test_passes &= action<sycl::half, sycl::half>{}(Q, args ...);
+    test_passes &= action<sycl::half, sycl::half>{}(Q, args...);
   }
 
   return test_passes;

--- a/SYCL/Complex/sycl_complex_math_test.cpp
+++ b/SYCL/Complex/sycl_complex_math_test.cpp
@@ -110,37 +110,37 @@ TEST_MATH_OP_TYPE(imag)
 // Macro for testing decimal in, complex out functions
 
 #define TEST_MATH_OP_TYPE(math_func)                                           \
-template <typename T, typename X>                                              \
-struct test_deci_cplx_##math_func {                                            \
-  bool operator()(sycl::queue &Q, X init, T ref = T{}, bool use_ref = false) { \
-    bool pass = true;                                                          \
+  template <typename T, typename X> struct test_deci_cplx_##math_func {        \
+    bool operator()(sycl::queue &Q, X init, T ref = T{},                       \
+                    bool use_ref = false) {                                    \
+      bool pass = true;                                                        \
                                                                                \
-    auto std_in = init_deci(init);                                             \
+      auto std_in = init_deci(init);                                           \
                                                                                \
-    /*Get std::complex output*/                                                \
-    std::complex<T> std_out = ref;                                             \
-    if (!use_ref)                                                              \
-      std_out = std::math_func(std_in);                                        \
+      /*Get std::complex output*/                                              \
+      std::complex<T> std_out = ref;                                           \
+      if (!use_ref)                                                            \
+        std_out = std::math_func(std_in);                                      \
                                                                                \
-    auto *cplx_out = sycl::malloc_shared<experimental::complex<T>>(1, Q);      \
+      auto *cplx_out = sycl::malloc_shared<experimental::complex<T>>(1, Q);    \
                                                                                \
-    /*Check cplx::complex output from device*/                                 \
-    Q.single_task([=]() {                                                      \
-       cplx_out[0] = experimental::math_func<X>(std_in);                       \
-     }).wait();                                                                \
+      /*Check cplx::complex output from device*/                               \
+      Q.single_task([=]() {                                                    \
+         cplx_out[0] = experimental::math_func<X>(std_in);                     \
+       }).wait();                                                              \
                                                                                \
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);           \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);         \
                                                                                \
-    /*Check cplx::complex output from host*/                                   \
-    cplx_out[0] = experimental::math_func<X>(std_in);                          \
+      /*Check cplx::complex output from host*/                                 \
+      cplx_out[0] = experimental::math_func<X>(std_in);                        \
                                                                                \
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);          \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);        \
                                                                                \
-    sycl::free(cplx_out, Q);                                                   \
+      sycl::free(cplx_out, Q);                                                 \
                                                                                \
-    return pass;                                                               \
-  }                                                                            \
-};
+      return pass;                                                             \
+    }                                                                          \
+  };
 
 TEST_MATH_OP_TYPE(conj)
 TEST_MATH_OP_TYPE(proj)
@@ -150,37 +150,37 @@ TEST_MATH_OP_TYPE(proj)
 // Macro for testing decimal in, decimal out functions
 
 #define TEST_MATH_OP_TYPE(math_func)                                           \
-template <typename T, typename X>                                              \
-struct test_deci_deci_##math_func {                                            \
-  bool operator()(sycl::queue &Q, X init, T ref = T{}, bool use_ref = false) { \
-    bool pass = true;                                                          \
+  template <typename T, typename X> struct test_deci_deci_##math_func {        \
+    bool operator()(sycl::queue &Q, X init, T ref = T{},                       \
+                    bool use_ref = false) {                                    \
+      bool pass = true;                                                        \
                                                                                \
-    auto std_in = init_deci(init);                                             \
+      auto std_in = init_deci(init);                                           \
                                                                                \
-    /*Get std::complex output*/                                                \
-    T std_out = ref;                                                           \
-    if (!use_ref)                                                              \
-      std_out = std::math_func(std_in);                                        \
+      /*Get std::complex output*/                                              \
+      T std_out = ref;                                                         \
+      if (!use_ref)                                                            \
+        std_out = std::math_func(std_in);                                      \
                                                                                \
-    auto *cplx_out = sycl::malloc_shared<T>(1, Q);                             \
+      auto *cplx_out = sycl::malloc_shared<T>(1, Q);                           \
                                                                                \
-    /*Check cplx::complex output from device*/                                 \
-    Q.single_task([=]() {                                                      \
-       cplx_out[0] = experimental::math_func<X>(init);                         \
-     }).wait();                                                                \
+      /*Check cplx::complex output from device*/                               \
+      Q.single_task([=]() {                                                    \
+         cplx_out[0] = experimental::math_func<X>(init);                       \
+       }).wait();                                                              \
                                                                                \
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);           \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);         \
                                                                                \
-    /*Check cplx::complex output from host*/                                   \
-    cplx_out[0] = experimental::math_func<X>(init);                            \
+      /*Check cplx::complex output from host*/                                 \
+      cplx_out[0] = experimental::math_func<X>(init);                          \
                                                                                \
-    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);          \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);        \
                                                                                \
-    sycl::free(cplx_out, Q);                                                   \
+      sycl::free(cplx_out, Q);                                                 \
                                                                                \
-    return pass;                                                               \
-  }                                                                            \
-};
+      return pass;                                                             \
+    }                                                                          \
+  };
 
 TEST_MATH_OP_TYPE(arg)
 TEST_MATH_OP_TYPE(norm)
@@ -227,119 +227,119 @@ int main() {
 
   bool test_passes = true;
 
- /* Test complex in, complex out functions */
+  /* Test complex in, complex out functions */
 
- {
-   cplx_test_cases<test_acos> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_acos> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_asin> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_asin> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_atan> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_atan> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_acosh> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_acosh> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_asinh> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_asinh> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_atanh> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_atanh> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_conj> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_conj> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_cos> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_cos> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_cosh> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_cosh> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_log> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_log> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_log10> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_log10> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_proj> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_proj> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_sin> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_sin> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_sinh> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_sinh> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_sqrt> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_sqrt> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_tan> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_tan> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_tanh> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_tanh> test;
+    test_passes &= test(Q);
+  }
 
- /* Test complex in, decimal out functions */
+  /* Test complex in, decimal out functions */
 
- {
-   cplx_test_cases<test_abs> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_abs> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_arg> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_arg> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_norm> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_norm> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_real> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_real> test;
+    test_passes &= test(Q);
+  }
 
- {
-   cplx_test_cases<test_imag> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_imag> test;
+    test_passes &= test(Q);
+  }
 
   /* Test decimal in, complex out functions */
 
@@ -349,38 +349,38 @@ int main() {
   }
 
   {
-   deci_test_cases<test_deci_cplx_proj> test;
-   test_passes &= test(Q);
+    deci_test_cases<test_deci_cplx_proj> test;
+    test_passes &= test(Q);
   }
 
- /* Test decimal in, decimal out functions */
+  /* Test decimal in, decimal out functions */
 
- {
-   deci_test_cases<test_deci_deci_arg> test;
-   test_passes &= test(Q);
- }
+  {
+    deci_test_cases<test_deci_deci_arg> test;
+    test_passes &= test(Q);
+  }
 
- {
-   deci_test_cases<test_deci_deci_norm> test;
-   test_passes &= test(Q);
- }
+  {
+    deci_test_cases<test_deci_deci_norm> test;
+    test_passes &= test(Q);
+  }
 
- {
-   deci_test_cases<test_deci_deci_real> test;
-   test_passes &= test(Q);
- }
+  {
+    deci_test_cases<test_deci_deci_real> test;
+    test_passes &= test(Q);
+  }
 
- {
-   deci_test_cases<test_deci_deci_imag> test;
-   test_passes &= test(Q);
- }
+  {
+    deci_test_cases<test_deci_deci_imag> test;
+    test_passes &= test(Q);
+  }
 
- /* Test polar function */
+  /* Test polar function */
 
- {
-   cplx_test_cases<test_polar> test;
-   test_passes &= test(Q);
- }
+  {
+    cplx_test_cases<test_polar> test;
+    test_passes &= test(Q);
+  }
 
   return !test_passes;
 }

--- a/SYCL/Complex/sycl_complex_math_test.cpp
+++ b/SYCL/Complex/sycl_complex_math_test.cpp
@@ -102,6 +102,90 @@ TEST_MATH_OP_TYPE(tanh)
 TEST_MATH_OP_TYPE(abs)
 TEST_MATH_OP_TYPE(arg)
 TEST_MATH_OP_TYPE(norm)
+TEST_MATH_OP_TYPE(real)
+TEST_MATH_OP_TYPE(imag)
+
+#undef TEST_MATH_OP_TYPE
+
+// Macro for testing decimal in, complex out functions
+
+#define TEST_MATH_OP_TYPE(math_func)                                           \
+template <typename T, typename X>                                              \
+struct test_deci_cplx_##math_func {                                            \
+  bool operator()(sycl::queue &Q, X init, T ref = T{}, bool use_ref = false) { \
+    bool pass = true;                                                          \
+                                                                               \
+    auto std_in = init_deci(init);                                             \
+                                                                               \
+    /*Get std::complex output*/                                                \
+    std::complex<T> std_out = ref;                                             \
+    if (!use_ref)                                                              \
+      std_out = std::math_func(std_in);                                        \
+                                                                               \
+    auto *cplx_out = sycl::malloc_shared<experimental::complex<T>>(1, Q);      \
+                                                                               \
+    /*Check cplx::complex output from device*/                                 \
+    Q.single_task([=]() {                                                      \
+       cplx_out[0] = experimental::math_func<X>(std_in);                       \
+     }).wait();                                                                \
+                                                                               \
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);           \
+                                                                               \
+    /*Check cplx::complex output from host*/                                   \
+    cplx_out[0] = experimental::math_func<X>(std_in);                          \
+                                                                               \
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);          \
+                                                                               \
+    sycl::free(cplx_out, Q);                                                   \
+                                                                               \
+    return pass;                                                               \
+  }                                                                            \
+};
+
+TEST_MATH_OP_TYPE(conj)
+TEST_MATH_OP_TYPE(proj)
+
+#undef TEST_MATH_OP_TYPE
+
+// Macro for testing decimal in, decimal out functions
+
+#define TEST_MATH_OP_TYPE(math_func)                                           \
+template <typename T, typename X>                                              \
+struct test_deci_deci_##math_func {                                            \
+  bool operator()(sycl::queue &Q, X init, T ref = T{}, bool use_ref = false) { \
+    bool pass = true;                                                          \
+                                                                               \
+    auto std_in = init_deci(init);                                             \
+                                                                               \
+    /*Get std::complex output*/                                                \
+    T std_out = ref;                                                           \
+    if (!use_ref)                                                              \
+      std_out = std::math_func(std_in);                                        \
+                                                                               \
+    auto *cplx_out = sycl::malloc_shared<T>(1, Q);                             \
+                                                                               \
+    /*Check cplx::complex output from device*/                                 \
+    Q.single_task([=]() {                                                      \
+       cplx_out[0] = experimental::math_func<X>(init);                         \
+     }).wait();                                                                \
+                                                                               \
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);           \
+                                                                               \
+    /*Check cplx::complex output from host*/                                   \
+    cplx_out[0] = experimental::math_func<X>(init);                            \
+                                                                               \
+    pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);          \
+                                                                               \
+    sycl::free(cplx_out, Q);                                                   \
+                                                                               \
+    return pass;                                                               \
+  }                                                                            \
+};
+
+TEST_MATH_OP_TYPE(arg)
+TEST_MATH_OP_TYPE(norm)
+TEST_MATH_OP_TYPE(real)
+TEST_MATH_OP_TYPE(imag)
 
 #undef TEST_MATH_OP_TYPE
 
@@ -143,110 +227,160 @@ int main() {
 
   bool test_passes = true;
 
+ /* Test complex in, complex out functions */
+
+ {
+   cplx_test_cases<test_acos> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_asin> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_atan> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_acosh> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_asinh> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_atanh> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_conj> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_cos> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_cosh> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_log> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_log10> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_proj> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_sin> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_sinh> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_sqrt> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_tan> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_tanh> test;
+   test_passes &= test(Q);
+ }
+
+ /* Test complex in, decimal out functions */
+
+ {
+   cplx_test_cases<test_abs> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_arg> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_norm> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_real> test;
+   test_passes &= test(Q);
+ }
+
+ {
+   cplx_test_cases<test_imag> test;
+   test_passes &= test(Q);
+ }
+
+  /* Test decimal in, complex out functions */
+
   {
-    test_cases<test_acos> test;
+    deci_test_cases<test_deci_cplx_conj> test;
     test_passes &= test(Q);
   }
 
   {
-    test_cases<test_asin> test;
-    test_passes &= test(Q);
+   deci_test_cases<test_deci_cplx_proj> test;
+   test_passes &= test(Q);
   }
 
-  {
-    test_cases<test_atan> test;
-    test_passes &= test(Q);
-  }
+ /* Test decimal in, decimal out functions */
 
-  {
-    test_cases<test_acosh> test;
-    test_passes &= test(Q);
-  }
+ {
+   deci_test_cases<test_deci_deci_arg> test;
+   test_passes &= test(Q);
+ }
 
-  {
-    test_cases<test_asinh> test;
-    test_passes &= test(Q);
-  }
+ {
+   deci_test_cases<test_deci_deci_norm> test;
+   test_passes &= test(Q);
+ }
 
-  {
-    test_cases<test_atanh> test;
-    test_passes &= test(Q);
-  }
+ {
+   deci_test_cases<test_deci_deci_real> test;
+   test_passes &= test(Q);
+ }
 
-  {
-    test_cases<test_conj> test;
-    test_passes &= test(Q);
-  }
+ {
+   deci_test_cases<test_deci_deci_imag> test;
+   test_passes &= test(Q);
+ }
 
-  {
-    test_cases<test_cos> test;
-    test_passes &= test(Q);
-  }
+ /* Test polar function */
 
-  {
-    test_cases<test_cosh> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_log> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_log10> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_proj> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_sin> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_sinh> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_sqrt> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_tan> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_tanh> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_abs> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_arg> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_norm> test;
-    test_passes &= test(Q);
-  }
-
-  {
-    test_cases<test_polar> test;
-    test_passes &= test(Q);
-  }
+ {
+   cplx_test_cases<test_polar> test;
+   test_passes &= test(Q);
+ }
 
   return !test_passes;
 }

--- a/SYCL/Complex/sycl_complex_math_test_cases.hpp
+++ b/SYCL/Complex/sycl_complex_math_test_cases.hpp
@@ -74,7 +74,8 @@ template <template <typename> typename test_struct> struct cplx_test_cases {
 // sycl_complex_math_test.cpp
 // Values are stored in the highest precision type, in this case that is double
 
-template <template <typename, typename> typename test_struct> struct deci_test_cases {
+template <template <typename, typename> typename test_struct>
+struct deci_test_cases {
   // Default test cases
   static vector<double> std_test_values;
   static vector<tuple<double, double>> comp_test_values;
@@ -130,8 +131,8 @@ vector<double> deci_test_cases<test_struct>::std_test_values = {
 };
 
 template <template <typename, typename> typename test_struct>
-vector<tuple<double, double>>
-    deci_test_cases<test_struct>::comp_test_values = {};
+vector<tuple<double, double>> deci_test_cases<test_struct>::comp_test_values =
+    {};
 
 // test_acos
 template <> const char *cplx_test_cases<test_acos>::test_name = "acos test";
@@ -320,9 +321,9 @@ const char *deci_test_cases<test_deci_deci_arg>::test_name = "arg test";
 
 template <>
 vector<double> deci_test_cases<test_deci_deci_arg>::std_test_values = {
-  4.42,
-  2.02,
-  INFINITYd,
+    4.42,
+    2.02,
+    INFINITYd,
 };
 
 // test norm

--- a/SYCL/Complex/sycl_complex_math_test_cases.hpp
+++ b/SYCL/Complex/sycl_complex_math_test_cases.hpp
@@ -2,7 +2,7 @@ using std::pair;
 using std::tuple;
 using std::vector;
 
-// Forward decleration of tests
+// Forward declaration of tests
 
 template <typename T> class test_acos;
 template <typename T> class test_asin;
@@ -26,13 +26,24 @@ template <typename T> class test_tanh;
 template <typename T> class test_abs;
 template <typename T> class test_arg;
 template <typename T> class test_norm;
+template <typename T> class test_real;
+template <typename T> class test_imag;
+
+template <typename T, typename X> class test_deci_cplx_conj;
+template <typename T, typename X> class test_deci_cplx_proj;
+
+template <typename T, typename X> class test_deci_deci_arg;
+template <typename T, typename X> class test_deci_deci_norm;
+template <typename T, typename X> class test_deci_deci_real;
+template <typename T, typename X> class test_deci_deci_imag;
 
 template <typename T> class test_polar;
 
-// Stores test cases for each math function used in sycl_complex_math_test.cpp
+// Stores test cases for each complex-complex math function used in
+// sycl_complex_math_test.cpp
 // Values are stored in the highest precision type, in this case that is double
 
-template <template <typename> typename test_struct> struct test_cases {
+template <template <typename> typename test_struct> struct cplx_test_cases {
   // Default test cases
   static vector<cmplx<double>> std_test_values;
   static vector<tuple<cmplx<double>, cmplx<double>>> comp_test_values;
@@ -59,8 +70,39 @@ template <template <typename> typename test_struct> struct test_cases {
   }
 };
 
+// Stores test cases for each math decimal-complex function used in
+// sycl_complex_math_test.cpp
+// Values are stored in the highest precision type, in this case that is double
+
+template <template <typename, typename> typename test_struct> struct deci_test_cases {
+  // Default test cases
+  static vector<double> std_test_values;
+  static vector<tuple<double, double>> comp_test_values;
+
+  static const char *test_name;
+
+  bool operator()(sycl::queue &Q) {
+    bool test_passes = true;
+
+    for (auto &test_value : std_test_values) {
+      test_passes &= test_valid_types<test_struct>(Q, test_value);
+    }
+
+    for (auto &test_tuple : comp_test_values) {
+      test_passes &= test_valid_types<test_struct>(Q, std::get<0>(test_tuple),
+                                                   std::get<1>(test_tuple),
+                                                   /*use_ref*/ true);
+    }
+
+    if (!test_passes)
+      std::cerr << test_name << " failed\n";
+
+    return test_passes;
+  }
+};
+
 template <template <typename> typename test_struct>
-vector<cmplx<double>> test_cases<test_struct>::std_test_values = {
+vector<cmplx<double>> cplx_test_cases<test_struct>::std_test_values = {
     cmplx(1, 1),
     cmplx(-1, 1),
     cmplx(1, -1),
@@ -77,19 +119,31 @@ vector<cmplx<double>> test_cases<test_struct>::std_test_values = {
 
 template <template <typename> typename test_struct>
 vector<tuple<cmplx<double>, cmplx<double>>>
-    test_cases<test_struct>::comp_test_values = {};
+    cplx_test_cases<test_struct>::comp_test_values = {};
+
+template <template <typename, typename> typename test_struct>
+vector<double> deci_test_cases<test_struct>::std_test_values = {
+    4.42,
+    2.02,
+    INFINITYd,
+    NANd,
+};
+
+template <template <typename, typename> typename test_struct>
+vector<tuple<double, double>>
+    deci_test_cases<test_struct>::comp_test_values = {};
 
 // test_acos
-template <> const char *test_cases<test_acos>::test_name = "acos test";
+template <> const char *cplx_test_cases<test_acos>::test_name = "acos test";
 
 // test_asin
-template <> const char *test_cases<test_asin>::test_name = "asin test";
+template <> const char *cplx_test_cases<test_asin>::test_name = "asin test";
 
 // test_atan
-template <> const char *test_cases<test_atan>::test_name = "atan test";
+template <> const char *cplx_test_cases<test_atan>::test_name = "atan test";
 
 template <>
-vector<cmplx<double>> test_cases<test_atan>::std_test_values = {
+vector<cmplx<double>> cplx_test_cases<test_atan>::std_test_values = {
     cmplx(1, 1),
     cmplx(-1, 1),
     cmplx(1, -1),
@@ -107,20 +161,20 @@ vector<cmplx<double>> test_cases<test_atan>::std_test_values = {
 // So check against reference value
 template <>
 vector<tuple<cmplx<double>, cmplx<double>>>
-    test_cases<test_atan>::comp_test_values = {
+    cplx_test_cases<test_atan>::comp_test_values = {
         tuple(cmplx(INFINITYd, NANd), cmplx(PI / 2.0, 0.0))};
 
 // test_acosh
-template <> const char *test_cases<test_acosh>::test_name = "acosh test";
+template <> const char *cplx_test_cases<test_acosh>::test_name = "acosh test";
 
 // test_asinh
-template <> const char *test_cases<test_asinh>::test_name = "asinh test";
+template <> const char *cplx_test_cases<test_asinh>::test_name = "asinh test";
 
 // test_atanh
-template <> const char *test_cases<test_atanh>::test_name = "atanh test";
+template <> const char *cplx_test_cases<test_atanh>::test_name = "atanh test";
 
 template <>
-vector<cmplx<double>> test_cases<test_atanh>::std_test_values = {
+vector<cmplx<double>> cplx_test_cases<test_atanh>::std_test_values = {
     cmplx(1, 1),
     cmplx(-1, 1),
     cmplx(1, -1),
@@ -138,44 +192,44 @@ vector<cmplx<double>> test_cases<test_atanh>::std_test_values = {
 // So check against reference value
 template <>
 vector<tuple<cmplx<double>, cmplx<double>>>
-    test_cases<test_atanh>::comp_test_values = {
+    cplx_test_cases<test_atanh>::comp_test_values = {
         tuple(cmplx(NANd, INFINITYd), cmplx(0.0, PI / 2.0))};
 
 // test_conj
-template <> const char *test_cases<test_conj>::test_name = "conj test";
+template <> const char *cplx_test_cases<test_conj>::test_name = "conj test";
 
 // test_cos
-template <> const char *test_cases<test_cos>::test_name = "cos test";
+template <> const char *cplx_test_cases<test_cos>::test_name = "cos test";
 
 // test_cosh
-template <> const char *test_cases<test_cosh>::test_name = "cosh test";
+template <> const char *cplx_test_cases<test_cosh>::test_name = "cosh test";
 
 // test_exp
-template <> const char *test_cases<test_exp>::test_name = "exp test";
+template <> const char *cplx_test_cases<test_exp>::test_name = "exp test";
 
 // test_log
-template <> const char *test_cases<test_log>::test_name = "log test";
+template <> const char *cplx_test_cases<test_log>::test_name = "log test";
 
 // test_log10
-template <> const char *test_cases<test_log10>::test_name = "log10 test";
+template <> const char *cplx_test_cases<test_log10>::test_name = "log10 test";
 
 // test_proj
-template <> const char *test_cases<test_proj>::test_name = "proj test";
+template <> const char *cplx_test_cases<test_proj>::test_name = "proj test";
 
 // test_sin
-template <> const char *test_cases<test_sin>::test_name = "sin test";
+template <> const char *cplx_test_cases<test_sin>::test_name = "sin test";
 
 // test_sinh
-template <> const char *test_cases<test_sinh>::test_name = "sinh test";
+template <> const char *cplx_test_cases<test_sinh>::test_name = "sinh test";
 
 // test_sqrt
-template <> const char *test_cases<test_sqrt>::test_name = "sqrt test";
+template <> const char *cplx_test_cases<test_sqrt>::test_name = "sqrt test";
 
 // test_tan
-template <> const char *test_cases<test_tan>::test_name = "tan test";
+template <> const char *cplx_test_cases<test_tan>::test_name = "tan test";
 
 template <>
-vector<cmplx<double>> test_cases<test_tan>::std_test_values = {
+vector<cmplx<double>> cplx_test_cases<test_tan>::std_test_values = {
     cmplx(1, 1),
     cmplx(-1, 1),
     cmplx(1, -1),
@@ -192,15 +246,15 @@ vector<cmplx<double>> test_cases<test_tan>::std_test_values = {
 // So check against reference value
 template <>
 vector<tuple<cmplx<double>, cmplx<double>>>
-    test_cases<test_tan>::comp_test_values = {
+    cplx_test_cases<test_tan>::comp_test_values = {
         tuple(cmplx(INFINITYd, INFINITYd), cmplx(0.0, 1.0)),
         tuple(cmplx(NANd, INFINITYd), cmplx(0.0, 1.0))};
 
 // test_tanh
-template <> const char *test_cases<test_tanh>::test_name = "tanh test";
+template <> const char *cplx_test_cases<test_tanh>::test_name = "tanh test";
 
 template <>
-vector<cmplx<double>> test_cases<test_tanh>::std_test_values = {
+vector<cmplx<double>> cplx_test_cases<test_tanh>::std_test_values = {
     cmplx(1, 1),
     cmplx(-1, 1),
     cmplx(1, -1),
@@ -217,21 +271,21 @@ vector<cmplx<double>> test_cases<test_tanh>::std_test_values = {
 // So check against reference value
 template <>
 vector<tuple<cmplx<double>, cmplx<double>>>
-    test_cases<test_tanh>::comp_test_values = {
+    cplx_test_cases<test_tanh>::comp_test_values = {
         tuple(cmplx(INFINITYd, INFINITYd), cmplx(1.0, 0.0)),
         tuple(cmplx(INFINITYd, NANd), cmplx(1.0, 0.0))};
 
 // test_abs
-template <> const char *test_cases<test_abs>::test_name = "abs test";
+template <> const char *cplx_test_cases<test_abs>::test_name = "abs test";
 
 // test_arg
-template <> const char *test_cases<test_arg>::test_name = "arg test";
+template <> const char *cplx_test_cases<test_arg>::test_name = "arg test";
 
 // test_norm
 // Difference between libstdc++ and libc++ when NaN's and Inf values are
 // combined.
 template <>
-vector<cmplx<double>> test_cases<test_norm>::std_test_values = {
+vector<cmplx<double>> cplx_test_cases<test_norm>::std_test_values = {
     cmplx(1, 1),
     cmplx(-1, 1),
     cmplx(1, -1),
@@ -244,17 +298,54 @@ vector<cmplx<double>> test_cases<test_norm>::std_test_values = {
     cmplx(NANd, NANd),
 };
 
-template <> const char *test_cases<test_norm>::test_name = "norm test";
+template <> const char *cplx_test_cases<test_norm>::test_name = "norm test";
+
+// test real
+template <> const char *cplx_test_cases<test_real>::test_name = "real test";
+
+// test imag
+template <> const char *cplx_test_cases<test_imag>::test_name = "imag test";
+
+// test conj
+template <>
+const char *deci_test_cases<test_deci_cplx_conj>::test_name = "conj test";
+
+// test proj
+template <>
+const char *deci_test_cases<test_deci_cplx_proj>::test_name = "proj test";
+
+// test arg
+template <>
+const char *deci_test_cases<test_deci_deci_arg>::test_name = "arg test";
+
+template <>
+vector<double> deci_test_cases<test_deci_deci_arg>::std_test_values = {
+  4.42,
+  2.02,
+  INFINITYd,
+};
+
+// test norm
+template <>
+const char *deci_test_cases<test_deci_deci_norm>::test_name = "norm test";
+
+// test real
+template <>
+const char *deci_test_cases<test_deci_deci_real>::test_name = "real test";
+
+// test imag
+template <>
+const char *deci_test_cases<test_deci_deci_imag>::test_name = "imag test";
 
 // test_polar
 // Note: values represent rho and theta, not real and imaginary values
 // Output is undefined if rho is negative or Nan, or theta is Inf
 template <>
-vector<cmplx<double>> test_cases<test_polar>::std_test_values = {
+vector<cmplx<double>> cplx_test_cases<test_polar>::std_test_values = {
     cmplx(1, 1),
     cmplx(1, -1),
     cmplx(2, 0),
     cmplx(0.5, 3.14),
 };
 
-template <> const char *test_cases<test_polar>::test_name = "polar test";
+template <> const char *cplx_test_cases<test_polar>::test_name = "polar test";

--- a/SYCL/Complex/sycl_complex_operator_test.cpp
+++ b/SYCL/Complex/sycl_complex_operator_test.cpp
@@ -119,12 +119,11 @@ test_op_assign(test_div_assign, /=);
     }                                                                          \
   };
 
-test_op_unary(test_unary_plus, +)
-test_op_unary(test_unary_minus, -)
+test_op_unary(test_unary_plus, +) test_op_unary(test_unary_minus, -)
 
 #undef test_op_unary
 
-int main() {
+    int main() {
   sycl::queue Q;
 
   bool test_passes = true;

--- a/SYCL/Complex/sycl_complex_operator_test.cpp
+++ b/SYCL/Complex/sycl_complex_operator_test.cpp
@@ -89,6 +89,41 @@ test_op_assign(test_div_assign, /=);
 
 #undef test_op_assign
 
+// Macro for testing unary operators
+
+#define test_op_unary(name, op)                                                \
+  template <typename T> struct name {                                          \
+    bool operator()(sycl::queue &Q, T init_re1, T init_im1, T init_re2,        \
+                    T init_im2) {                                              \
+      bool pass = true;                                                        \
+                                                                               \
+      auto std_in = init_std_complex(init_re1, init_im1);                      \
+      experimental::complex<T> cplx_input{init_re1, init_im1};                 \
+                                                                               \
+      std::complex<T> std_out{};                                               \
+      auto *cplx_out = sycl::malloc_shared<experimental::complex<T>>(1, Q);    \
+                                                                               \
+      std_out = op std_in;                                                     \
+                                                                               \
+      Q.single_task([=]() { cplx_out[0] = op cplx_input; }).wait();            \
+                                                                               \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ true);         \
+                                                                               \
+      cplx_out[0] = op cplx_input;                                             \
+                                                                               \
+      pass &= check_results(cplx_out[0], std_out, /*is_device*/ false);        \
+                                                                               \
+      sycl::free(cplx_out, Q);                                                 \
+                                                                               \
+      return pass;                                                             \
+    }                                                                          \
+  };
+
+test_op_unary(test_unary_plus, +)
+test_op_unary(test_unary_minus, -)
+
+#undef test_op_unary
+
 int main() {
   sycl::queue Q;
 
@@ -131,6 +166,17 @@ int main() {
 
   {
     test_cases<test_div_assign> test;
+    test_passes &= test(Q);
+  }
+
+  /* Test unary operators */
+
+  {
+    test_cases<test_unary_plus> test;
+    test_passes &= test(Q);
+  }
+  {
+    test_cases<test_unary_minus> test;
     test_passes &= test(Q);
   }
 

--- a/SYCL/Complex/sycl_complex_operator_test.cpp
+++ b/SYCL/Complex/sycl_complex_operator_test.cpp
@@ -119,11 +119,12 @@ test_op_assign(test_div_assign, /=);
     }                                                                          \
   };
 
-test_op_unary(test_unary_plus, +) test_op_unary(test_unary_minus, -)
+test_op_unary(test_unary_plus, +);
+test_op_unary(test_unary_minus, -);
 
 #undef test_op_unary
 
-    int main() {
+int main() {
   sycl::queue Q;
 
   bool test_passes = true;

--- a/SYCL/Complex/sycl_complex_operator_test_cases.hpp
+++ b/SYCL/Complex/sycl_complex_operator_test_cases.hpp
@@ -79,8 +79,7 @@ template <>
 const char *test_cases<test_div_assign>::test_name = "division assign test";
 
 // test_unary_plus
-template <>
-const char *test_cases<test_unary_plus>::test_name = "unary + test";
+template <> const char *test_cases<test_unary_plus>::test_name = "unary + test";
 
 // test_unary_minus
 template <>

--- a/SYCL/Complex/sycl_complex_operator_test_cases.hpp
+++ b/SYCL/Complex/sycl_complex_operator_test_cases.hpp
@@ -13,6 +13,9 @@ template <typename T> class test_sub_assign;
 template <typename T> class test_mul_assign;
 template <typename T> class test_div_assign;
 
+template <typename T> class test_unary_plus;
+template <typename T> class test_unary_minus;
+
 // Stores test cases for each math function used in sycl_complex_math_test.cpp
 // Values are stored in the highest precision type, in this case that is double
 
@@ -74,3 +77,11 @@ const char *test_cases<test_mul_assign>::test_name =
 // test_div_assign
 template <>
 const char *test_cases<test_div_assign>::test_name = "division assign test";
+
+// test_unary_plus
+template <>
+const char *test_cases<test_unary_plus>::test_name = "unary + test";
+
+// test_unary_minus
+template <>
+const char *test_cases<test_unary_minus>::test_name = "unary - test";


### PR DESCRIPTION
This PR updates the tests for the experimental sycl complex implementation.

It tests the new unary operators `+` and `-`, the new functions `real` and `imag` and the variant of `conj`, `proj`, `arg`, `norm`, when the function is called with decimals as arguments.

An overload of `test_valid_types` which takes a template template parameter that takes two typename parameters has been introduced to support the new `deci_test_cases`.

Finally, the `test_cases` structure has been renamed to `cplx_test_cases` to be coherent with the new `deci_test_cases`.

Depends on: https://github.com/intel/llvm/pull/8068


