### PR TITLE
[SYCL] Do not use `cl_*` types in DeviceLib tests

### DIFF
--- a/SYCL/DeviceLib/built-ins/nan.cpp
+++ b/SYCL/DeviceLib/built-ins/nan.cpp
@@ -38,10 +38,10 @@ template <typename T, typename R> void check_nan(s::queue &Queue) {
 }
 
 int main() {
-  test_nan_call<s::ushort, s::half>();
-  test_nan_call<s::uint, float>();
-  test_nan_call<s::ulong, double>();
-  test_nan_call<s::ulonglong, double>();
+  test_nan_call<unsigned short, s::half>();
+  test_nan_call<unsigned int, float>();
+  test_nan_call<unsigned long, double>();
+  test_nan_call<unsigned long long, double>();
   test_nan_call<s::ushort2, s::half2>();
   test_nan_call<s::uint2, s::float2>();
   test_nan_call<s::ulong2, s::double2>();

--- a/SYCL/DeviceLib/built-ins/scalar_common.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_common.cpp
@@ -12,14 +12,14 @@ namespace s = sycl;
 int main() {
   // max
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxF1F1>(
-            [=]() { AccR[0] = s::max(s::cl_float{0.5f}, s::cl_float{2.3f}); });
+            [=]() { AccR[0] = s::max(float{0.5f}, float{2.3f}); });
       });
     }
     assert(r == 2.3f);

--- a/SYCL/DeviceLib/built-ins/scalar_geometric.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_geometric.cpp
@@ -12,14 +12,14 @@ namespace s = sycl;
 int main() {
   // dot
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class dotF1F1>(
-            [=]() { AccR[0] = s::dot(s::cl_float{0.5}, s::cl_float{1.6}); });
+            [=]() { AccR[0] = s::dot(float{0.5}, float{1.6}); });
       });
     }
     assert(r == 0.8f);
@@ -27,15 +27,14 @@ int main() {
 
   // distance
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class distanceF1>([=]() {
-          AccR[0] = s::distance(s::cl_float{1.f}, s::cl_float{3.f});
-        });
+        cgh.single_task<class distanceF1>(
+            [=]() { AccR[0] = s::distance(float{1.f}, float{3.f}); });
       });
     }
     assert(r == 2.f);
@@ -43,14 +42,14 @@ int main() {
 
   // length
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class lengthF1>(
-            [=]() { AccR[0] = s::length(s::cl_float{1.f}); });
+            [=]() { AccR[0] = s::length(float{1.f}); });
       });
     }
     assert(r == 1.f);
@@ -58,14 +57,14 @@ int main() {
 
   // normalize
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class normalizeF1>(
-            [=]() { AccR[0] = s::normalize(s::cl_float{2.f}); });
+            [=]() { AccR[0] = s::normalize(float{2.f}); });
       });
     }
     assert(r == 1.f);
@@ -73,15 +72,14 @@ int main() {
 
   // fast_distance
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class fast_distanceF1>([=]() {
-          AccR[0] = s::fast_distance(s::cl_float{1.f}, s::cl_float{3.f});
-        });
+        cgh.single_task<class fast_distanceF1>(
+            [=]() { AccR[0] = s::fast_distance(float{1.f}, float{3.f}); });
       });
     }
     assert(r == 2.f);
@@ -89,14 +87,14 @@ int main() {
 
   // fast_length
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fast_lengthF1>(
-            [=]() { AccR[0] = s::fast_length(s::cl_float{2.f}); });
+            [=]() { AccR[0] = s::fast_length(float{2.f}); });
       });
     }
     assert(r == 2.f);
@@ -104,14 +102,14 @@ int main() {
 
   // fast_normalize
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fast_normalizeF1>(
-            [=]() { AccR[0] = s::fast_normalize(s::cl_float{2.f}); });
+            [=]() { AccR[0] = s::fast_normalize(float{2.f}); });
       });
     }
 

--- a/SYCL/DeviceLib/built-ins/scalar_integer.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_integer.cpp
@@ -19,8 +19,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class maxSI1SI1>(
-            [=]() { AccR[0] = s::max(5, 2); });
+        cgh.single_task<class maxSI1SI1>([=]() { AccR[0] = s::max(5, 2); });
       });
     }
     assert(r == 5);
@@ -34,8 +33,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class maxUI1UI1>(
-            [=]() { AccR[0] = s::max(5u, 2u); });
+        cgh.single_task<class maxUI1UI1>([=]() { AccR[0] = s::max(5u, 2u); });
       });
     }
     assert(r == 5);
@@ -49,8 +47,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class minSI1SI1>(
-            [=]() { AccR[0] = s::min(5, 2); });
+        cgh.single_task<class minSI1SI1>([=]() { AccR[0] = s::min(5, 2); });
       });
     }
     assert(r == 2);
@@ -79,8 +76,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class minUI1UI1>(
-            [=]() { AccR[0] = s::min(5u, 2u); });
+        cgh.single_task<class minUI1UI1>([=]() { AccR[0] = s::min(5u, 2u); });
       });
     }
     assert(r == 2);
@@ -109,8 +105,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class absSI1>(
-            [=]() { AccR[0] = s::abs(-5); });
+        cgh.single_task<class absSI1>([=]() { AccR[0] = s::abs(-5); });
       });
     }
     assert(r == 5);
@@ -139,8 +134,9 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class abs_diffUC1UC1>(
-            [=]() { AccR[0] = s::abs_diff((unsigned char)3, (unsigned char)250); });
+        cgh.single_task<class abs_diffUC1UC1>([=]() {
+          AccR[0] = s::abs_diff((unsigned char)3, (unsigned char)250);
+        });
       });
     }
     assert(r == 247);
@@ -154,9 +150,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class add_satSI1SI1>([=]() {
-          AccR[0] = s::add_sat(0x7FFFFFFF, 100);
-        });
+        cgh.single_task<class add_satSI1SI1>(
+            [=]() { AccR[0] = s::add_sat(0x7FFFFFFF, 100); });
       });
     }
     assert(r == 0x7FFFFFFF);
@@ -170,9 +165,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class haddSI1SI1>([=]() {
-          AccR[0] = s::hadd(0x0000007F, 0x00000020);
-        });
+        cgh.single_task<class haddSI1SI1>(
+            [=]() { AccR[0] = s::hadd(0x0000007F, 0x00000020); });
       });
     }
     assert(r == 0x0000004F);
@@ -186,9 +180,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class rhaddSI1SI1>([=]() {
-          AccR[0] = s::rhadd(0x0000007F, 0x00000020);
-        });
+        cgh.single_task<class rhaddSI1SI1>(
+            [=]() { AccR[0] = s::rhadd(0x0000007F, 0x00000020); });
       });
     }
     assert(r == 0x50);
@@ -202,9 +195,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class clampSI1SI1SI1>([=]() {
-          AccR[0] = s::clamp(5, 10, 30);
-        });
+        cgh.single_task<class clampSI1SI1SI1>(
+            [=]() { AccR[0] = s::clamp(5, 10, 30); });
       });
     }
     assert(r == 10);
@@ -218,8 +210,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class clzSI1>(
-            [=]() { AccR[0] = s::clz(0x0FFFFFFF); });
+        cgh.single_task<class clzSI1>([=]() { AccR[0] = s::clz(0x0FFFFFFF); });
       });
     }
     assert(r == 4);
@@ -249,8 +240,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad_hiSI1SI1SI1>([=]() {
-          AccR[0] = s::mad_hi(0x10000000, 0x00000100,
-                              0x00000001);
+          AccR[0] = s::mad_hi(0x10000000, 0x00000100, 0x00000001);
         }); // 2^28 * 2^8 = 2^36 -> 0x10 00000000.
       });
     }
@@ -266,8 +256,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad_satSI1SI1SI1>([=]() {
-          AccR[0] = s::mad_sat(0x10000000, 0x00000100,
-                               0x00000001);
+          AccR[0] = s::mad_sat(0x10000000, 0x00000100, 0x00000001);
         }); // 2^31 * 2^8 = 2^39 -> 0x80 00000000 -> reuslt is saturated in the
             // product.
       });
@@ -353,9 +342,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class rotateSI1SI1>([=]() {
-          AccR[0] = s::rotate(0x11100000, 12);
-        });
+        cgh.single_task<class rotateSI1SI1>(
+            [=]() { AccR[0] = s::rotate(0x11100000, 12); });
       });
     }
     assert(r == 0x00000111);
@@ -369,9 +357,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class rotateSI1SI2>([=]() {
-          AccR[0] = s::rotate((char)0xe0, (char)50);
-        });
+        cgh.single_task<class rotateSI1SI2>(
+            [=]() { AccR[0] = s::rotate((char)0xe0, (char)50); });
       });
     }
     assert((unsigned char)r == 0x83);
@@ -426,9 +413,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class upsampleSC1UC1>([=]() {
-          AccR[0] = s::upsample((char)0x10, (unsigned char)0x10);
-        });
+        cgh.single_task<class upsampleSC1UC1>(
+            [=]() { AccR[0] = s::upsample((char)0x10, (unsigned char)0x10); });
       });
     }
     assert(r == 0x1010);
@@ -474,9 +460,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class upsampleUI1UI1>([=]() {
-          AccR[0] = s::upsample(0x00000010u, 0x00000010u);
-        });
+        cgh.single_task<class upsampleUI1UI1>(
+            [=]() { AccR[0] = s::upsample(0x00000010u, 0x00000010u); });
       });
     }
     assert(r == 0x0000001000000010);
@@ -490,9 +475,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class upsampleSI1UI1>([=]() {
-          AccR[0] = s::upsample(0x00000010, 0x00000010u);
-        });
+        cgh.single_task<class upsampleSI1UI1>(
+            [=]() { AccR[0] = s::upsample(0x00000010, 0x00000010u); });
       });
     }
     assert(r == 0x0000001000000010);
@@ -521,10 +505,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class mad24SI1SI1SI1>([=]() {
-          AccR[0] =
-              s::mad24((int)0xFFFFFFFF, (int)20, (int)20);
-        });
+        cgh.single_task<class mad24SI1SI1SI1>(
+            [=]() { AccR[0] = s::mad24((int)0xFFFFFFFF, (int)20, (int)20); });
       });
     }
     assert(r == 0);
@@ -538,9 +520,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class mul24SI1SI1>([=]() {
-          AccR[0] = s::mul24((int)0xFFFFFFFF, (int)20);
-        });
+        cgh.single_task<class mul24SI1SI1>(
+            [=]() { AccR[0] = s::mul24((int)0xFFFFFFFF, (int)20); });
       });
     }
     assert(r == -20);

--- a/SYCL/DeviceLib/built-ins/scalar_integer.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_integer.cpp
@@ -370,7 +370,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class rotateSI1SI2>([=]() {
-          AccR[0] = s::rotate((unsigned char)0xe0, (unsigned char)50);
+          AccR[0] = s::rotate((char)0xe0, (char)50);
         });
       });
     }

--- a/SYCL/DeviceLib/built-ins/scalar_integer.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_integer.cpp
@@ -13,14 +13,14 @@ namespace s = sycl;
 int main() {
   // max
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxSI1SI1>(
-            [=]() { AccR[0] = s::max(s::cl_int{5}, s::cl_int{2}); });
+            [=]() { AccR[0] = s::max(5, 2); });
       });
     }
     assert(r == 5);
@@ -28,14 +28,14 @@ int main() {
 
   // max
   {
-    s::cl_uint r{0};
+    unsigned int r{0};
     {
-      s::buffer<s::cl_uint, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxUI1UI1>(
-            [=]() { AccR[0] = s::max(s::cl_uint{5}, s::cl_uint{2}); });
+            [=]() { AccR[0] = s::max(5u, 2u); });
       });
     }
     assert(r == 5);
@@ -43,29 +43,29 @@ int main() {
 
   // min
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minSI1SI1>(
-            [=]() { AccR[0] = s::min(s::cl_int{5}, s::cl_int{2}); });
+            [=]() { AccR[0] = s::min(5, 2); });
       });
     }
     assert(r == 2);
   }
 
-  // min (longlong)
+  // min (long long)
   {
-    s::longlong r{0};
+    long long r{0};
     {
-      s::buffer<s::longlong, 1> BufR(&r, s::range<1>(1));
+      s::buffer<long long, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minSLL1SLL1>(
-            [=]() { AccR[0] = s::min(s::longlong{5}, s::longlong{2}); });
+            [=]() { AccR[0] = s::min(5ll, 2ll); });
       });
     }
     assert(r == 2);
