### PR TITLE
[SYCL] Updated atomic_memory_order_capabilities query test for OpenCL 3.0 backend

### DIFF
--- a/SYCL/AtomicRef/atomic_memory_order.cpp
+++ b/SYCL/AtomicRef/atomic_memory_order.cpp
@@ -2,11 +2,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// L0, OpenCL (<3.0) backends don't currently support
-// info::device::atomic_memory_order_capabilities
-// UNSUPPORTED: level_zero
 
-// NOTE: General tests for atomic memory order capabilities.
+// This test checks whether the minimum required memory order capabilities are
+// supported in both context and device queries. Specifically the "relaxed"
+// memory order capability, which is used in other tests.
 
 #include "atomic_memory_order.h"
 #include <cassert>
@@ -21,16 +20,12 @@ int main() {
       q.get_context()
           .get_info<info::context::atomic_memory_order_capabilities>();
 
-  // Relaxed memory order must be supported. This ordering is used in other
-  // tests.
   assert(is_supported(supported_context_memory_orders, memory_order::relaxed));
 
   // Device
   std::vector<memory_order> supported_device_memory_orders =
       q.get_device().get_info<info::device::atomic_memory_order_capabilities>();
 
-  // Relaxed memory order must be supported. This ordering is used in other
-  // tests.
   assert(is_supported(supported_device_memory_orders, memory_order::relaxed));
 
   std::cout << "Test passed." << std::endl;

--- a/SYCL/AtomicRef/atomic_memory_order.cpp
+++ b/SYCL/AtomicRef/atomic_memory_order.cpp
@@ -2,9 +2,9 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// L0, OpenCL backends don't currently support
+// L0, OpenCL (<3.0) backends don't currently support
 // info::device::atomic_memory_order_capabilities
-// UNSUPPORTED: level_zero || opencl
+// UNSUPPORTED: level_zero
 
 // NOTE: General tests for atomic memory order capabilities.
 
@@ -16,12 +16,22 @@ using namespace sycl;
 int main() {
   queue q;
 
-  std::vector<memory_order> supported_memory_orders =
+  // Context
+  std::vector<memory_order> supported_context_memory_orders =
+      q.get_context()
+          .get_info<info::context::atomic_memory_order_capabilities>();
+
+  // Relaxed memory order must be supported. This ordering is used in other
+  // tests.
+  assert(is_supported(supported_context_memory_orders, memory_order::relaxed));
+
+  // Device
+  std::vector<memory_order> supported_device_memory_orders =
       q.get_device().get_info<info::device::atomic_memory_order_capabilities>();
 
   // Relaxed memory order must be supported. This ordering is used in other
   // tests.
-  assert(is_supported(supported_memory_orders, memory_order::relaxed));
+  assert(is_supported(supported_device_memory_orders, memory_order::relaxed));
 
   std::cout << "Test passed." << std::endl;
 }

--- a/SYCL/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/SYCL/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -11,7 +11,7 @@
 using namespace sycl;
 
 template <memory_order order> void test_acquire_global() {
-  const size_t N_items = 1024;
+  const size_t N_items = 256;
   const size_t N_iters = 1000;
 
   int error = 0;
@@ -53,7 +53,7 @@ template <memory_order order> void test_acquire_global() {
 }
 
 template <memory_order order> void test_acquire_local() {
-  const size_t local_size = 1024;
+  const size_t local_size = 256;
   const size_t N_wgs = 16;
   const size_t global_size = local_size * N_wgs;
   const size_t N_iters = 1000;
@@ -102,7 +102,7 @@ template <memory_order order> void test_acquire_local() {
 }
 
 template <memory_order order> void test_release_global() {
-  const size_t N_items = 1024;
+  const size_t N_items = 256;
   const size_t N_iters = 1000;
 
   int error = 0;
@@ -144,7 +144,7 @@ template <memory_order order> void test_release_global() {
 }
 
 template <memory_order order> void test_release_local() {
-  const size_t local_size = 1024;
+  const size_t local_size = 256;
   const size_t N_wgs = 16;
   const size_t global_size = local_size * N_wgs;
   const size_t N_iters = 1000;

--- a/SYCL/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/SYCL/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/SYCL/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -1,10 +1,7 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// L0, OpenCL, and HIP backends don't currently support
-// info::device::atomic_memory_order_capabilities
-// UNSUPPORTED: level_zero, opencl
 
 // NOTE: Tests fetch_add for acquire and release memory ordering.
 

--- a/SYCL/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/SYCL/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out

--- a/SYCL/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/SYCL/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -1,10 +1,7 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O3 -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// L0, OpenCL, and HIP backends don't currently support
-// info::device::atomic_memory_order_capabilities
-// UNSUPPORTED: level_zero, opencl
 
 #include "atomic_memory_order.h"
 #include <iostream>


### PR DESCRIPTION
Both `context` and `device` should return at least `memory_order::relaxed` now on implementation-side in https://github.com/intel/llvm/pull/8517, so this test should pass if the target device has an OpenCL 3.0 backend or newer.

Remaining work/discussions required:
1. How should the test be structured for Level Zero and OpenCL <3.0 backends? These don't support the query presently (subject to change?) so this test can fail on older OCL backends currently.
2. `atomic_memory_order_acq_rel.cpp` and `atomic_memory_order_seq_cst.cpp` require updating once the query fully supports the rest of the possible values, also.