### PR TITLE
[SYCL] Test reduction for complex numbers.

### DIFF
--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -42,7 +42,7 @@ void test_identityless_reduction_for_complex_nums(queue &q) {
                      });
   });
 
-  assert(sumBuf.get_host_access()[0] == std::complex<T>(32385, 32895));
+  assert(sumBuf.get_host_access()[0] == std::complex<T>(32640,32895));
 }
 
 int main() {

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -24,8 +24,10 @@ void test_identityless_reduction_for_complex_nums(queue &q) {
   {
     host_accessor a{valuesBuf};
     T n = 0;
-    std::generate(a.begin(), a.end(),
-                  [&n] { n++; return std::complex<T>(n, n + 1); });
+    std::generate(a.begin(), a.end(), [&n] {
+      n++;
+      return std::complex<T>(n, n + 1);
+    });
   }
 
   // Buffer to hold the reduction results.

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -44,7 +44,7 @@ void test_identityless_reduction_for_complex_nums(queue &q) {
                      });
   });
 
-  assert(sumBuf.get_host_access()[0] == std::complex<T>(32640,32895));
+  assert(sumBuf.get_host_access()[0] == std::complex<T>(32640, 32895));
 }
 
 int main() {

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -17,24 +17,22 @@ using namespace sycl;
 template <typename T>
 void test_identityless_reduction_for_complex_nums(queue &q) {
   // Allocate and initialize buffer on the host with all 1's.
-  buffer<std::complex<T>> valuesBuf { 1024 };
+  buffer<std::complex<T>> valuesBuf{1024};
   {
-    host_accessor a { valuesBuf };
+    host_accessor a{valuesBuf};
     std::fill(a.begin(), a.end(), std::complex<T>(1));
   }
 
   // Buffer to hold the reduction results.
   std::complex<T> sumResult = 0;
-  buffer<std::complex<T>> sumBuf { &sumResult, 1 };
+  buffer<std::complex<T>> sumBuf{&sumResult, 1};
 
-  q.submit([&](handler& cgh) {
+  q.submit([&](handler &cgh) {
     auto inputVals = valuesBuf.template get_access<access_mode::read>(cgh);
     auto sumReduction = reduction(sumBuf, cgh, plus<std::complex<T>>());
 
-    cgh.parallel_for(range<1> {1024}, sumReduction,
-                     [=](id<1> idx, auto& sum) {
-      sum += inputVals[idx];
-    });
+    cgh.parallel_for(range<1>{1024}, sumReduction,
+                     [=](id<1> idx, auto &sum) { sum += inputVals[idx]; });
   });
 
   assert(sumBuf.get_host_access()[0] == static_cast<T>(1024));

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -20,7 +20,9 @@ void test_identityless_reduction_for_complex_nums(queue &q) {
   buffer<std::complex<T>> valuesBuf{1024};
   {
     host_accessor a{valuesBuf};
-    std::fill(a.begin(), a.end(), std::complex<T>(1));
+    T n = 0;
+    std::generate(a.begin(), a.end(),
+                  [&n] { return std::complex<T>(n, ++n + 1); });
   }
 
   // Buffer to hold the reduction results.
@@ -28,14 +30,14 @@ void test_identityless_reduction_for_complex_nums(queue &q) {
   buffer<std::complex<T>> sumBuf{&sumResult, 1};
 
   q.submit([&](handler &cgh) {
-    auto inputVals = valuesBuf.template get_access<access_mode::read>(cgh);
+    accessor inputVals{valuesBuf, cgh, sycl::read_only};
     auto sumReduction = reduction(sumBuf, cgh, plus<std::complex<T>>());
 
     cgh.parallel_for(range<1>{1024}, sumReduction,
                      [=](id<1> idx, auto &sum) { sum += inputVals[idx]; });
   });
 
-  assert(sumBuf.get_host_access()[0] == static_cast<T>(1024));
+  assert(sumBuf.get_host_access()[0] == std::complex<T>(523776, 525824));
 }
 
 int main() {

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -5,6 +5,7 @@
 
 #include <complex>
 #include <numeric>
+#include <algorithm>
 
 #include <sycl/sycl.hpp>
 

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -3,9 +3,9 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+#include <algorithm>
 #include <complex>
 #include <numeric>
-#include <algorithm>
 
 #include <sycl/sycl.hpp>
 

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -41,8 +41,6 @@ void test_identityless_reduction_for_complex_nums(queue &q) {
 int main() {
   queue q;
 
-  test_identityless_reduction_for_complex_nums<short>(q);
-  test_identityless_reduction_for_complex_nums<int>(q);
   test_identityless_reduction_for_complex_nums<float>(q);
   test_identityless_reduction_for_complex_nums<double>(q);
 

--- a/SYCL/Reduction/reduction_complex_nums.cpp
+++ b/SYCL/Reduction/reduction_complex_nums.cpp
@@ -1,0 +1,52 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+#include <complex>
+#include <numeric>
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+// Currently, Identityless reduction for complex numbers is
+// only valid for plus operator.
+// TODO: Extend this test case once we support known_identity for std::complex
+// and more operators (apart from plus).
+template <typename T>
+void test_identityless_reduction_for_complex_nums(queue &q) {
+  // Allocate and initialize buffer on the host with all 1's.
+  buffer<std::complex<T>> valuesBuf { 1024 };
+  {
+    host_accessor a { valuesBuf };
+    std::fill(a.begin(), a.end(), std::complex<T>(1));
+  }
+
+  // Buffer to hold the reduction results.
+  std::complex<T> sumResult = 0;
+  buffer<std::complex<T>> sumBuf { &sumResult, 1 };
+
+  q.submit([&](handler& cgh) {
+    auto inputVals = valuesBuf.template get_access<access_mode::read>(cgh);
+    auto sumReduction = reduction(sumBuf, cgh, plus<std::complex<T>>());
+
+    cgh.parallel_for(range<1> {1024}, sumReduction,
+                     [=](id<1> idx, auto& sum) {
+      sum += inputVals[idx];
+    });
+  });
+
+  assert(sumBuf.get_host_access()[0] == static_cast<T>(1024));
+}
+
+int main() {
+  queue q;
+
+  test_identityless_reduction_for_complex_nums<short>(q);
+  test_identityless_reduction_for_complex_nums<int>(q);
+  test_identityless_reduction_for_complex_nums<float>(q);
+  test_identityless_reduction_for_complex_nums<double>(q);
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds test case for testing identityless reduction for complex numbers.

Corresponding intel/llvm PR: https://github.com/intel/llvm/pull/8425