@@ -73,29 +73,29 @@ int main() {
 
   // min
   {
-    s::cl_uint r{0};
+    unsigned int r{0};
     {
-      s::buffer<s::cl_uint, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minUI1UI1>(
-            [=]() { AccR[0] = s::min(s::cl_uint{5}, s::cl_uint{2}); });
+            [=]() { AccR[0] = s::min(5u, 2u); });
       });
     }
     assert(r == 2);
   }
 
-  // min (ulonglong)
+  // min (unsigned long long)
   {
-    s::ulonglong r{0};
+    unsigned long long r{0};
     {
-      s::buffer<s::ulonglong, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned long long, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minULL1ULL1>(
-            [=]() { AccR[0] = s::min(s::ulonglong{5}, s::ulonglong{2}); });
+            [=]() { AccR[0] = s::min(5ull, 2ull); });
       });
     }
     assert(r == 2);
@@ -103,14 +103,14 @@ int main() {
 
   // abs
   {
-    s::cl_uint r{0};
+    unsigned int r{0};
     {
-      s::buffer<s::cl_uint, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class absSI1>(
-            [=]() { AccR[0] = s::abs(s::cl_int{-5}); });
+            [=]() { AccR[0] = s::abs(-5); });
       });
     }
     assert(r == 5);
@@ -118,14 +118,14 @@ int main() {
 
   // abs_diff
   {
-    s::cl_uint r{0};
+    unsigned int r{0};
     {
-      s::buffer<s::cl_uint, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class abs_diffSI1SI1>(
-            [=]() { AccR[0] = s::abs_diff(s::cl_int{-5}, s::cl_int{-1}); });
+            [=]() { AccR[0] = s::abs_diff(-5, -1); });
       });
     }
     assert(r == 4);
@@ -133,14 +133,14 @@ int main() {
 
   // abs_diff(uchar)
   {
-    s::cl_uchar r{0};
+    unsigned char r{0};
     {
-      s::buffer<s::cl_uchar, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned char, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class abs_diffUC1UC1>(
-            [=]() { AccR[0] = s::abs_diff(s::uchar{3}, s::uchar{250}); });
+            [=]() { AccR[0] = s::abs_diff((unsigned char)3, (unsigned char)250); });
       });
     }
     assert(r == 247);
@@ -148,14 +148,14 @@ int main() {
 
   // add_sat
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class add_satSI1SI1>([=]() {
-          AccR[0] = s::add_sat(s::cl_int{0x7FFFFFFF}, s::cl_int{100});
+          AccR[0] = s::add_sat(0x7FFFFFFF, 100);
         });
       });
     }
@@ -164,14 +164,14 @@ int main() {
 
   // hadd
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class haddSI1SI1>([=]() {
-          AccR[0] = s::hadd(s::cl_int{0x0000007F}, s::cl_int{0x00000020});
+          AccR[0] = s::hadd(0x0000007F, 0x00000020);
         });
       });
     }
@@ -180,14 +180,14 @@ int main() {
 
   // rhadd
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class rhaddSI1SI1>([=]() {
-          AccR[0] = s::rhadd(s::cl_int{0x0000007F}, s::cl_int{0x00000020});
+          AccR[0] = s::rhadd(0x0000007F, 0x00000020);
         });
       });
     }
@@ -196,14 +196,14 @@ int main() {
 
   // clamp
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class clampSI1SI1SI1>([=]() {
-          AccR[0] = s::clamp(s::cl_int{5}, s::cl_int{10}, s::cl_int{30});
+          AccR[0] = s::clamp(5, 10, 30);
         });
       });
     }
@@ -212,14 +212,14 @@ int main() {
 
   // clz
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class clzSI1>(
-            [=]() { AccR[0] = s::clz(s::cl_int{0x0FFFFFFF}); });
+            [=]() { AccR[0] = s::clz(0x0FFFFFFF); });
       });
     }
     assert(r == 4);
@@ -227,14 +227,14 @@ int main() {
 
   // ctz
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class ctzSI1>(
-            [=]() { AccR[0] = s::intel::ctz(s::cl_int{0x7FFFFFF0}); });
+            [=]() { AccR[0] = s::intel::ctz(0x7FFFFFF0); });
       });
     }
     assert(r == 4);
@@ -242,15 +242,15 @@ int main() {
 
   // mad_hi
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad_hiSI1SI1SI1>([=]() {
-          AccR[0] = s::mad_hi(s::cl_int{0x10000000}, s::cl_int{0x00000100},
-                              s::cl_int{0x00000001});
+          AccR[0] = s::mad_hi(0x10000000, 0x00000100,
+                              0x00000001);
         }); // 2^28 * 2^8 = 2^36 -> 0x10 00000000.
       });
     }
@@ -259,15 +259,15 @@ int main() {
 
   // mad_sat
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad_satSI1SI1SI1>([=]() {
-          AccR[0] = s::mad_sat(s::cl_int{0x10000000}, s::cl_int{0x00000100},
-                               s::cl_int{0x00000001});
+          AccR[0] = s::mad_sat(0x10000000, 0x00000100,
+                               0x00000001);
         }); // 2^31 * 2^8 = 2^39 -> 0x80 00000000 -> reuslt is saturated in the
             // product.
       });
@@ -298,14 +298,14 @@ int main() {
 
   // mul_hi
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mul_hiSI1SI1>([=]() {
-          AccR[0] = s::mul_hi(s::cl_int{0x10000000}, s::cl_int{0x00000100});
+          AccR[0] = s::mul_hi(0x10000000, 0x00000100);
         }); // 2^28 * 2^8 = 2^36 -> 0x10 00000000.
       });
     }
@@ -314,14 +314,14 @@ int main() {
 
   // mul_hi with negative result w/ carry
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mul_hiSI1SI2>([=]() {
-          AccR[0] = s::mul_hi(s::cl_int{-0x10000000}, s::cl_int{0x00000100});
+          AccR[0] = s::mul_hi(-0x10000000, 0x00000100);
         }); // -2^28 * 2^8 = -2^36 -> -0x10 (FFFFFFF0) 00000000.
       });
     }
@@ -330,14 +330,14 @@ int main() {
 
   // mul_hi with negative result w/o carry
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mul_hiSI1SI3>([=]() {
-          AccR[0] = s::mul_hi(s::cl_int{-0x10000000}, s::cl_int{0x00000101});
+          AccR[0] = s::mul_hi(-0x10000000, 0x00000101);
         }); // -2^28 * (2^8 + 1) = -2^36 - 2^28 -> -0x11 (FFFFFFEF) -0x10000000
             // (F0000000).
       });
@@ -347,14 +347,14 @@ int main() {
 
   // rotate
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class rotateSI1SI1>([=]() {
-          AccR[0] = s::rotate(s::cl_int{0x11100000}, s::cl_int{12});
+          AccR[0] = s::rotate(0x11100000, 12);
         });
       });
     }
@@ -363,15 +363,14 @@ int main() {
 
   // rotate (with large rotate size)
   {
-    s::cl_char r{0};
+    char r{0};
     {
-      s::buffer<s::cl_char, 1> BufR(&r, s::range<1>(1));
+      s::buffer<char, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class rotateSI1SI2>([=]() {
-          AccR[0] = s::rotate(static_cast<s::cl_char>((unsigned char)0xe0),
-                              s::cl_char{50});
+          AccR[0] = s::rotate((unsigned char)0xe0, (unsigned char)50);
         });
       });
     }
@@ -379,10 +378,10 @@ int main() {
   }
   // sub_sat
   {
-    auto TestSubSat = [](s::cl_int x, s::cl_int y) {
-      s::cl_int r{0};
+    auto TestSubSat = [](int x, int y) {
+      int r{0};
       {
-        s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+        s::buffer<int, 1> BufR(&r, s::range<1>(1));
         s::queue myQueue;
         myQueue.submit([&](s::handler &cgh) {
           auto AccR = BufR.get_access<s::access::mode::write>(cgh);
@@ -393,26 +392,26 @@ int main() {
       return r;
     };
     // 10 - (-2^31(minimum value)) = saturates on Maximum value
-    s::cl_int r1 = TestSubSat(10, 0x80000000);
+    int r1 = TestSubSat(10, 0x80000000);
     assert(r1 == 0x7FFFFFFF);
-    s::cl_int r2 = TestSubSat(0x7FFFFFFF, 0xFFFFFFFF);
+    int r2 = TestSubSat(0x7FFFFFFF, 0xFFFFFFFF);
     assert(r2 == 0x7FFFFFFF);
-    s::cl_int r3 = TestSubSat(0x80000000, 0x00000001);
+    int r3 = TestSubSat(0x80000000, 0x00000001);
     assert(r3 == 0x80000000);
-    s::cl_int r4 = TestSubSat(10499, 30678);
+    int r4 = TestSubSat(10499, 30678);
     assert(r4 == -20179);
   }
 
   // upsample - 1
   {
-    s::cl_ushort r{0};
+    unsigned short r{0};
     {
-      s::buffer<s::cl_ushort, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned short, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleUC1UC1>([=]() {
-          AccR[0] = s::upsample(s::cl_uchar{0x10}, s::cl_uchar{0x10});
+          AccR[0] = s::upsample((unsigned char)0x10, (unsigned char)0x10);
         });
       });
     }
@@ -421,14 +420,14 @@ int main() {
 
   // upsample - 2
   {
-    s::cl_short r{0};
+    short r{0};
     {
-      s::buffer<s::cl_short, 1> BufR(&r, s::range<1>(1));
+      s::buffer<short, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleSC1UC1>([=]() {
-          AccR[0] = s::upsample(s::cl_char{0x10}, s::cl_uchar{0x10});
+          AccR[0] = s::upsample((char)0x10, (unsigned char)0x10);
         });
       });
     }
@@ -437,14 +436,14 @@ int main() {
 
   // upsample - 3
   {
-    s::cl_uint r{0};
+    unsigned int r{0};
     {
-      s::buffer<s::cl_uint, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleUS1US1>([=]() {
-          AccR[0] = s::upsample(s::cl_ushort{0x0010}, s::cl_ushort{0x0010});
+          AccR[0] = s::upsample((unsigned short)0x0010, (unsigned short)0x0010);
         });
       });
     }
@@ -453,14 +452,14 @@ int main() {
 
   // upsample - 4
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleSS1US1>([=]() {
-          AccR[0] = s::upsample(s::cl_short{0x0010}, s::cl_ushort{0x0010});
+          AccR[0] = s::upsample((short)0x0010, (unsigned short)0x0010);
         });
       });
     }
@@ -469,14 +468,14 @@ int main() {
 
   // upsample - 5
   {
-    s::cl_ulong r{0};
+    unsigned long long r{0};
     {
-      s::buffer<s::cl_ulong, 1> BufR(&r, s::range<1>(1));
+      s::buffer<unsigned long long, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleUI1UI1>([=]() {
-          AccR[0] = s::upsample(s::cl_uint{0x00000010}, s::cl_uint{0x00000010});
+          AccR[0] = s::upsample(0x00000010u, 0x00000010u);
         });
       });
     }
@@ -485,14 +484,14 @@ int main() {
 
   // upsample - 6
   {
-    s::cl_long r{0};
+    long long r{0};
     {
-      s::buffer<s::cl_long, 1> BufR(&r, s::range<1>(1));
+      s::buffer<long long, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleSI1UI1>([=]() {
-          AccR[0] = s::upsample(s::cl_int{0x00000010}, s::cl_uint{0x00000010});
+          AccR[0] = s::upsample(0x00000010, 0x00000010u);
         });
       });
     }
@@ -501,14 +500,14 @@ int main() {
 
   // popcount
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class popcountSI1>(
-            [=]() { AccR[0] = s::popcount(s::cl_int{0x000000FF}); });
+            [=]() { AccR[0] = s::popcount(0x000000FF); });
       });
     }
     assert(r == 8);
@@ -516,15 +515,15 @@ int main() {
 
   // mad24
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad24SI1SI1SI1>([=]() {
           AccR[0] =
-              s::mad24(s::cl_int(0xFFFFFFFF), s::cl_int{20}, s::cl_int{20});
+              s::mad24((int)0xFFFFFFFF, (int)20, (int)20);
         });
       });
     }
