### PR TITLE
[SYCL][NFC] Modernize Basic/info.cpp

### DIFF
--- a/SYCL/Basic/info.cpp
+++ b/SYCL/Basic/info.cpp
@@ -213,10 +213,10 @@ int main() {
   device dev(selector.select_device());
 
   print_info<info::device::device_type, info::device_type>(dev, "Device type");
-  print_info<info::device::vendor_id, sycl::cl_uint>(dev, "Vendor ID");
-  print_info<info::device::max_compute_units, sycl::cl_uint>(
+  print_info<info::device::vendor_id, std::uint32_t>(dev, "Vendor ID");
+  print_info<info::device::max_compute_units, std::uint32_t>(
       dev, "Max compute units");
-  print_info<info::device::max_work_item_dimensions, sycl::cl_uint>(
+  print_info<info::device::max_work_item_dimensions, std::uint32_t>(
       dev, "Max work item dimensions");
   print_info<info::device::max_work_item_sizes<1>, id<1>>(
       dev, "Max work item sizes 1D");
@@ -226,44 +226,44 @@ int main() {
       dev, "Max work item sizes 3D");
   print_info<info::device::max_work_group_size, size_t>(dev,
                                                         "Max work group size");
-  print_info<info::device::preferred_vector_width_char, sycl::cl_uint>(
+  print_info<info::device::preferred_vector_width_char, std::uint32_t>(
       dev, "Preferred vector width char");
-  print_info<info::device::preferred_vector_width_short, sycl::cl_uint>(
+  print_info<info::device::preferred_vector_width_short, std::uint32_t>(
       dev, "Preferred vector width short");
-  print_info<info::device::preferred_vector_width_int, sycl::cl_uint>(
+  print_info<info::device::preferred_vector_width_int, std::uint32_t>(
       dev, "Preferred vector width int");
-  print_info<info::device::preferred_vector_width_long, sycl::cl_uint>(
+  print_info<info::device::preferred_vector_width_long, std::uint32_t>(
       dev, "Preferred vector width long");
-  print_info<info::device::preferred_vector_width_float, sycl::cl_uint>(
+  print_info<info::device::preferred_vector_width_float, std::uint32_t>(
       dev, "Preferred vector width float");
-  print_info<info::device::preferred_vector_width_double, sycl::cl_uint>(
+  print_info<info::device::preferred_vector_width_double, std::uint32_t>(
       dev, "Preferred vector width double");
-  print_info<info::device::preferred_vector_width_half, sycl::cl_uint>(
+  print_info<info::device::preferred_vector_width_half, std::uint32_t>(
       dev, "Preferred vector width half");
-  print_info<info::device::native_vector_width_char, sycl::cl_uint>(
+  print_info<info::device::native_vector_width_char, std::uint32_t>(
       dev, "Native vector width char");
-  print_info<info::device::native_vector_width_short, sycl::cl_uint>(
+  print_info<info::device::native_vector_width_short, std::uint32_t>(
       dev, "Native vector width short");
-  print_info<info::device::native_vector_width_int, sycl::cl_uint>(
+  print_info<info::device::native_vector_width_int, std::uint32_t>(
       dev, "Native vector width int");
-  print_info<info::device::native_vector_width_long, sycl::cl_uint>(
+  print_info<info::device::native_vector_width_long, std::uint32_t>(
       dev, "Native vector width long");
-  print_info<info::device::native_vector_width_float, sycl::cl_uint>(
+  print_info<info::device::native_vector_width_float, std::uint32_t>(
       dev, "Native vector width float");
-  print_info<info::device::native_vector_width_double, sycl::cl_uint>(
+  print_info<info::device::native_vector_width_double, std::uint32_t>(
       dev, "Native vector width double");
-  print_info<info::device::native_vector_width_half, sycl::cl_uint>(
+  print_info<info::device::native_vector_width_half, std::uint32_t>(
       dev, "Native vector width half");
   /*TODO: uncomment when problem with frequency detection is fixed
-  print_info<info::device::max_clock_frequency, sycl::cl_uint>(
+  print_info<info::device::max_clock_frequency, std::uint32_t>(
       dev, "Max clock frequency");*/
-  print_info<info::device::address_bits, sycl::cl_uint>(dev, "Address bits");
-  print_info<info::device::max_mem_alloc_size, sycl::cl_ulong>(
+  print_info<info::device::address_bits, std::uint32_t>(dev, "Address bits");
+  print_info<info::device::max_mem_alloc_size, std::uint64_t>(
       dev, "Max mem alloc size");
   print_info<info::device::image_support, bool>(dev, "Image support");
-  print_info<info::device::max_read_image_args, sycl::cl_uint>(
+  print_info<info::device::max_read_image_args, std::uint32_t>(
       dev, "Max read image args");
-  print_info<info::device::max_write_image_args, sycl::cl_uint>(
+  print_info<info::device::max_write_image_args, std::uint32_t>(
       dev, "Max write image args");
   print_info<info::device::image2d_max_width, size_t>(dev, "Image2D max width");
   print_info<info::device::image2d_max_height, size_t>(dev,
@@ -276,10 +276,10 @@ int main() {
       dev, "Image max buffer size");
   print_info<info::device::image_max_array_size, size_t>(
       dev, "Image max array size");
-  print_info<info::device::max_samplers, sycl::cl_uint>(dev, "Max samplers");
+  print_info<info::device::max_samplers, std::uint32_t>(dev, "Max samplers");
   print_info<info::device::max_parameter_size, size_t>(dev,
                                                        "Max parameter size");
-  print_info<info::device::mem_base_addr_align, sycl::cl_uint>(
+  print_info<info::device::mem_base_addr_align, std::uint32_t>(
       dev, "Mem base addr align");
   print_info<info::device::half_fp_config, std::vector<info::fp_config>>(
       dev, "Half fp config");
@@ -289,20 +289,20 @@ int main() {
       dev, "Double fp config");
   print_info<info::device::global_mem_cache_type, info::global_mem_cache_type>(
       dev, "Global mem cache type");
-  print_info<info::device::global_mem_cache_line_size, sycl::cl_uint>(
+  print_info<info::device::global_mem_cache_line_size, std::uint32_t>(
       dev, "Global mem cache line size");
-  print_info<info::device::global_mem_cache_size, sycl::cl_ulong>(
+  print_info<info::device::global_mem_cache_size, std::uint64_t>(
       dev, "Global mem cache size");
-  print_info<info::device::global_mem_size, sycl::cl_ulong>(dev,
-                                                            "Global mem size");
-  print_info<info::device::max_constant_buffer_size, sycl::cl_ulong>(
+  print_info<info::device::global_mem_size, std::uint64_t>(dev,
+                                                           "Global mem size");
+  print_info<info::device::max_constant_buffer_size, std::uint64_t>(
       dev, "Max constant buffer size");
-  print_info<info::device::max_constant_args, sycl::cl_uint>(
+  print_info<info::device::max_constant_args, std::uint32_t>(
       dev, "Max constant args");
   print_info<info::device::local_mem_type, info::local_mem_type>(
       dev, "Local mem type");
-  print_info<info::device::local_mem_size, sycl::cl_ulong>(dev,
-                                                           "Local mem size");
+  print_info<info::device::local_mem_size, std::uint64_t>(dev,
+                                                          "Local mem size");
   print_info<info::device::error_correction_support, bool>(
       dev, "Error correction support");
   print_info<info::device::host_unified_memory, bool>(dev,
@@ -341,7 +341,7 @@ int main() {
     std::cout << "Expected exception has been caught: " << e.what()
               << std::endl;
   }
-  print_info<info::device::partition_max_sub_devices, sycl::cl_uint>(
+  print_info<info::device::partition_max_sub_devices, std::uint32_t>(
       dev, "Partition max sub devices");
   print_info<info::device::partition_properties,
              std::vector<info::partition_property>>(dev,
@@ -355,8 +355,8 @@ int main() {
   print_info<info::device::partition_type_affinity_domain,
              info::partition_affinity_domain>(dev,
                                               "Partition type affinity domain");
-  print_info<info::device::reference_count, sycl::cl_uint>(dev,
-                                                           "Reference count");
+  print_info<info::device::reference_count, sycl::opencl::cl_uint>(
+      dev, "Reference count");
 
   std::cout << separator << "Platform information\n" << separator;
   platform plt(dev.get_platform());


### PR DESCRIPTION
Replaced usages of `cl_*` types with data types listed in SYCL 2020 spec.

The only exception is `info::reference_count`: I can't find this query in the spec and therefore left `cl_*` type in place, but prefixed it with `opencl::` namespace so it matches its defintion in SYCL 2020.