### PR TITLE
[SYCL][NFC] Modernize some tests to match SYCL 2020

### DIFF
--- a/SYCL/Basic/boolean.cpp
+++ b/SYCL/Basic/boolean.cpp
@@ -17,9 +17,9 @@ d::Boolean<3> foo() {
 
 int main() {
   {
-    s::cl_long4 r{0};
+    s::long4 r{0};
     {
-      buffer<s::cl_long4, 1> BufR(&r, range<1>(1));
+      buffer<s::long4, 1> BufR(&r, range<1>(1));
       queue myQueue;
       myQueue.submit([&](handler &cgh) {
         auto AccR = BufR.get_access<access::mode::write>(cgh);
@@ -29,10 +29,10 @@ int main() {
         });
       });
     }
-    s::cl_long r1 = r.s0();
-    s::cl_long r2 = r.s1();
-    s::cl_long r3 = r.s2();
-    s::cl_long r4 = r.s3();
+    long long r1 = r.s0();
+    long long r2 = r.s1();
+    long long r3 = r.s2();
+    long long r4 = r.s3();
 
     std::cout << "r1 " << r1 << " r2 " << r2 << " r3 " << r3 << " r4 " << r4
               << std::endl;
@@ -44,18 +44,18 @@ int main() {
   }
 
   {
-    s::cl_short3 r{0};
+    s::short3 r{0};
     {
-      buffer<s::cl_short3, 1> BufR(&r, range<1>(1));
+      buffer<s::short3, 1> BufR(&r, range<1>(1));
       queue myQueue;
       myQueue.submit([&](handler &cgh) {
         auto AccR = BufR.get_access<access::mode::write>(cgh);
         cgh.single_task<class b3_sh3>([=]() { AccR[0] = foo(); });
       });
     }
-    s::cl_short r1 = r.s0();
-    s::cl_short r2 = r.s1();
-    s::cl_short r3 = r.s2();
+    short r1 = r.s0();
+    short r2 = r.s1();
+    short r3 = r.s2();
 
     std::cout << "r1 " << r1 << " r2 " << r2 << " r3 " << r3 << std::endl;
 
@@ -65,11 +65,11 @@ int main() {
   }
 
   {
-    s::cl_int r1[6];
-    s::cl_int r2[6];
+    int r1[6];
+    int r2[6];
     {
-      buffer<s::cl_int, 1> BufR1(r1, range<1>(6));
-      buffer<s::cl_int, 1> BufR2(r2, range<1>(6));
+      buffer<int, 1> BufR1(r1, range<1>(6));
+      buffer<int, 1> BufR2(r2, range<1>(6));
       queue myQueue;
       myQueue.submit([&](handler &cgh) {
         auto AccR1 = BufR1.get_access<access::mode::write>(cgh);
@@ -117,14 +117,14 @@ int main() {
   }
 
   {
-    s::cl_int4 i4 = {1, -2, 0, -3};
+    s::int4 i4 = {1, -2, 0, -3};
     d::Boolean<4> b4(i4);
     i4 = b4;
 
-    s::cl_int r1 = i4.s0();
-    s::cl_int r2 = i4.s1();
-    s::cl_int r3 = i4.s2();
-    s::cl_int r4 = i4.s3();
+    int r1 = i4.s0();
+    int r2 = i4.s1();
+    int r3 = i4.s2();
+    int r4 = i4.s3();
 
     std::cout << "r1 " << r1 << " r2 " << r2 << " r3 " << r3 << " r4 " << r4
               << std::endl;
@@ -135,9 +135,9 @@ int main() {
   }
 
   {
-    s::cl_int r1 = d::Boolean<1>(s::cl_int{-1});
-    s::cl_int r2 = d::Boolean<1>(s::cl_int{0});
-    s::cl_int r3 = d::Boolean<1>(s::cl_int{1});
+    int r1 = d::Boolean<1>(int{-1});
+    int r2 = d::Boolean<1>(int{0});
+    int r3 = d::Boolean<1>(int{1});
     std::cout << "r1 " << r1 << " r2 " << r2 << " r3 " << r3 << std::endl;
     assert(r1 == 1);
     assert(r2 == 0);

--- a/SYCL/Basic/built-ins.cpp
+++ b/SYCL/Basic/built-ins.cpp
@@ -56,14 +56,14 @@ int main() {
 
   // Test common
   {
-    s::buffer<s::cl_float, 1> BufMin(s::range<1>(1));
-    s::buffer<s::cl_float2, 1> BufMax(s::range<1>(1));
+    s::buffer<float, 1> BufMin(s::range<1>(1));
+    s::buffer<s::float2, 1> BufMax(s::range<1>(1));
     q.submit([&](s::handler &cgh) {
       auto AccMin = BufMin.get_access<s::access::mode::write>(cgh);
       auto AccMax = BufMax.get_access<s::access::mode::write>(cgh);
       cgh.single_task<class common>([=]() {
-        AccMax[0] = s::max(s::cl_float2{0.5f, 2.5f}, s::cl_float2{2.3f, 2.3f});
-        AccMin[0] = s::min(s::cl_float{0.5f}, s::cl_float{2.3f});
+        AccMax[0] = s::max(s::float2{0.5f, 2.5f}, s::float2{2.3f, 2.3f});
+        AccMin[0] = s::min(float{0.5f}, float{2.3f});
       });
     });
 

--- a/SYCL/Basic/group_async_copy.cpp
+++ b/SYCL/Basic/group_async_copy.cpp
@@ -161,7 +161,7 @@ int main() {
       return 1;
     if (test<vec<bool, 4>>(Stride))
       return 1;
-    if (test<sycl::cl_bool>(Stride))
+    if (test<sycl::opencl::cl_bool>(Stride))
       return 1;
     if (test<std::byte>(Stride))
       return 1;

--- a/SYCL/Basic/vector_operators.cpp
+++ b/SYCL/Basic/vector_operators.cpp
@@ -43,7 +43,7 @@ int main() {
   /* Separate checks for NumElements=1 edge case */
 
   {
-    using vec_type = s::vec<s::cl_char, 1>;
+    using vec_type = s::vec<char, 1>;
     vec_type res;
     {
       s::buffer<vec_type, 1> Buf(&res, s::range<1>(1));
@@ -63,7 +63,7 @@ int main() {
   }
 
   {
-    using vec_type = s::vec<s::cl_char, 1>;
+    using vec_type = s::vec<char, 1>;
     vec_type res;
     {
       s::buffer<vec_type, 1> Buf(&res, s::range<1>(1));
@@ -71,7 +71,7 @@ int main() {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isequal_vec_op_1_elem_scalar>([=]() {
           vec_type vec(2);
-          s::cl_char rhs_scalar = 2;
+          char rhs_scalar = 2;
           Acc[0] = vec == rhs_scalar;
         });
       });
@@ -87,17 +87,17 @@ int main() {
 
   // SYCL vec<>, SYCL vec<>
 
-  // Operator ==, cl_uint
+  // Operator ==, unsigned int
   {
-    using res_vec_type = s::vec<s::cl_int, 4>;
+    using res_vec_type = s::int4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isequal_vec_op>([=]() {
-          s::vec<s::cl_uint, 4> vec1(42, 42, 42, 0);
-          s::vec<s::cl_uint, 4> vec2(0, 42, 42, 0);
+          s::uint4 vec1(42, 42, 42, 0);
+          s::uint4 vec2(0, 42, 42, 0);
           Acc[0] = vec1 == vec2;
         });
       });
@@ -106,17 +106,17 @@ int main() {
     check_result_length_4<res_vec_type>(res, expected);
   }
 
-  // Operator <, cl_double
+  // Operator <, double
   if (Queue.get_device().has(sycl::aspect::fp64)) {
-    using res_vec_type = s::vec<s::cl_long, 4>;
+    using res_vec_type = s::long4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isless_vec_op>([=]() {
-          s::vec<s::cl_double, 4> vec1(0.5, 10.1, 10.2, 10.3);
-          s::vec<s::cl_double, 4> vec2(10.5, 0.1, 0.2, 0.3);
+          s::double4 vec1(0.5, 10.1, 10.2, 10.3);
+          s::double4 vec2(10.5, 0.1, 0.2, 0.3);
           Acc[0] = vec1 < vec2;
         });
       });
@@ -125,17 +125,17 @@ int main() {
     check_result_length_4<res_vec_type>(res, expected);
   }
 
-  // Operator >, cl_char
+  // Operator >, char
   {
-    using res_vec_type = s::vec<s::cl_char, 4>;
+    using res_vec_type = s::char4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isgreater_vec_op>([=]() {
-          s::vec<s::cl_char, 4> vec1(0, 0, 42, 42);
-          s::vec<s::cl_char, 4> vec2(42, 0, 0, -42);
+          s::char4 vec1(0, 0, 42, 42);
+          s::char4 vec2(42, 0, 0, -42);
           Acc[0] = vec1 > vec2;
         });
       });
@@ -144,17 +144,17 @@ int main() {
     check_result_length_4<res_vec_type>(res, expected);
   }
 
-  // Operator <=, cl_half
+  // Operator <=, half
   if (Queue.get_device().has(sycl::aspect::fp16)) {
-    using res_vec_type = s::vec<s::cl_short, 4>;
+    using res_vec_type = s::short4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnotgreater_vec_op>([=]() {
-          s::vec<s::cl_half, 4> vec1(0, 0, 42, 42);
-          s::vec<s::cl_half, 4> vec2(42, 0, 0, -42);
+          s::half4 vec1(0, 0, 42, 42);
+          s::half4 vec2(42, 0, 0, -42);
           Acc[0] = vec1 <= vec2;
         });
       });
@@ -165,17 +165,17 @@ int main() {
 
   // SYCL vec<>, OpenCL built-in
 
-  // Operator >=, cl_ulong
+  // Operator >=, unsigned long
   {
-    using res_vec_type = s::vec<s::cl_long, 4>;
+    using res_vec_type = s::long4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnotless_vec_op>([=]() {
-          s::vec<s::cl_ulong, 4> vec1(0, 0, 42, 42);
-          s::cl_ulong4 vec2{42, 0, 0, 0};
+          s::ulong4 vec1(0, 0, 42, 42);
+          s::ulong4 vec2{42, 0, 0, 0};
           Acc[0] = vec1 >= vec2;
         });
       });
@@ -184,17 +184,17 @@ int main() {
     check_result_length_4<res_vec_type>(res, expected);
   }
 
-  // Operator !=, cl_ushort
+  // Operator !=, unsigned short
   {
-    using res_vec_type = s::vec<s::cl_short, 4>;
+    using res_vec_type = s::short4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class isnotequal_vec_op>([=]() {
-          s::vec<s::cl_ushort, 4> vec1(0, 0, 42, 42);
-          s::cl_ushort4 vec2{42, 0, 0, 42};
+          s::ushort4 vec1(0, 0, 42, 42);
+          s::ushort4 vec2{42, 0, 0, 42};
           Acc[0] = vec1 != vec2;
         });
       });
@@ -203,17 +203,17 @@ int main() {
     check_result_length_4<res_vec_type>(res, expected);
   }
 
-  // Operator &&, cl_int
+  // Operator &&, int
   {
-    using res_vec_type = s::vec<s::cl_int, 4>;
+    using res_vec_type = s::int4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class logical_and_vec_op>([=]() {
-          s::vec<s::cl_int, 4> vec1(0, 0, 42, 42);
-          s::cl_int4 vec2{42, 0, 0, 42};
+          s::int4 vec1(0, 0, 42, 42);
+          s::int4 vec2{42, 0, 0, 42};
           Acc[0] = vec1 && vec2;
         });
       });
@@ -222,17 +222,17 @@ int main() {
     check_result_length_4<res_vec_type>(res, expected);
   }
 
-  // Operator ||, cl_int
+  // Operator ||, int
   {
-    using res_vec_type = s::vec<s::cl_int, 4>;
+    using res_vec_type = s::int4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class logical_or_vec_op>([=]() {
-          s::vec<s::cl_int, 4> vec1(0, 0, 42, 42);
-          s::cl_int4 vec2{42, 0, 0, 42};
+          s::int4 vec1(0, 0, 42, 42);
+          s::int4 vec2{42, 0, 0, 42};
           Acc[0] = vec1 || vec2;
         });
       });
@@ -244,14 +244,14 @@ int main() {
   // as() function.
   // reinterprets each element as a different datatype.
   {
-    using res_vec_type = s::vec<s::cl_int, 4>;
+    using res_vec_type = s::int4;
     res_vec_type res;
     {
       s::buffer<res_vec_type, 1> Buf(&res, s::range<1>(1));
       Queue.submit([&](s::handler &cgh) {
         auto Acc = Buf.get_access<s::access::mode::write>(cgh);
         cgh.single_task<class as_op>([=]() {
-          s::vec<s::cl_float, 4> vec1(4.5f, 0, 3.5f, -10.0f);
+          s::float4 vec1(4.5f, 0, 3.5f, -10.0f);
           Acc[0] = vec1.template as<res_vec_type>();
         });
       });

--- a/SYCL/KernelParams/struct_kernel_param.cpp
+++ b/SYCL/KernelParams/struct_kernel_param.cpp
@@ -23,32 +23,32 @@ struct MyNestedStruct {
   bool operator==(const MyNestedStruct &Rhs) {
     return (FldArr[0] == Rhs.FldArr[0] && FldFloat == Rhs.FldFloat);
   }
-  sycl::cl_char FldArr[1];
-  sycl::cl_float FldFloat;
+  char FldArr[1];
+  float FldFloat;
 };
 
 struct MyStruct {
   bool operator==(const MyStruct &Rhs) {
-    return (FldChar == Rhs.FldChar && FldLong == Rhs.FldLong &&
+    return (FldChar == Rhs.FldChar && FldLongLong == Rhs.FldLongLong &&
             FldShort == Rhs.FldShort && FldUint == Rhs.FldUint &&
             FldStruct == Rhs.FldStruct &&
             std::equal(std::begin(FldArr), std::end(FldArr),
                        std::begin(Rhs.FldArr)) &&
             FldInt == Rhs.FldInt);
   }
-  sycl::cl_char FldChar;
-  sycl::cl_long FldLong;
-  sycl::cl_short FldShort;
-  sycl::cl_uint FldUint;
+  char FldChar;
+  long long FldLongLong;
+  short FldShort;
+  unsigned int FldUint;
   MyNestedStruct FldStruct;
-  sycl::cl_short FldArr[3];
-  sycl::cl_int FldInt;
+  short FldArr[3];
+  int FldInt;
 };
 
 MyStruct GlobS;
 
 static void printStruct(const MyStruct &S0) {
-  std::cout << "{ " << (int)S0.FldChar << ", " << S0.FldLong << ", "
+  std::cout << "{ " << (int)S0.FldChar << ", " << S0.FldLongLong << ", "
             << S0.FldShort << ", " << S0.FldUint << " { { "
             << (int)S0.FldStruct.FldArr[0] << " }, " << S0.FldStruct.FldFloat
             << " }, { " << S0.FldArr[0] << ", " << S0.FldArr[1] << ", "
@@ -114,15 +114,15 @@ bool test1() {
 }
 
 int main(int argc, char **argv) {
-  sycl::cl_char PartChar = argc;
-  sycl::cl_short PartShort = argc << 8;
-  sycl::cl_int PartInt = argc << 16;
-  sycl::cl_uint PartUint = argc << 16;
-  sycl::cl_long PartLong = ((sycl::cl_long)argc) << 32;
-  sycl::cl_float PartFloat = argc;
+  char PartChar = argc;
+  short PartShort = argc << 8;
+  int PartInt = argc << 16;
+  unsigned int PartUint = argc << 16;
+  long long PartLongLong = ((long long)argc) << 32;
+  float PartFloat = argc;
 
   GlobS = {PartChar,
-           PartLong,
+           PartLongLong,
            PartShort,
            PartUint,
            {{PartChar}, PartFloat},

--- a/SYCL/Regression/commandlist/Inputs/FindPrimesSYCL.cpp
+++ b/SYCL/Regression/commandlist/Inputs/FindPrimesSYCL.cpp
@@ -25,7 +25,7 @@ float find_prime_s(work *w) {
   auto nitems = w->nitems;
 
   sycl::range<1> numOfItems{nitems};
-  sycl::buffer<sycl::cl_short, 1> bufferR(VRI.data(), N);
+  sycl::buffer<sycl::opencl::cl_short, 1> bufferR(VRI.data(), N);
 
   auto start = std::chrono::high_resolution_clock::now();
 

--- a/SYCL/Regression/commandlist/Inputs/FindPrimesSYCL.h
+++ b/SYCL/Regression/commandlist/Inputs/FindPrimesSYCL.h
@@ -14,7 +14,7 @@ struct work {
   size_t niter;
   size_t nitems;
 
-  std::vector<sycl::cl_short> VRI;
+  std::vector<sycl::opencl::cl_short> VRI;
 
   size_t result;
 


### PR DESCRIPTION
- removed usage of `cl_*` types in favor of standard C++ types and/or `vec` aliases defined in SYCL 2020 spec.
- prefixed some `cl_*` types with `opencl::` namespace