@@ -533,14 +532,14 @@ int main() {
 
   // mul24
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mul24SI1SI1>([=]() {
-          AccR[0] = s::mul24(s::cl_int(0xFFFFFFFF), s::cl_int{20});
+          AccR[0] = s::mul24((int)0xFFFFFFFF, (int)20);
         });
       });
     }

--- a/SYCL/DeviceLib/built-ins/scalar_math.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_math.cpp
@@ -20,8 +20,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class acosF1>(
-            [=]() { AccR[0] = s::acos(float{0.5}); });
+        cgh.single_task<class acosF1>([=]() { AccR[0] = s::acos(float{0.5}); });
       });
     }
     assert(r > 1.047f && r < 1.048f); // ~1.0471975511965979
@@ -50,8 +49,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class asinF1>(
-            [=]() { AccR[0] = s::asin(float{0.5}); });
+        cgh.single_task<class asinF1>([=]() { AccR[0] = s::asin(float{0.5}); });
       });
     }
     assert(r > 0.523f && r < 0.524f); // ~0.5235987755982989
@@ -80,8 +78,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class atanF1>(
-            [=]() { AccR[0] = s::atan(float{0.5}); });
+        cgh.single_task<class atanF1>([=]() { AccR[0] = s::atan(float{0.5}); });
       });
     }
     assert(r > 0.463f && r < 0.464f); // ~0.4636476090008061
@@ -125,8 +122,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class ceilF1>(
-            [=]() { AccR[0] = s::ceil(float{0.5}); });
+        cgh.single_task<class ceilF1>([=]() { AccR[0] = s::ceil(float{0.5}); });
       });
     }
     assert(r == 1.f);
@@ -140,8 +136,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class cosF1>(
-            [=]() { AccR[0] = s::cos(float{0.5}); });
+        cgh.single_task<class cosF1>([=]() { AccR[0] = s::cos(float{0.5}); });
       });
     }
     assert(r > 0.877f && r < 0.878f); // ~0.8775825618903728
@@ -155,8 +150,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class coshF1>(
-            [=]() { AccR[0] = s::cosh(float{0.5}); });
+        cgh.single_task<class coshF1>([=]() { AccR[0] = s::cosh(float{0.5}); });
       });
     }
     assert(r > 1.127f && r < 1.128f); // ~1.1276259652063807
@@ -185,8 +179,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class erfcF1>(
-            [=]() { AccR[0] = s::erfc(float{0.5}); });
+        cgh.single_task<class erfcF1>([=]() { AccR[0] = s::erfc(float{0.5}); });
       });
     }
     assert(r > 0.479f && r < 0.480f); // ~0.4795001221869535
@@ -200,8 +193,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class erfF1>(
-            [=]() { AccR[0] = s::erf(float{0.5}); });
+        cgh.single_task<class erfF1>([=]() { AccR[0] = s::erf(float{0.5}); });
       });
     }
     assert(r > 0.520f && r < 0.521f); // ~0.5204998778130465
@@ -215,8 +207,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class expF1>(
-            [=]() { AccR[0] = s::exp(float{0.5}); });
+        cgh.single_task<class expF1>([=]() { AccR[0] = s::exp(float{0.5}); });
       });
     }
     assert(r > 1.648f && r < 1.649f); // ~1.6487212707001282
@@ -230,8 +221,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class exp2F1>(
-            [=]() { AccR[0] = s::exp2(float{8.0}); });
+        cgh.single_task<class exp2F1>([=]() { AccR[0] = s::exp2(float{8.0}); });
       });
     }
     assert(r == 256.0f);
@@ -245,8 +235,7 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class exp10F1>(
-            [=]() { AccR[0] = s::exp10(float{2}); });
+        cgh.single_task<class exp10F1>([=]() { AccR[0] = s::exp10(float{2}); });
       });
     }
     assert(r == 100.0f);

--- a/SYCL/DeviceLib/built-ins/scalar_math.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_math.cpp
@@ -14,14 +14,14 @@ namespace s = sycl;
 int main() {
   // acos
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class acosF1>(
-            [=]() { AccR[0] = s::acos(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::acos(float{0.5}); });
       });
     }
     assert(r > 1.047f && r < 1.048f); // ~1.0471975511965979
@@ -29,14 +29,14 @@ int main() {
 
   // acosh
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class acoshF1>(
-            [=]() { AccR[0] = s::acosh(s::cl_float{2.4}); });
+            [=]() { AccR[0] = s::acosh(float{2.4}); });
       });
     }
     assert(r > 1.522f && r < 1.523f); // ~1.5220793674636532
@@ -44,14 +44,14 @@ int main() {
 
   // asin
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class asinF1>(
-            [=]() { AccR[0] = s::asin(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::asin(float{0.5}); });
       });
     }
     assert(r > 0.523f && r < 0.524f); // ~0.5235987755982989
@@ -59,14 +59,14 @@ int main() {
 
   // asinh
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class asinhF1>(
-            [=]() { AccR[0] = s::asinh(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::asinh(float{0.5}); });
       });
     }
     assert(r > 0.481f && r < 0.482f); // ~0.48121182505960347
@@ -74,14 +74,14 @@ int main() {
 
   // atan
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class atanF1>(
-            [=]() { AccR[0] = s::atan(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::atan(float{0.5}); });
       });
     }
     assert(r > 0.463f && r < 0.464f); // ~0.4636476090008061
@@ -89,14 +89,14 @@ int main() {
 
   // atanh
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class atanhF1>(
-            [=]() { AccR[0] = s::atanh(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::atanh(float{0.5}); });
       });
     }
     assert(r > 0.549f && r < 0.550f); // ~0.5493061443340549
@@ -104,14 +104,14 @@ int main() {
 
   // cbrt
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class cbrtF1>(
-            [=]() { AccR[0] = s::cbrt(s::cl_float{27.0}); });
+            [=]() { AccR[0] = s::cbrt(float{27.0}); });
       });
     }
     assert(r == 3.f);
@@ -119,14 +119,14 @@ int main() {
 
   // ceil
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class ceilF1>(
-            [=]() { AccR[0] = s::ceil(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::ceil(float{0.5}); });
       });
     }
     assert(r == 1.f);
@@ -134,14 +134,14 @@ int main() {
 
   // cos
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class cosF1>(
-            [=]() { AccR[0] = s::cos(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::cos(float{0.5}); });
       });
     }
     assert(r > 0.877f && r < 0.878f); // ~0.8775825618903728
@@ -149,14 +149,14 @@ int main() {
 
   // cosh
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class coshF1>(
-            [=]() { AccR[0] = s::cosh(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::cosh(float{0.5}); });
       });
     }
     assert(r > 1.127f && r < 1.128f); // ~1.1276259652063807
@@ -164,14 +164,14 @@ int main() {
 
   // cospi
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class cospiF1>(
-            [=]() { AccR[0] = s::cospi(s::cl_float{0.1}); });
+            [=]() { AccR[0] = s::cospi(float{0.1}); });
       });
     }
     assert(r > 0.951f && r < 0.952f); // ~0.9510565162951535
@@ -179,14 +179,14 @@ int main() {
 
   // erfc
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class erfcF1>(
-            [=]() { AccR[0] = s::erfc(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::erfc(float{0.5}); });
       });
     }
     assert(r > 0.479f && r < 0.480f); // ~0.4795001221869535
@@ -194,14 +194,14 @@ int main() {
 
   // erf
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class erfF1>(
-            [=]() { AccR[0] = s::erf(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::erf(float{0.5}); });
       });
     }
     assert(r > 0.520f && r < 0.521f); // ~0.5204998778130465
@@ -209,14 +209,14 @@ int main() {
 
   // exp
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class expF1>(
-            [=]() { AccR[0] = s::exp(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::exp(float{0.5}); });
       });
     }
     assert(r > 1.648f && r < 1.649f); // ~1.6487212707001282
@@ -224,14 +224,14 @@ int main() {
 
   // exp2
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class exp2F1>(
-            [=]() { AccR[0] = s::exp2(s::cl_float{8.0}); });
+            [=]() { AccR[0] = s::exp2(float{8.0}); });
       });
     }
     assert(r == 256.0f);
@@ -239,14 +239,14 @@ int main() {
 
   // exp10
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class exp10F1>(
-            [=]() { AccR[0] = s::exp10(s::cl_float{2}); });
+            [=]() { AccR[0] = s::exp10(float{2}); });
       });
     }
     assert(r == 100.0f);
@@ -254,14 +254,14 @@ int main() {
 
   // expm1
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class expm1F1>(
-            [=]() { AccR[0] = s::expm1(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::expm1(float{0.5}); });
       });
     }
     assert(r > 0.648f && r < 0.649f); // ~0.6487212707001282
@@ -269,14 +269,14 @@ int main() {
 
   // fabs
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fabsF1>(
-            [=]() { AccR[0] = s::fabs(s::cl_float{-0.5}); });
+            [=]() { AccR[0] = s::fabs(float{-0.5}); });
       });
     }
     assert(r == 0.5f);
@@ -284,14 +284,14 @@ int main() {
 
   // floor
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class floorF1>(
-            [=]() { AccR[0] = s::floor(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::floor(float{0.5}); });
       });
     }
     assert(r == 0.f);
@@ -299,14 +299,14 @@ int main() {
 
   // fmax
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fmaxF1F1>(
-            [=]() { AccR[0] = s::fmax(s::cl_float{0.5}, s::cl_float{0.8}); });
+            [=]() { AccR[0] = s::fmax(float{0.5}, float{0.8}); });
       });
     }
     assert(r == 0.8f);
@@ -314,14 +314,14 @@ int main() {
 
   // fmin
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fminF1F1>(
-            [=]() { AccR[0] = s::fmin(s::cl_float{0.5}, s::cl_float{0.8}); });
+            [=]() { AccR[0] = s::fmin(float{0.5}, float{0.8}); });
       });
     }
     assert(r == 0.5f);
@@ -329,14 +329,14 @@ int main() {
 
   // fmod
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fmodF1F1>(
-            [=]() { AccR[0] = s::fmod(s::cl_float{5.1}, s::cl_float{3.0}); });
+            [=]() { AccR[0] = s::fmod(float{5.1}, float{3.0}); });
       });
     }
     assert(r == 2.1f);
@@ -344,14 +344,14 @@ int main() {
 
   // lgamma with private memory
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class lgammaF1>(
-            [=]() { AccR[0] = s::lgamma(s::cl_float{10.f}); });
+            [=]() { AccR[0] = s::lgamma(float{10.f}); });
       });
     }
     assert(r > 12.8017f && r < 12.8019f); // ~12.8018
@@ -359,14 +359,14 @@ int main() {
 
   // lgamma with private memory
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class lgammaF1_neg>(
-            [=]() { AccR[0] = s::lgamma(s::cl_float{-2.4f}); });
+            [=]() { AccR[0] = s::lgamma(float{-2.4f}); });
       });
     }
     assert(r > 0.1024f && r < 0.1026f); // ~0.102583

--- a/SYCL/DeviceLib/built-ins/scalar_math_2.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_math_2.cpp
@@ -81,9 +81,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class atan2piF1F1>([=]() {
-          AccR[0] = s::atan2pi(float{0.5}, float{0.5});
-        });
+        cgh.single_task<class atan2piF1F1>(
+            [=]() { AccR[0] = s::atan2pi(float{0.5}, float{0.5}); });
       });
     }
     assert(r > 0.249f && r < 0.251f); // ~0.25
@@ -97,9 +96,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class copysignF1F1>([=]() {
-          AccR[0] = s::copysign(float{1}, float{-0.5});
-        });
+        cgh.single_task<class copysignF1F1>(
+            [=]() { AccR[0] = s::copysign(float{1}, float{-0.5}); });
       });
     }
     assert(r == -1.f);
@@ -128,10 +126,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class fmaF1F1F1>([=]() {
-          AccR[0] =
-              s::fma(float{0.5}, float{10.0}, float{3.0});
-        });
+        cgh.single_task<class fmaF1F1F1>(
+            [=]() { AccR[0] = s::fma(float{0.5}, float{10.0}, float{3.0}); });
       });
     }
     assert(r == 8.0f);
