### PR TITLE
[SYCL][NFC] Update InlineAsm tests to match SYCL 2020

### DIFF
--- a/SYCL/InlineAsm/asm_16_empty.cpp
+++ b/SYCL/InlineAsm/asm_16_empty.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}

--- a/SYCL/InlineAsm/asm_16_matrix_mult.cpp
+++ b/SYCL/InlineAsm/asm_16_matrix_mult.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}

--- a/SYCL/InlineAsm/asm_16_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_16_no_input_int.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}

--- a/SYCL/InlineAsm/asm_16_no_opts.cpp
+++ b/SYCL/InlineAsm/asm_16_no_opts.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}

--- a/SYCL/InlineAsm/asm_8_empty.cpp
+++ b/SYCL/InlineAsm/asm_8_empty.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}

--- a/SYCL/InlineAsm/asm_8_no_input_int.cpp
+++ b/SYCL/InlineAsm/asm_8_no_input_int.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}

--- a/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
+++ b/SYCL/InlineAsm/asm_arbitrary_ops_order.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_decl_in_scope.cpp
+++ b/SYCL/InlineAsm/asm_decl_in_scope.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_float_add.cpp
+++ b/SYCL/InlineAsm/asm_float_add.cpp
@@ -9,7 +9,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_double;
+using dataType = sycl::opencl::cl_double;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_float_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_float_imm_arg.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 constexpr double IMM_ARGUMENT = 0.5;
-using dataType = sycl::cl_double;
+using dataType = sycl::opencl::cl_double;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_float_neg.cpp
+++ b/SYCL/InlineAsm/asm_float_neg.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_float;
+using dataType = sycl::opencl::cl_float;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_if.cpp
+++ b/SYCL/InlineAsm/asm_if.cpp
@@ -6,7 +6,7 @@
 #include "include/asmhelper.h"
 #include <sycl/sycl.hpp>
 
-using DataType = sycl::cl_int;
+using DataType = sycl::opencl::cl_int;
 
 template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t ProblemSize) : WithOutputBuffer<T>(ProblemSize) {}

--- a/SYCL/InlineAsm/asm_imm_arg.cpp
+++ b/SYCL/InlineAsm/asm_imm_arg.cpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 constexpr int CONST_ARGUMENT = 0xabc;
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_loop.cpp
+++ b/SYCL/InlineAsm/asm_loop.cpp
@@ -9,7 +9,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using DataType = sycl::cl_int;
+using DataType = sycl::opencl::cl_int;
 
 template <typename T = DataType>
 struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_mul.cpp
+++ b/SYCL/InlineAsm/asm_mul.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_multiple_instructions.cpp
+++ b/SYCL/InlineAsm/asm_multiple_instructions.cpp
@@ -12,7 +12,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_no_output.cpp
+++ b/SYCL/InlineAsm/asm_no_output.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t problem_size) : WithOutputBuffer<T>(problem_size) {}

--- a/SYCL/InlineAsm/asm_plus_mod.cpp
+++ b/SYCL/InlineAsm/asm_plus_mod.cpp
@@ -8,7 +8,7 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-using dataType = sycl::cl_int;
+using dataType = sycl::opencl::cl_int;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {

--- a/SYCL/InlineAsm/asm_switch.cpp
+++ b/SYCL/InlineAsm/asm_switch.cpp
@@ -6,7 +6,7 @@
 #include "include/asmhelper.h"
 #include <sycl/sycl.hpp>
 
-using DataType = sycl::cl_int;
+using DataType = sycl::opencl::cl_int;
 
 template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
   KernelFunctor(size_t ProblemSize) : WithOutputBuffer<T>(ProblemSize) {}


### PR DESCRIPTION
SYCL 2020 defines `cl_* aliases in `opencl` namespace contrary to SYCL 1.2.1