### PR TITLE
[SYCL][Fusion] Test fusion device info descriptor

### DIFF
--- a/SYCL/KernelFusion/device_info_descriptor.cpp
+++ b/SYCL/KernelFusion/device_info_descriptor.cpp
@@ -1,0 +1,23 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// XFAIL: cuda || hip
+// REQUIRES: fusion
+
+// Test correct return from device information descriptor.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+
+  queue q;
+
+  assert(q.get_device()
+             .get_info<sycl::ext::codeplay::experimental::info::device::
+                           supports_fusion>() &&
+         "Device should support fusion");
+
+  return 0;
+}


### PR DESCRIPTION
Test the `sycl::ext::codeplay::experimental::info::device::supports_fusion` device descriptor defined by the [kernel fusion extension proposal](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc). 

Kernel fusion is currently limited to SPIR-V based backends and Linux. The test is unsupported on Windows and expectedly fails (`XFAIL` ) for the CUDA and HIP backends.

Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>