@@ -144,7 +140,7 @@ int main() {
     {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::buffer<float, 1> BufI(&i, s::range<1>(1),
-                                     {s::property::buffer::use_host_ptr()});
+                               {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
@@ -166,7 +162,7 @@ int main() {
     {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::buffer<float, 1> BufI(&i, s::range<1>(1),
-                                     {s::property::buffer::use_host_ptr()});
+                               {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
@@ -190,7 +186,7 @@ int main() {
     {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::buffer<int, 1> BufI(&i, s::range<1>(1),
-                                   {s::property::buffer::use_host_ptr()});
+                             {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
@@ -214,7 +210,7 @@ int main() {
     {
       s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::buffer<int, 1> BufI(&i, s::range<1>(1),
-                                   {s::property::buffer::use_host_ptr()});
+                             {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);

--- a/SYCL/DeviceLib/built-ins/scalar_math_2.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_math_2.cpp
@@ -15,14 +15,14 @@ int main() {
 
   // acospi
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class acospiF1>(
-            [=]() { AccR[0] = s::acospi(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::acospi(float{0.5}); });
       });
     }
     assert(r > 0.333f && r < 0.334f); // ~0.33333333333333337
@@ -30,14 +30,14 @@ int main() {
 
   // asinpi
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class asinpiF1>(
-            [=]() { AccR[0] = s::asinpi(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::asinpi(float{0.5}); });
       });
     }
     assert(r > 0.166f && r < 0.167f); // ~0.16666666666666669
@@ -45,14 +45,14 @@ int main() {
 
   // atan2
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class atan2F1F1>(
-            [=]() { AccR[0] = s::atan2(s::cl_float{0.5}, s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::atan2(float{0.5}, float{0.5}); });
       });
     }
     assert(r > 0.785f && r < 0.786f); // ~0.7853981633974483
@@ -60,14 +60,14 @@ int main() {
 
   // atanpi
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class atanpiF1>(
-            [=]() { AccR[0] = s::atanpi(s::cl_float{0.5}); });
+            [=]() { AccR[0] = s::atanpi(float{0.5}); });
       });
     }
     assert(r > 0.147f && r < 0.148f); // ~0.14758361765043326
@@ -75,14 +75,14 @@ int main() {
 
   // atan2pi
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class atan2piF1F1>([=]() {
-          AccR[0] = s::atan2pi(s::cl_float{0.5}, s::cl_float{0.5});
+          AccR[0] = s::atan2pi(float{0.5}, float{0.5});
         });
       });
     }
@@ -91,14 +91,14 @@ int main() {
 
   // copysign
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class copysignF1F1>([=]() {
-          AccR[0] = s::copysign(s::cl_float{1}, s::cl_float{-0.5});
+          AccR[0] = s::copysign(float{1}, float{-0.5});
         });
       });
     }
@@ -107,14 +107,14 @@ int main() {
 
   // fdim
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fdimF1F1>(
-            [=]() { AccR[0] = s::fdim(s::cl_float{1.6}, s::cl_float{0.6}); });
+            [=]() { AccR[0] = s::fdim(float{1.6}, float{0.6}); });
       });
     }
     assert(r == 1.0f);
@@ -122,15 +122,15 @@ int main() {
 
   // fma
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fmaF1F1F1>([=]() {
           AccR[0] =
-              s::fma(s::cl_float{0.5}, s::cl_float{10.0}, s::cl_float{3.0});
+              s::fma(float{0.5}, float{10.0}, float{3.0});
         });
       });
     }
@@ -139,19 +139,19 @@ int main() {
 
   // fract with global memory
   {
-    s::cl_float r{0};
-    s::cl_float i{999};
+    float r{0};
+    float i{999};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
-      s::buffer<s::cl_float, 1> BufI(&i, s::range<1>(1),
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufI(&i, s::range<1>(1),
                                      {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class fractF1GF1>([=]() {
-          s::global_ptr<s::cl_float> Iptr(AccI);
-          AccR[0] = s::fract(s::cl_float{1.5}, Iptr);
+          s::global_ptr<float> Iptr(AccI);
+          AccR[0] = s::fract(float{1.5}, Iptr);
         });
       });
     }
@@ -161,20 +161,20 @@ int main() {
 
   // fract with private memory
   {
-    s::cl_float r{0};
-    s::cl_float i{999};
+    float r{0};
+    float i{999};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
-      s::buffer<s::cl_float, 1> BufI(&i, s::range<1>(1),
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufI(&i, s::range<1>(1),
                                      {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class fractF1PF1>([=]() {
-          s::cl_float temp(0.0);
-          s::private_ptr<s::cl_float> Iptr(&temp);
-          AccR[0] = s::fract(s::cl_float{1.5f}, Iptr);
+          float temp(0.0);
+          s::private_ptr<float> Iptr(&temp);
+          AccR[0] = s::fract(float{1.5f}, Iptr);
           AccI[0] = *Iptr;
         });
       });
@@ -185,20 +185,20 @@ int main() {
 
   // lgamma_r with private memory
   {
-    s::cl_float r{0};
-    s::cl_int i{999};
+    float r{0};
+    int i{999};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
-      s::buffer<s::cl_int, 1> BufI(&i, s::range<1>(1),
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufI(&i, s::range<1>(1),
                                    {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class lgamma_rF1PI1>([=]() {
-          s::cl_int temp(0.0);
-          s::private_ptr<s::cl_int> Iptr(&temp);
-          AccR[0] = s::lgamma_r(s::cl_float{10.f}, Iptr);
+          int temp(0.0);
+          s::private_ptr<int> Iptr(&temp);
+          AccR[0] = s::lgamma_r(float{10.f}, Iptr);
           AccI[0] = *Iptr;
         });
       });
@@ -209,20 +209,20 @@ int main() {
 
   // lgamma_r with private memory
   {
-    s::cl_float r{0};
-    s::cl_int i{999};
+    float r{0};
+    int i{999};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
-      s::buffer<s::cl_int, 1> BufI(&i, s::range<1>(1),
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufI(&i, s::range<1>(1),
                                    {s::property::buffer::use_host_ptr()});
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class lgamma_rF1PI1_neg>([=]() {
-          s::cl_int temp(0.0);
-          s::private_ptr<s::cl_int> Iptr(&temp);
-          AccR[0] = s::lgamma_r(s::cl_float{-2.4f}, Iptr);
+          int temp(0.0);
+          s::private_ptr<int> Iptr(&temp);
+          AccR[0] = s::lgamma_r(float{-2.4f}, Iptr);
           AccI[0] = *Iptr;
         });
       });

--- a/SYCL/DeviceLib/built-ins/scalar_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_relational.cpp
@@ -15,13 +15,13 @@ int main() {
 
   // isequal-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isequalF1F1>([=]() {
-          AccR[0] = s::isequal(s::cl_float{10.5f}, s::cl_float{10.5f});
+          AccR[0] = s::isequal(float{10.5f}, float{10.5f});
         });
       });
     }
@@ -30,13 +30,13 @@ int main() {
 
   // isnotequal-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnotequalF1F1>([=]() {
-          AccR[0] = s::isnotequal(s::cl_float{0.4f}, s::cl_float{0.5f});
+          AccR[0] = s::isnotequal(float{0.4f}, float{0.5f});
         });
       });
     }
@@ -45,13 +45,13 @@ int main() {
 
   // isgreater-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isgreaterF1F1>([=]() {
-          AccR[0] = s::isgreater(s::cl_float{0.6f}, s::cl_float{0.5f});
+          AccR[0] = s::isgreater(float{0.6f}, float{0.5f});
         });
       });
     }
@@ -60,13 +60,13 @@ int main() {
 
   // isgreaterequal-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isgreaterequalF1F1>([=]() {
-          AccR[0] = s::isgreaterequal(s::cl_float{0.5f}, s::cl_float{0.5f});
+          AccR[0] = s::isgreaterequal(float{0.5f}, float{0.5f});
         });
       });
     }
@@ -75,13 +75,13 @@ int main() {
 
   // isless-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class islessF1F1>([=]() {
-          AccR[0] = s::isless(s::cl_float{0.4f}, s::cl_float{0.5f});
+          AccR[0] = s::isless(float{0.4f}, float{0.5f});
         });
       });
     }
@@ -90,13 +90,13 @@ int main() {
 
   // islessequal-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class islessequalF1F1>([=]() {
-          AccR[0] = s::islessequal(s::cl_float{0.5f}, s::cl_float{0.5f});
+          AccR[0] = s::islessequal(float{0.5f}, float{0.5f});
         });
       });
     }
@@ -105,13 +105,13 @@ int main() {
 
   // islessgreater-float
   {
-    s::cl_int r{1};
+    int r{1};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class islessgreaterF1F1>([=]() {
-          AccR[0] = s::islessgreater(s::cl_float{0.5f}, s::cl_float{0.5f});
+          AccR[0] = s::islessgreater(float{0.5f}, float{0.5f});
         });
       });
     }
@@ -120,13 +120,13 @@ int main() {
 
   // isfinite-float
   {
-    s::cl_int r{1};
+    int r{1};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isfiniteF1>(
-            [=]() { AccR[0] = s::isfinite(s::cl_float{NAN}); });
+            [=]() { AccR[0] = s::isfinite(float{NAN}); });
       });
     }
     assert(r == 0);
@@ -134,13 +134,13 @@ int main() {
 
   // isinf-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isinfF1>(
-            [=]() { AccR[0] = s::isinf(s::cl_float{INFINITY}); });
+            [=]() { AccR[0] = s::isinf(float{INFINITY}); });
       });
     }
     assert(r == 1);
@@ -148,13 +148,13 @@ int main() {
 
   // isnan-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnanF1>(
-            [=]() { AccR[0] = s::isnan(s::cl_float{NAN}); });
+            [=]() { AccR[0] = s::isnan(float{NAN}); });
       });
     }
     assert(r == 1);
@@ -162,13 +162,13 @@ int main() {
 
   // isnormal-float
   {
-    s::cl_int r{1};
+    int r{1};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnormalF1>(
-            [=]() { AccR[0] = s::isnormal(s::cl_float{INFINITY}); });
+            [=]() { AccR[0] = s::isnormal(float{INFINITY}); });
       });
     }
     assert(r == 0);
@@ -176,13 +176,13 @@ int main() {
 
   // isnormal-double
   if (myQueue.get_device().has(sycl::aspect::fp64)) {
-    s::cl_int r{1};
+    int r{1};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnormalD1>(
-            [=]() { AccR[0] = s::isnormal(s::cl_double{INFINITY}); });
+            [=]() { AccR[0] = s::isnormal(double{INFINITY}); });
       });
     }
     assert(r == 0);
@@ -190,13 +190,13 @@ int main() {
 
   // isordered-float
   {
-    s::cl_int r{1};
+    int r{1};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isorderedF1F1>([=]() {
-          AccR[0] = s::isordered(s::cl_float{4.0f}, s::cl_float{NAN});
+          AccR[0] = s::isordered(float{4.0f}, float{NAN});
         });
       });
     }
@@ -205,13 +205,13 @@ int main() {
 
   // isunordered-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isunorderedF1F1>([=]() {
-          AccR[0] = s::isunordered(s::cl_float{4.0f}, s::cl_float{NAN});
+          AccR[0] = s::isunordered(float{4.0f}, float{NAN});
         });
       });
     }
@@ -220,13 +220,13 @@ int main() {
 
   // signbit-float
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class signbitF1>(
-            [=]() { AccR[0] = s::signbit(s::cl_float{-12.0f}); });
+            [=]() { AccR[0] = s::signbit(float{-12.0f}); });
       });
     }
     assert(r == 1);
@@ -234,26 +234,26 @@ int main() {
 
   // any-integer
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class anyF1positive>(
-            [=]() { AccR[0] = s::any(s::cl_int{12}); });
+            [=]() { AccR[0] = s::any(int{12}); });
       });
     }
     assert(r == 0);
   }
   // any-integer
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class anyF1zero>(
-            [=]() { AccR[0] = s::any(s::cl_int{0}); });
+            [=]() { AccR[0] = s::any(int{0}); });
       });
     }
     assert(r == 0);
@@ -261,13 +261,13 @@ int main() {
 
   // any-integer
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class anyF1negative>(
-            [=]() { AccR[0] = s::any(s::cl_int{-12}); });
+            [=]() { AccR[0] = s::any(int{-12}); });
       });
     }
     assert(r == 1);
@@ -275,13 +275,13 @@ int main() {
 
   // all-integer
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class allF1positive>(
-            [=]() { AccR[0] = s::all(s::cl_int{12}); });
+            [=]() { AccR[0] = s::all(int{12}); });
       });
     }
     assert(r == 0);
@@ -289,13 +289,13 @@ int main() {
 
   // all-integer
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class allF1zero>(
-            [=]() { AccR[0] = s::all(s::cl_int{0}); });
+            [=]() { AccR[0] = s::all(int{0}); });
       });
     }
     assert(r == 0);
@@ -303,13 +303,13 @@ int main() {
 
   // all-integer
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class allF1negative>(
-            [=]() { AccR[0] = s::all(s::cl_int{-12}); });
+            [=]() { AccR[0] = s::all(int{-12}); });
       });
     }
     assert(r == 1);
@@ -317,14 +317,14 @@ int main() {
 
   // bitselect-float
   {
-    s::cl_float r{0.0f};
+    float r{0.0f};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class bitselectF1F1F1>([=]() {
-          AccR[0] = s::bitselect(s::cl_float{112.112}, s::cl_float{34.34},
-                                 s::cl_float{3.3});
+          AccR[0] = s::bitselect(float{112.112}, float{34.34},
+                                 float{3.3});
         });
       });
     }
@@ -333,14 +333,14 @@ int main() {
 
   // select-float,int
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1I1positive>([=]() {
           AccR[0] =
-              s::select(s::cl_float{34.34}, s::cl_float{123.123}, s::cl_int{1});
+              s::select(float{34.34}, float{123.123}, int{1});
         });
       });
     }
@@ -349,14 +349,14 @@ int main() {
 
   // select-float,int
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1I1zero>([=]() {
           AccR[0] =
-              s::select(s::cl_float{34.34}, s::cl_float{123.123}, s::cl_int{0});
+              s::select(float{34.34}, float{123.123}, int{0});
         });
       });
     }
@@ -365,14 +365,14 @@ int main() {
 
   // select-float,int
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1I1negative>([=]() {
-          AccR[0] = s::select(s::cl_float{34.34}, s::cl_float{123.123},
-                              s::cl_int{-1});
+          AccR[0] = s::select(float{34.34}, float{123.123},
+                              int{-1});
         });
       });
     }
@@ -381,14 +381,14 @@ int main() {
 
   // select-float,bool
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1B1true>([=]() {
-          AccR[0] = s::select(s::cl_float{34.34}, s::cl_float{123.123}, true);
+          AccR[0] = s::select(34.34f, 123.123f, true);
         });
       });
     }
@@ -397,14 +397,14 @@ int main() {
 
   // select-float,bool
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1B1false>([=]() {
-          AccR[0] = s::select(s::cl_float{34.34}, s::cl_float{123.123}, false);
+          AccR[0] = s::select(34.34f, 123.123f, false);
         });
       });
     }

--- a/SYCL/DeviceLib/built-ins/scalar_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/scalar_relational.cpp
@@ -20,9 +20,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class isequalF1F1>([=]() {
-          AccR[0] = s::isequal(float{10.5f}, float{10.5f});
-        });
+        cgh.single_task<class isequalF1F1>(
+            [=]() { AccR[0] = s::isequal(float{10.5f}, float{10.5f}); });
       });
     }
     assert(r == 1);
@@ -35,9 +34,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class isnotequalF1F1>([=]() {
-          AccR[0] = s::isnotequal(float{0.4f}, float{0.5f});
-        });
+        cgh.single_task<class isnotequalF1F1>(
+            [=]() { AccR[0] = s::isnotequal(float{0.4f}, float{0.5f}); });
       });
     }
     assert(r == 1);
@@ -50,9 +48,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class isgreaterF1F1>([=]() {
-          AccR[0] = s::isgreater(float{0.6f}, float{0.5f});
-        });
+        cgh.single_task<class isgreaterF1F1>(
+            [=]() { AccR[0] = s::isgreater(float{0.6f}, float{0.5f}); });
       });
     }
     assert(r == 1);
@@ -65,9 +62,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class isgreaterequalF1F1>([=]() {
-          AccR[0] = s::isgreaterequal(float{0.5f}, float{0.5f});
-        });
+        cgh.single_task<class isgreaterequalF1F1>(
+            [=]() { AccR[0] = s::isgreaterequal(float{0.5f}, float{0.5f}); });
       });
     }
     assert(r == 1);
@@ -80,9 +76,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class islessF1F1>([=]() {
-          AccR[0] = s::isless(float{0.4f}, float{0.5f});
-        });
+        cgh.single_task<class islessF1F1>(
+            [=]() { AccR[0] = s::isless(float{0.4f}, float{0.5f}); });
       });
     }
     assert(r == 1);
@@ -95,9 +90,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class islessequalF1F1>([=]() {
-          AccR[0] = s::islessequal(float{0.5f}, float{0.5f});
-        });
+        cgh.single_task<class islessequalF1F1>(
+            [=]() { AccR[0] = s::islessequal(float{0.5f}, float{0.5f}); });
       });
     }
     assert(r == 1);
@@ -110,9 +104,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class islessgreaterF1F1>([=]() {
-          AccR[0] = s::islessgreater(float{0.5f}, float{0.5f});
-        });
+        cgh.single_task<class islessgreaterF1F1>(
+            [=]() { AccR[0] = s::islessgreater(float{0.5f}, float{0.5f}); });
       });
     }
     assert(r == 0);
@@ -195,9 +188,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class isorderedF1F1>([=]() {
-          AccR[0] = s::isordered(float{4.0f}, float{NAN});
-        });
+        cgh.single_task<class isorderedF1F1>(
+            [=]() { AccR[0] = s::isordered(float{4.0f}, float{NAN}); });
       });
     }
     assert(r == 0);
@@ -210,9 +202,8 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class isunorderedF1F1>([=]() {
-          AccR[0] = s::isunordered(float{4.0f}, float{NAN});
-        });
+        cgh.single_task<class isunorderedF1F1>(
+            [=]() { AccR[0] = s::isunordered(float{4.0f}, float{NAN}); });
       });
     }
     assert(r == 1);
@@ -252,8 +243,7 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class anyF1zero>(
-            [=]() { AccR[0] = s::any(int{0}); });
+        cgh.single_task<class anyF1zero>([=]() { AccR[0] = s::any(int{0}); });
       });
     }
     assert(r == 0);
@@ -294,8 +284,7 @@ int main() {
       s::buffer<int, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class allF1zero>(
-            [=]() { AccR[0] = s::all(int{0}); });
+        cgh.single_task<class allF1zero>([=]() { AccR[0] = s::all(int{0}); });
       });
     }
     assert(r == 0);
@@ -323,8 +312,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class bitselectF1F1F1>([=]() {
-          AccR[0] = s::bitselect(float{112.112}, float{34.34},
-                                 float{3.3});
+          AccR[0] = s::bitselect(float{112.112}, float{34.34}, float{3.3});
         });
       });
     }
@@ -339,8 +327,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1I1positive>([=]() {
-          AccR[0] =
-              s::select(float{34.34}, float{123.123}, int{1});
+          AccR[0] = s::select(float{34.34}, float{123.123}, int{1});
         });
       });
     }
@@ -355,8 +342,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1I1zero>([=]() {
-          AccR[0] =
-              s::select(float{34.34}, float{123.123}, int{0});
+          AccR[0] = s::select(float{34.34}, float{123.123}, int{0});
         });
       });
     }
@@ -371,8 +357,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF1F1I1negative>([=]() {
-          AccR[0] = s::select(float{34.34}, float{123.123},
-                              int{-1});
+          AccR[0] = s::select(float{34.34}, float{123.123}, int{-1});
         });
       });
     }
@@ -387,9 +372,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class selectF1F1B1true>([=]() {
-          AccR[0] = s::select(34.34f, 123.123f, true);
-        });
+        cgh.single_task<class selectF1F1B1true>(
+            [=]() { AccR[0] = s::select(34.34f, 123.123f, true); });
       });
     }
     assert(r <= 123.124 && r >= 123.122); // r = 123.123
@@ -403,9 +387,8 @@ int main() {
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
-        cgh.single_task<class selectF1F1B1false>([=]() {
-          AccR[0] = s::select(34.34f, 123.123f, false);
-        });
+        cgh.single_task<class selectF1F1B1false>(
+            [=]() { AccR[0] = s::select(34.34f, 123.123f, false); });
       });
     }
     assert(r <= 34.35 && r >= 34.33); // r = 34.34

--- a/SYCL/DeviceLib/built-ins/vector_common.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_common.cpp
@@ -12,38 +12,38 @@ namespace s = sycl;
 int main() {
   // max
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxF2F2>([=]() {
-          AccR[0] = s::max(s::cl_float2{0.5f, 3.4f}, s::cl_float2{2.3f, 0.4f});
+          AccR[0] = s::max(s::float2{0.5f, 3.4f}, s::float2{2.3f, 0.4f});
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
     assert(r1 == 2.3f);
     assert(r2 == 3.4f);
   }
 
   // max
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxF2F1>([=]() {
-          AccR[0] = s::max(s::cl_float2{0.5f, 3.4f}, s::cl_float{3.0f});
+          AccR[0] = s::max(s::float2{0.5f, 3.4f}, float{3.0f});
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
     assert(r1 == 3.0f);
     assert(r2 == 3.4f);
   }

--- a/SYCL/DeviceLib/built-ins/vector_geometric.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_geometric.cpp
@@ -19,18 +19,18 @@ int main() {
 
   // dot
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class dotF2F2>([=]() {
           AccR[0] = s::dot(
-              s::cl_float2{
+              s::float2{
                   1.f,
                   2.f,
               },
-              s::cl_float2{4.f, 6.f});
+              s::float2{4.f, 6.f});
         });
       });
     }
@@ -39,20 +39,20 @@ int main() {
 
   // cross (float)
   {
-    s::cl_float4 r{0};
+    s::float4 r{0};
     {
-      s::buffer<s::cl_float4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float4, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class crossF4>([=]() {
           AccR[0] = s::cross(
-              s::cl_float4{
+              s::float4{
                   2.f,
                   3.f,
                   4.f,
                   0.f,
               },
-              s::cl_float4{
+              s::float4{
                   5.f,
                   6.f,
                   7.f,
@@ -62,10 +62,10 @@ int main() {
       });
     }
 
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
-    s::cl_float r3 = r.z();
-    s::cl_float r4 = r.w();
+    float r1 = r.x();
+    float r2 = r.y();
+    float r3 = r.z();
+    float r4 = r.w();
 
     assert(r1 == -3.f);
     assert(r2 == 6.f);
@@ -75,20 +75,20 @@ int main() {
 
   // cross (double)
   if (myQueue.get_device().has(sycl::aspect::fp64)) {
-    s::cl_double4 r{0};
+    s::double4 r{0};
     {
-      s::buffer<s::cl_double4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::double4, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class crossD4>([=]() {
           AccR[0] = s::cross(
-              s::cl_double4{
+              s::double4{
                   2.5,
                   3.0,
                   4.0,
                   0.0,
               },
-              s::cl_double4{
+              s::double4{
                   5.2,
                   6.0,
                   7.0,
@@ -98,10 +98,10 @@ int main() {
       });
     }
 
-    s::cl_double r1 = r.x();
-    s::cl_double r2 = r.y();
-    s::cl_double r3 = r.z();
-    s::cl_double r4 = r.w();
+    double r1 = r.x();
+    double r2 = r.y();
+    double r3 = r.z();
+    double r4 = r.w();
 
     assert(isEqualTo<double>(r1, -3.0));
     assert(isEqualTo<double>(r2, 3.3));
@@ -111,18 +111,18 @@ int main() {
 
   // distance
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class distanceF2>([=]() {
           AccR[0] = s::distance(
-              s::cl_float2{
+              s::float2{
                   1.f,
                   2.f,
               },
-              s::cl_float2{
+              s::float2{
                   3.f,
                   4.f,
               });
@@ -134,13 +134,13 @@ int main() {
 
   // length
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class lengthF2>([=]() {
-          AccR[0] = s::length(s::cl_float2{
+          AccR[0] = s::length(s::float2{
               1.f,
               2.f,
           });
@@ -152,21 +152,21 @@ int main() {
 
   // normalize
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class normalizeF2>([=]() {
-          AccR[0] = s::normalize(s::cl_float2{
+          AccR[0] = s::normalize(s::float2{
               1.f,
               2.f,
           });
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
 
     assert(isEqualTo<float>(r1, 0.447214f));
     assert(isEqualTo<float>(r2, 0.894427f));
@@ -174,18 +174,18 @@ int main() {
 
   // fast_distance
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fast_distanceF2>([=]() {
           AccR[0] = s::fast_distance(
-              s::cl_float2{
+              s::float2{
                   1.f,
                   2.f,
               },
-              s::cl_float2{
+              s::float2{
                   3.f,
                   4.f,
               });
@@ -197,13 +197,13 @@ int main() {
 
   // fast_length
   {
-    s::cl_float r{0};
+    float r{0};
     {
-      s::buffer<s::cl_float, 1> BufR(&r, s::range<1>(1));
+      s::buffer<float, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fast_lengthF2>([=]() {
-          AccR[0] = s::fast_length(s::cl_float2{
+          AccR[0] = s::fast_length(s::float2{
               1.f,
               2.f,
           });
@@ -215,21 +215,21 @@ int main() {
 
   // fast_normalize
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fast_normalizeF2>([=]() {
-          AccR[0] = s::fast_normalize(s::cl_float2{
+          AccR[0] = s::fast_normalize(s::float2{
               1.f,
               2.f,
           });
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
 
     assert(isEqualTo<float>(r1, 0.447144));
     assert(isEqualTo<float>(r2, 0.894287));

--- a/SYCL/DeviceLib/built-ins/vector_integer.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_integer.cpp
@@ -13,57 +13,57 @@ namespace s = sycl;
 int main() {
   // max
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxSI2SI2>([=]() {
-          AccR[0] = s::max(s::cl_int2{5, 3}, s::cl_int2{2, 7});
+          AccR[0] = s::max(s::int2{5, 3}, s::int2{2, 7});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 7);
   }
 
   // max
   {
-    s::cl_uint2 r{0};
+    s::uint2 r{0};
     {
-      s::buffer<s::cl_uint2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::uint2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxUI2UI2>([=]() {
-          AccR[0] = s::max(s::cl_uint2{5, 3}, s::cl_uint2{2, 7});
+          AccR[0] = s::max(s::uint2{5, 3}, s::uint2{2, 7});
         });
       });
     }
-    s::cl_uint r1 = r.x();
-    s::cl_uint r2 = r.y();
+    unsigned int r1 = r.x();
+    unsigned int r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 7);
   }
 
   // max
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxSI2SI1>([=]() {
-          AccR[0] = s::max(s::cl_int2{5, 3}, s::cl_int{2});
+          AccR[0] = s::max(s::int2{5, 3}, int{2});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 3);
   }
@@ -78,31 +78,31 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxSLL2SLL1>([=]() {
-          AccR[0] = s::max(longlong2{5, 3}, s::longlong{2});
+          AccR[0] = s::max(longlong2{5, 3}, 2ll);
         });
       });
     }
-    s::longlong r1 = r.x();
-    s::longlong r2 = r.y();
+    long long r1 = r.x();
+    long long r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 3);
   }
 
   // max
   {
-    s::cl_uint2 r{0};
+    s::uint2 r{0};
     {
-      s::buffer<s::cl_uint2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::uint2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxUI2UI1>([=]() {
-          AccR[0] = s::max(s::cl_uint2{5, 3}, s::cl_uint{2});
+          AccR[0] = s::max(s::uint2{5, 3}, 2u);
         });
       });
     }
-    s::cl_uint r1 = r.x();
-    s::cl_uint r2 = r.y();
+    unsigned int r1 = r.x();
+    unsigned int r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 3);
   }
@@ -117,107 +117,107 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class maxULL2ULL1>([=]() {
-          AccR[0] = s::max(ulonglong2{5, 3}, s::ulonglong{2});
+          AccR[0] = s::max(ulonglong2{5, 3}, 2ull);
         });
       });
     }
-    s::ulonglong r1 = r.x();
-    s::ulonglong r2 = r.y();
+    unsigned long long r1 = r.x();
+    unsigned long long r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 3);
   }
 
   // min
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minSI2SI2>([=]() {
-          AccR[0] = s::min(s::cl_int2{5, 3}, s::cl_int2{2, 7});
+          AccR[0] = s::min(s::int2{5, 3}, s::int2{2, 7});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 2);
     assert(r2 == 3);
   }
 
   // min
   {
-    s::cl_uint2 r{0};
+    s::uint2 r{0};
     {
-      s::buffer<s::cl_uint2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::uint2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minUI2UI2>([=]() {
-          AccR[0] = s::min(s::cl_uint2{5, 3}, s::cl_uint2{2, 7});
+          AccR[0] = s::min(s::uint2{5, 3}, s::uint2{2, 7});
         });
       });
     }
-    s::cl_uint r1 = r.x();
-    s::cl_uint r2 = r.y();
+    unsigned int r1 = r.x();
+    unsigned int r2 = r.y();
     assert(r1 == 2);
     assert(r2 == 3);
   }
 
   // min
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minSI2SI1>([=]() {
-          AccR[0] = s::min(s::cl_int2{5, 3}, s::cl_int{2});
+          AccR[0] = s::min(s::int2{5, 3}, int{2});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 2);
     assert(r2 == 2);
   }
 
   // min
   {
-    s::cl_uint2 r{0};
+    s::uint2 r{0};
     {
-      s::buffer<s::cl_uint2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::uint2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class minUI2UI1>([=]() {
-          AccR[0] = s::min(s::cl_uint2{5, 3}, s::cl_uint{2});
+          AccR[0] = s::min(s::uint2{5, 3}, 2u);
         });
       });
     }
-    s::cl_uint r1 = r.x();
-    s::cl_uint r2 = r.y();
+    unsigned int r1 = r.x();
+    unsigned int r2 = r.y();
     assert(r1 == 2);
     assert(r2 == 2);
   }
 
   // abs
   {
-    s::cl_uint2 r{0};
+    s::uint2 r{0};
     {
-      s::buffer<s::cl_uint2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::uint2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class absSI2>([=]() {
-          AccR[0] = s::abs(s::cl_int2{-5, -2});
+          AccR[0] = s::abs(s::int2{-5, -2});
         });
       });
     }
-    s::cl_uint r1 = r.x();
-    s::cl_uint r2 = r.y();
+    unsigned int r1 = r.x();
+    unsigned int r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 2);
   }
@@ -237,256 +237,252 @@ int main() {
         });
       });
     }
-    s::ulonglong r1 = r.x();
-    s::ulonglong r2 = r.y();
+    unsigned long long r1 = r.x();
+    unsigned long long r2 = r.y();
     assert(r1 == 5);
     assert(r2 == 2);
   }
 
   // abs_diff
   {
-    s::cl_uint2 r{0};
+    s::uint2 r{0};
     {
-      s::buffer<s::cl_uint2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::uint2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class abs_diffSI2SI2>([=]() {
-          AccR[0] = s::abs_diff(s::cl_int2{-5, -2}, s::cl_int2{-1, -1});
+          AccR[0] = s::abs_diff(s::int2{-5, -2}, s::int2{-1, -1});
         });
       });
     }
-    s::cl_uint r1 = r.x();
-    s::cl_uint r2 = r.y();
+    unsigned int r1 = r.x();
+    unsigned int r2 = r.y();
     assert(r1 == 4);
     assert(r2 == 1);
   }
 
   // add_sat
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class add_satSI2SI2>([=]() {
-          AccR[0] = s::add_sat(s::cl_int2{0x7FFFFFFF, 0x7FFFFFFF},
-                               s::cl_int2{100, 90});
+          AccR[0] =
+              s::add_sat(s::int2{0x7FFFFFFF, 0x7FFFFFFF}, s::int2{100, 90});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x7FFFFFFF);
     assert(r2 == 0x7FFFFFFF);
   }
 
   // hadd
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class haddSI2SI2>([=]() {
-          AccR[0] = s::hadd(s::cl_int2{0x0000007F, 0x0000007F},
-                            s::cl_int2{0x00000020, 0x00000020});
+          AccR[0] = s::hadd(s::int2{0x0000007F, 0x0000007F},
+                            s::int2{0x00000020, 0x00000020});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x0000004F);
     assert(r2 == 0x0000004F);
   }
 
   // rhadd
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class rhaddSI2SI2>([=]() {
-          AccR[0] = s::rhadd(s::cl_int2{0x0000007F, 0x0000007F},
-                             s::cl_int2{0x00000020, 0x00000020});
+          AccR[0] = s::rhadd(s::int2{0x0000007F, 0x0000007F},
+                             s::int2{0x00000020, 0x00000020});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x00000050);
     assert(r2 == 0x00000050);
   }
 
   // clamp - 1
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class clampSI2SI2SI2>([=]() {
-          AccR[0] = s::clamp(s::cl_int2{5, 5}, s::cl_int2{10, 10},
-                             s::cl_int2{30, 30});
+          AccR[0] = s::clamp(s::int2{5, 5}, s::int2{10, 10}, s::int2{30, 30});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 10);
     assert(r2 == 10);
   }
 
   // clamp - 2
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class clampSI2SI1SI1>([=]() {
-          AccR[0] = s::clamp(s::cl_int2{5, 5}, s::cl_int{10}, s::cl_int{30});
+          AccR[0] = s::clamp(s::int2{5, 5}, int{10}, int{30});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 10);
     assert(r2 == 10);
   }
 
   // clz
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class clzSI2>([=]() {
-          AccR[0] = s::clz(s::cl_int2{0x0FFFFFFF, 0x0FFFFFFF});
+          AccR[0] = s::clz(s::int2{0x0FFFFFFF, 0x0FFFFFFF});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 4);
     assert(r2 == 4);
   }
 
   // ctz
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class ctzSI2>([=]() {
-          AccR[0] = s::intel::ctz(s::cl_int2{0x7FFFFFF0, 0x7FFFFFF0});
+          AccR[0] = s::intel::ctz(s::int2{0x7FFFFFF0, 0x7FFFFFF0});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 4);
     assert(r2 == 4);
   }
 
   // mad_hi
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad_hiSI2SI2SI2>([=]() {
-          AccR[0] =
-              s::mad_hi(s::cl_int2{0x10000000, 0x10000000},
-                        s::cl_int2{0x00000100, 0x00000100}, s::cl_int2{1, 1});
+          AccR[0] = s::mad_hi(s::int2{0x10000000, 0x10000000},
+                              s::int2{0x00000100, 0x00000100}, s::int2{1, 1});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x11);
     assert(r2 == 0x11);
   }
 
   // mad_sat
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad_satSI2SI2SI2>([=]() {
-          AccR[0] =
-              s::mad_sat(s::cl_int2{0x10000000, 0x10000000},
-                         s::cl_int2{0x00000100, 0x00000100}, s::cl_int2{1, 1});
+          AccR[0] = s::mad_sat(s::int2{0x10000000, 0x10000000},
+                               s::int2{0x00000100, 0x00000100}, s::int2{1, 1});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x7FFFFFFF);
     assert(r2 == 0x7FFFFFFF);
   }
 
   // mul_hi
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mul_hiSI2SI2>([=]() {
-          AccR[0] = s::mul_hi(s::cl_int2{0x10000000, 0x10000000},
-                              s::cl_int2{0x00000100, 0x00000100});
+          AccR[0] = s::mul_hi(s::int2{0x10000000, 0x10000000},
+                              s::int2{0x00000100, 0x00000100});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x10);
     assert(r2 == 0x10);
   }
 
   // rotate
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class rotateSI2SI2>([=]() {
-          AccR[0] =
-              s::rotate(s::cl_int2{0x11100000, 0x11100000}, s::cl_int2{12, 12});
+          AccR[0] = s::rotate(s::int2{0x11100000, 0x11100000}, s::int2{12, 12});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x00000111);
     assert(r2 == 0x00000111);
   }
 
   // sub_sat
   {
-    auto TestSubSat = [](s::cl_int2 x, s::cl_int2 y) {
-      s::cl_int2 r{0};
+    auto TestSubSat = [](s::int2 x, s::int2 y) {
+      s::int2 r{0};
       {
-        s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+        s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
         s::queue myQueue;
         myQueue.submit([&](s::handler &cgh) {
           auto AccR = BufR.get_access<s::access::mode::write>(cgh);
@@ -496,201 +492,198 @@ int main() {
       }
       return r;
     };
-    s::cl_int2 r1 =
-        TestSubSat(s::cl_int2{10, 10}, s::cl_int2{0x80000000, 0x80000000});
-    s::cl_int r1x = r1.x();
-    s::cl_int r1y = r1.y();
+    s::int2 r1 = TestSubSat(s::int2{10, 10}, s::int2{0x80000000, 0x80000000});
+    int r1x = r1.x();
+    int r1y = r1.y();
     assert(r1x == 0x7FFFFFFF);
     assert(r1y == 0x7FFFFFFF);
-    s::cl_int2 r2 = TestSubSat(s::cl_int2{0x7FFFFFFF, 0x80000000},
-                               s::cl_int2{0xFFFFFFFF, 0x00000001});
-    s::cl_int r2x = r2.x();
-    s::cl_int r2y = r2.y();
+    s::int2 r2 = TestSubSat(s::int2{0x7FFFFFFF, 0x80000000},
+                            s::int2{0xFFFFFFFF, 0x00000001});
+    int r2x = r2.x();
+    int r2y = r2.y();
     assert(r2x == 0x7FFFFFFF);
     assert(r2y == 0x80000000);
-    s::cl_int2 r3 =
-        TestSubSat(s::cl_int2{10499, 30678}, s::cl_int2{30678, 10499});
-    s::cl_int r3x = r3.x();
-    s::cl_int r3y = r3.y();
+    s::int2 r3 = TestSubSat(s::int2{10499, 30678}, s::int2{30678, 10499});
+    int r3x = r3.x();
+    int r3y = r3.y();
     assert(r3x == -20179);
     assert(r3y == 20179);
   }
 
   // upsample - 1
   {
-    s::cl_ushort2 r{0};
+    s::ushort2 r{0};
     {
-      s::buffer<s::cl_ushort2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::ushort2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleUC2UC2>([=]() {
           AccR[0] =
-              s::upsample(s::cl_uchar2{0x10, 0x10}, s::cl_uchar2{0x10, 0x10});
+              s::upsample(s::uchar2{0x10, 0x10}, s::uchar2{0x10, 0x10});
         });
       });
     }
-    s::cl_ushort r1 = r.x();
-    s::cl_ushort r2 = r.y();
+    unsigned short r1 = r.x();
+    unsigned short r2 = r.y();
     assert(r1 == 0x1010);
     assert(r2 == 0x1010);
   }
 
   // upsample - 2
   {
-    s::cl_short2 r{0};
+    s::short2 r{0};
     {
-      s::buffer<s::cl_short2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::short2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleSC2UC2>([=]() {
           AccR[0] =
-              s::upsample(s::cl_char2{0x10, 0x10}, s::cl_uchar2{0x10, 0x10});
+              s::upsample(s::char2{0x10, 0x10}, s::uchar2{0x10, 0x10});
         });
       });
     }
-    s::cl_short r1 = r.x();
-    s::cl_short r2 = r.y();
+    short r1 = r.x();
+    short r2 = r.y();
     assert(r1 == 0x1010);
     assert(r2 == 0x1010);
   }
 
   // upsample - 3
   {
-    s::cl_uint2 r{0};
+    s::uint2 r{0};
     {
-      s::buffer<s::cl_uint2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::uint2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleUS2US2>([=]() {
-          AccR[0] = s::upsample(s::cl_ushort2{0x0010, 0x0010},
-                                s::cl_ushort2{0x0010, 0x0010});
+          AccR[0] = s::upsample(s::ushort2{0x0010, 0x0010},
+                                s::ushort2{0x0010, 0x0010});
         });
       });
     }
-    s::cl_uint r1 = r.x();
-    s::cl_uint r2 = r.y();
+    unsigned int r1 = r.x();
+    unsigned int r2 = r.y();
     assert(r1 == 0x00100010);
     assert(r2 == 0x00100010);
   }
 
   // upsample - 4
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleSS2US2>([=]() {
-          AccR[0] = s::upsample(s::cl_short2{0x0010, 0x0010},
-                                s::cl_ushort2{0x0010, 0x0010});
+          AccR[0] = s::upsample(s::short2{0x0010, 0x0010},
+                                s::ushort2{0x0010, 0x0010});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0x00100010);
     assert(r2 == 0x00100010);
   }
 
   // upsample - 5
   {
-    s::cl_ulong2 r{0};
+    s::ulong2 r{0};
     {
-      s::buffer<s::cl_ulong2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::ulong2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleUI2UI2>([=]() {
-          AccR[0] = s::upsample(s::cl_uint2{0x00000010, 0x00000010},
-                                s::cl_uint2{0x00000010, 0x00000010});
+          AccR[0] = s::upsample(s::uint2{0x00000010, 0x00000010},
+                                s::uint2{0x00000010, 0x00000010});
         });
       });
     }
-    s::cl_ulong r1 = r.x();
-    s::cl_ulong r2 = r.y();
+    unsigned long long r1 = r.x();
+    unsigned long long r2 = r.y();
     assert(r1 == 0x0000001000000010);
     assert(r2 == 0x0000001000000010);
   }
 
   // upsample - 6
   {
-    s::cl_long2 r{0};
+    s::long2 r{0};
     {
-      s::buffer<s::cl_long2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::long2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleSI2UI2>([=]() {
-          AccR[0] = s::upsample(s::cl_int2{0x00000010, 0x00000010},
-                                s::cl_uint2{0x00000010, 0x00000010});
+          AccR[0] = s::upsample(s::int2{0x00000010, 0x00000010},
+                                s::uint2{0x00000010, 0x00000010});
         });
       });
     }
-    s::cl_long r1 = r.x();
-    s::cl_long r2 = r.y();
+    long long r1 = r.x();
+    long long r2 = r.y();
     assert(r1 == 0x0000001000000010);
     assert(r2 == 0x0000001000000010);
   }
 
   // popcount
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class popcountSI2>([=]() {
-          AccR[0] = s::popcount(s::cl_int2{0x000000FF, 0x000000FF});
+          AccR[0] = s::popcount(s::int2{0x000000FF, 0x000000FF});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 8);
     assert(r2 == 8);
   }
 
   // mad24
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mad24SI2SI2SI2>([=]() {
-          AccR[0] = s::mad24(s::cl_int2{0xFFFFFFFF, 0xFFFFFFFF},
-                             s::cl_int2{20, 20}, s::cl_int2{20, 20});
+          AccR[0] = s::mad24(s::int2{0xFFFFFFFF, 0xFFFFFFFF}, s::int2{20, 20},
+                             s::int2{20, 20});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == 0);
     assert(r2 == 0);
   }
 
   // mul24
   {
-    s::cl_int2 r{0};
+    s::int2 r{0};
     {
-      s::buffer<s::cl_int2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class mul24SI2SI2SI2>([=]() {
-          AccR[0] =
-              s::mul24(s::cl_int2{0xFFFFFFFF, 0xFFFFFFFF}, s::cl_int2{20, 20});
+          AccR[0] = s::mul24(s::int2{0xFFFFFFFF, 0xFFFFFFFF}, s::int2{20, 20});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
+    int r1 = r.x();
+    int r2 = r.y();
     assert(r1 == -20);
     assert(r2 == -20);
   }

--- a/SYCL/DeviceLib/built-ins/vector_integer.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_integer.cpp
@@ -519,8 +519,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleUC2UC2>([=]() {
-          AccR[0] =
-              s::upsample(s::uchar2{0x10, 0x10}, s::uchar2{0x10, 0x10});
+          AccR[0] = s::upsample(s::uchar2{0x10, 0x10}, s::uchar2{0x10, 0x10});
         });
       });
     }
@@ -539,8 +538,7 @@ int main() {
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class upsampleSC2UC2>([=]() {
-          AccR[0] =
-              s::upsample(s::char2{0x10, 0x10}, s::uchar2{0x10, 0x10});
+          AccR[0] = s::upsample(s::char2{0x10, 0x10}, s::uchar2{0x10, 0x10});
         });
       });
     }

--- a/SYCL/DeviceLib/built-ins/vector_math.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_math.cpp
@@ -14,103 +14,103 @@ namespace s = sycl;
 int main() {
   // fmin
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fminF2F2>([=]() {
-          AccR[0] = s::fmin(s::cl_float2{0.5f, 3.4f}, s::cl_float2{2.3f, 0.4f});
+          AccR[0] = s::fmin(s::float2{0.5f, 3.4f}, s::float2{2.3f, 0.4f});
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
     assert(r1 == 0.5f);
     assert(r2 == 0.4f);
   }
 
   // fabs
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class fabsF2>([=]() {
-          AccR[0] = s::fabs(s::cl_float2{-1.0f, 2.0f});
+          AccR[0] = s::fabs(s::float2{-1.0f, 2.0f});
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
     assert(r1 == 1.0f);
     assert(r2 == 2.0f);
   }
 
   // floor
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class floorF2>([=]() {
-          AccR[0] = s::floor(s::cl_float2{1.4f, 2.8f});
+          AccR[0] = s::floor(s::float2{1.4f, 2.8f});
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
     assert(r1 == 1.0f);
     assert(r2 == 2.0f);
   }
 
   // ceil
   {
-    s::cl_float2 r{0};
+    s::float2 r{0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class ceilF2>([=]() {
-          AccR[0] = s::ceil(s::cl_float2{1.4f, 2.8f});
+          AccR[0] = s::ceil(s::float2{1.4f, 2.8f});
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
     assert(r1 == 2);
     assert(r2 == 3);
   }
 
   // fract with global memory
   {
-    s::cl_float2 r{0, 0};
-    s::cl_float2 i{0, 0};
+    s::float2 r{0, 0};
+    s::float2 i{0, 0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
-      s::buffer<s::cl_float2, 1> BufI(&i, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufI(&i, s::range<1>(1));
 
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class fractF2GF2>([=]() {
-          s::global_ptr<s::cl_float2> Iptr(AccI);
-          AccR[0] = s::fract(s::cl_float2{1.5f, 2.5f}, Iptr);
+          s::global_ptr<s::float2> Iptr(AccI);
+          AccR[0] = s::fract(s::float2{1.5f, 2.5f}, Iptr);
         });
       });
     }
 
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
-    s::cl_float i1 = i.x();
-    s::cl_float i2 = i.y();
+    float r1 = r.x();
+    float r2 = r.y();
+    float i1 = i.x();
+    float i2 = i.y();
 
     assert(r1 == 0.5f);
     assert(r2 == 0.5f);
@@ -120,28 +120,28 @@ int main() {
 
   // fract with private memory
   {
-    s::cl_float2 r{0, 0};
-    s::cl_float2 i{0, 0};
+    s::float2 r{0, 0};
+    s::float2 i{0, 0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
-      s::buffer<s::cl_float2, 1> BufI(&i, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufI(&i, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class fractF2PF2>([=]() {
-          s::cl_float2 temp(0.0);
-          s::private_ptr<s::cl_float2> Iptr(&temp);
-          AccR[0] = s::fract(s::cl_float2{1.5f, 2.5f}, Iptr);
+          s::float2 temp(0.0);
+          s::private_ptr<s::float2> Iptr(&temp);
+          AccR[0] = s::fract(s::float2{1.5f, 2.5f}, Iptr);
           AccI[0] = *Iptr;
         });
       });
     }
 
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
-    s::cl_float i1 = i.x();
-    s::cl_float i2 = i.y();
+    float r1 = r.x();
+    float r2 = r.y();
+    float i1 = i.x();
+    float i2 = i.y();
 
     assert(r1 == 0.5f);
     assert(r2 == 0.5f);
@@ -151,20 +151,20 @@ int main() {
 
   // lgamma with private memory
   {
-    s::cl_float2 r{0, 0};
+    s::float2 r{0, 0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class lgamma_rF2>([=]() {
-          AccR[0] = s::lgamma(s::cl_float2{10.f, -2.4f});
+          AccR[0] = s::lgamma(s::float2{10.f, -2.4f});
         });
       });
     }
 
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
+    float r1 = r.x();
+    float r2 = r.y();
 
     assert(r1 > 12.8017f && r1 < 12.8019f); // ~12.8018
     assert(r2 > 0.1024f && r2 < 0.1026f);   // ~0.102583
@@ -172,28 +172,28 @@ int main() {
 
   // lgamma_r with private memory
   {
-    s::cl_float2 r{0, 0};
-    s::cl_int2 i{0, 0};
+    s::float2 r{0, 0};
+    s::int2 i{0, 0};
     {
-      s::buffer<s::cl_float2, 1> BufR(&r, s::range<1>(1));
-      s::buffer<s::cl_int2, 1> BufI(&i, s::range<1>(1));
+      s::buffer<s::float2, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int2, 1> BufI(&i, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::read_write>(cgh);
         auto AccI = BufI.get_access<s::access::mode::read_write>(cgh);
         cgh.single_task<class lgamma_rF2PF2>([=]() {
-          s::cl_int2 temp(0.0);
-          s::private_ptr<s::cl_int2> Iptr(&temp);
-          AccR[0] = s::lgamma_r(s::cl_float2{10.f, -2.4f}, Iptr);
+          s::int2 temp(0.0);
+          s::private_ptr<s::int2> Iptr(&temp);
+          AccR[0] = s::lgamma_r(s::float2{10.f, -2.4f}, Iptr);
           AccI[0] = *Iptr;
         });
       });
     }
 
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
-    s::cl_int i1 = i.x();
-    s::cl_int i2 = i.y();
+    float r1 = r.x();
+    float r2 = r.y();
+    int i1 = i.x();
+    int i2 = i.y();
 
     assert(r1 > 12.8017f && r1 < 12.8019f); // ~12.8018
     assert(r2 > 0.1024f && r2 < 0.1026f);   // ~0.102583

--- a/SYCL/DeviceLib/built-ins/vector_relational.cpp
+++ b/SYCL/DeviceLib/built-ins/vector_relational.cpp
@@ -16,22 +16,22 @@ namespace s = sycl;
 int main() {
   // isequal
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isequalF4F4>([=]() {
-          AccR[0] = s::isequal(s::cl_float4{0.5f, 0.6f, NAN, INFINITY},
-                               s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::isequal(s::float4{0.5f, 0.6f, NAN, INFINITY},
+                               s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == -1);
     assert(r2 == 0);
@@ -41,22 +41,22 @@ int main() {
 
   // isnotequal
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnotequalF4F4>([=]() {
-          AccR[0] = s::isnotequal(s::cl_float4{0.5f, 0.6f, NAN, INFINITY},
-                                  s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::isnotequal(s::float4{0.5f, 0.6f, NAN, INFINITY},
+                                  s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == 0);
     assert(r2 == -1);
@@ -66,22 +66,22 @@ int main() {
 
   // isgreater
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isgreaterF4F4>([=]() {
-          AccR[0] = s::isgreater(s::cl_float4{0.5f, 0.6f, NAN, INFINITY},
-                                 s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::isgreater(s::float4{0.5f, 0.6f, NAN, INFINITY},
+                                 s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == 0);
     assert(r2 == -1);
@@ -91,22 +91,22 @@ int main() {
 
   // isgreaterequal
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isgreaterequalF4F4>([=]() {
-          AccR[0] = s::isgreaterequal(s::cl_float4{0.5f, 0.6f, NAN, INFINITY},
-                                      s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::isgreaterequal(s::float4{0.5f, 0.6f, NAN, INFINITY},
+                                      s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == -1);
     assert(r2 == -1);
@@ -116,22 +116,22 @@ int main() {
 
   // isless
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class islessF4F4>([=]() {
-          AccR[0] = s::isless(s::cl_float4{0.5f, 0.4f, NAN, INFINITY},
-                              s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::isless(s::float4{0.5f, 0.4f, NAN, INFINITY},
+                              s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == 0);
     assert(r2 == -1);
@@ -141,22 +141,22 @@ int main() {
 
   // islessequal
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class islessequalF4F4>([=]() {
-          AccR[0] = s::islessequal(s::cl_float4{0.5f, 0.4f, NAN, INFINITY},
-                                   s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::islessequal(s::float4{0.5f, 0.4f, NAN, INFINITY},
+                                   s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == -1);
     assert(r2 == -1);
@@ -166,22 +166,22 @@ int main() {
 
   // islessgreater
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class islessgreaterF4F4>([=]() {
-          AccR[0] = s::islessgreater(s::cl_float4{0.5f, 0.4f, NAN, INFINITY},
-                                     s::cl_float4{0.5f, 0.5f, 0.5f, INFINITY});
+          AccR[0] = s::islessgreater(s::float4{0.5f, 0.4f, NAN, INFINITY},
+                                     s::float4{0.5f, 0.5f, 0.5f, INFINITY});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == 0);
     assert(r2 == -1);
@@ -192,21 +192,21 @@ int main() {
 
   // isfinite
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isfiniteF4F4>([=]() {
-          AccR[0] = s::isfinite(s::cl_float4{0.5f, 0.4f, NAN, INFINITY});
+          AccR[0] = s::isfinite(s::float4{0.5f, 0.4f, NAN, INFINITY});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == -1);
     assert(r2 == -1);
@@ -216,21 +216,21 @@ int main() {
 
   // isinf
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isinfF4F4>([=]() {
-          AccR[0] = s::isinf(s::cl_float4{0.5f, 0.4f, NAN, INFINITY});
+          AccR[0] = s::isinf(s::float4{0.5f, 0.4f, NAN, INFINITY});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == 0);
     assert(r2 == 0);
@@ -240,21 +240,21 @@ int main() {
 
   // isnan
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnanF4F4>([=]() {
-          AccR[0] = s::isnan(s::cl_float4{0.5f, 0.4f, NAN, INFINITY});
+          AccR[0] = s::isnan(s::float4{0.5f, 0.4f, NAN, INFINITY});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == 0);
     assert(r2 == 0);
@@ -264,21 +264,21 @@ int main() {
 
   // isnormal
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnormalF4F4>([=]() {
-          AccR[0] = s::isnormal(s::cl_float4{0.5f, 0.4f, NAN, INFINITY});
+          AccR[0] = s::isnormal(s::float4{0.5f, 0.4f, NAN, INFINITY});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == -1);
     assert(r2 == -1);
@@ -288,22 +288,22 @@ int main() {
 
   // isordered
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isorderedF4F4>([=]() {
-          AccR[0] = s::isordered(s::cl_float4{0.5f, 0.6f, NAN, INFINITY},
-                                 s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::isordered(s::float4{0.5f, 0.6f, NAN, INFINITY},
+                                 s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == -1);
     assert(r2 == -1);
@@ -313,22 +313,22 @@ int main() {
 
   // isunordered
   {
-    s::cl_int4 r{0};
+    s::int4 r{0};
     {
-      s::buffer<s::cl_int4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isunorderedF4F4>([=]() {
-          AccR[0] = s::isunordered(s::cl_float4{0.5f, 0.6f, NAN, INFINITY},
-                                   s::cl_float4{0.5f, 0.5f, 0.5f, 0.5f});
+          AccR[0] = s::isunordered(s::float4{0.5f, 0.6f, NAN, INFINITY},
+                                   s::float4{0.5f, 0.5f, 0.5f, 0.5f});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
-    s::cl_int r4 = r.w();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
+    int r4 = r.w();
 
     assert(r1 == 0);
     assert(r2 == 0);
@@ -338,20 +338,20 @@ int main() {
 
   // signbit
   {
-    s::cl_int3 r{0};
+    s::int3 r{0};
     {
-      s::buffer<s::cl_int3, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::int3, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class signbitF3>([=]() {
-          AccR[0] = s::signbit(s::cl_float3{0.5f, -12.0f, INFINITY});
+          AccR[0] = s::signbit(s::float3{0.5f, -12.0f, INFINITY});
         });
       });
     }
-    s::cl_int r1 = r.x();
-    s::cl_int r2 = r.y();
-    s::cl_int r3 = r.z();
+    int r1 = r.x();
+    int r2 = r.y();
+    int r3 = r.z();
 
     assert(r1 == 0);
     assert(r2 == -1);
@@ -361,18 +361,18 @@ int main() {
   // any.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class anyI4>([=]() {
-          AccR[0] = s::any(s::cl_int4{-12, -12, 0, 1});
+          AccR[0] = s::any(s::int4{-12, -12, 0, 1});
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 1);
   }
@@ -380,18 +380,18 @@ int main() {
   // any.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class anyI4negative>([=]() {
-          AccR[0] = s::any(s::cl_int4{-12, -12, -12, -12});
+          AccR[0] = s::any(s::int4{-12, -12, -12, -12});
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 1);
   }
@@ -399,18 +399,18 @@ int main() {
   // any.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class anyI4zero>([=]() {
-          AccR[0] = s::any(s::cl_int4{0, 0, 0, 0});
+          AccR[0] = s::any(s::int4{0, 0, 0, 0});
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 0);
   }
@@ -418,18 +418,18 @@ int main() {
   // any.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class anyI4positive>([=]() {
-          AccR[0] = s::any(s::cl_int4{12, 12, 12, 12});
+          AccR[0] = s::any(s::int4{12, 12, 12, 12});
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 0);
   }
@@ -437,21 +437,21 @@ int main() {
   // all.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class allI4>([=]() {
-          AccR[0] = s::all(s::cl_int4{-12, -12, -12, -12});
+          AccR[0] = s::all(s::int4{-12, -12, -12, -12});
           // Infinity (positive or negative) or Nan are not integers.
           // Passing them creates inconsistent results between host and device
           // execution.
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 1);
   }
@@ -459,18 +459,18 @@ int main() {
   // all.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class allI4negative>([=]() {
-          AccR[0] = s::all(s::cl_int4{-12, -12, -12, -12});
+          AccR[0] = s::all(s::int4{-12, -12, -12, -12});
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 1);
   }
@@ -478,18 +478,18 @@ int main() {
   // all.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class allI4zero>([=]() {
-          AccR[0] = s::all(s::cl_int4{0, 0, 0, 0});
+          AccR[0] = s::all(s::int4{0, 0, 0, 0});
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 0);
   }
@@ -497,42 +497,42 @@ int main() {
   // all.
   // Call to the device function with vector parameters work. Scalars do not.
   {
-    s::cl_int r{0};
+    int r{0};
     {
-      s::buffer<s::cl_int, 1> BufR(&r, s::range<1>(1));
+      s::buffer<int, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class allI4positive>([=]() {
-          AccR[0] = s::all(s::cl_int4{12, 12, 12, 12});
+          AccR[0] = s::all(s::int4{12, 12, 12, 12});
         });
       });
     }
-    s::cl_int r1 = r;
+    int r1 = r;
 
     assert(r1 == 0);
   }
 
   // bitselect
   {
-    s::cl_float4 r{0};
+    s::float4 r{0};
     {
-      s::buffer<s::cl_float4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class bitselectF4F4F4>([=]() {
-          AccR[0] = s::bitselect(s::cl_float4{112.112f, 12.12f, 0, 0.0f},
-                                 s::cl_float4{34.34f, 23.23f, 1, 0.0f},
-                                 s::cl_float4{3.3f, 6.6f, 1, 0.0f});
+          AccR[0] = s::bitselect(s::float4{112.112f, 12.12f, 0, 0.0f},
+                                 s::float4{34.34f, 23.23f, 1, 0.0f},
+                                 s::float4{3.3f, 6.6f, 1, 0.0f});
         }); // Using NAN/INFINITY as any float produced consistent results
             // between host and device.
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
-    s::cl_float r3 = r.z();
-    s::cl_float r4 = r.w();
+    float r1 = r.x();
+    float r2 = r.y();
+    float r3 = r.z();
+    float r4 = r.w();
 
     assert(abs(r1 - 80.5477f) < 0.0001);
     assert(abs(r2 - 18.2322f) < 0.0001);
@@ -542,25 +542,25 @@ int main() {
 
   // select
   {
-    s::cl_float4 r{0};
+    s::float4 r{0};
     {
-      s::buffer<s::cl_float4, 1> BufR(&r, s::range<1>(1));
+      s::buffer<s::float4, 1> BufR(&r, s::range<1>(1));
       s::queue myQueue;
       myQueue.submit([&](s::handler &cgh) {
         auto AccR = BufR.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class selectF4F4I4>([=]() {
-          AccR[0] = s::select(s::cl_float4{112.112f, 34.34f, 112.112f, 34.34f},
-                              s::cl_float4{34.34f, 112.112f, 34.34f, 112.112f},
-                              s::cl_int4{0, -1, 0, 1});
+          AccR[0] = s::select(s::float4{112.112f, 34.34f, 112.112f, 34.34f},
+                              s::float4{34.34f, 112.112f, 34.34f, 112.112f},
+                              s::int4{0, -1, 0, 1});
           // Using NAN/infinity as an input, which gets
           // selected by -1, produces a NAN/infinity as expected.
         });
       });
     }
-    s::cl_float r1 = r.x();
-    s::cl_float r2 = r.y();
-    s::cl_float r3 = r.z();
-    s::cl_float r4 = r.w();
+    float r1 = r.x();
+    float r2 = r.y();
+    float r3 = r.z();
+    float r4 = r.w();
 
     assert(r1 == 112.112f);
     assert(r2 == 112.112f);


### PR DESCRIPTION
`cl_*` types are only defined by SYCL 2020 spec for interoperability with OpenCL backend. We should be focusing on core SYCL types instead.