### PR TITLE
[SYCL] Disable tests failed during pulldown

### DIFF
--- a/SYCL/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -1,4 +1,4 @@
-// Test hangs on AMD
+// Test hangs on AMD with https://github.com/intel/llvm/pull/8412
 // UNSUPPORTED: hip_amd
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s  -o %t.out

--- a/SYCL/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -1,3 +1,6 @@
+// Temporarily disable:
+// XFAIL: *
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s  -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/SYCL/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -1,5 +1,5 @@
-// Temporarily disable:
-// XFAIL: *
+// Test hangs on AMD
+// UNSUPPORTED: hip_amd
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s  -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/GroupAlgorithm/barrier.cpp
+++ b/SYCL/GroupAlgorithm/barrier.cpp
@@ -1,6 +1,6 @@
-// Temporarily disabled due to regressions introduced by https://github.com/intel/llvm/pull/8412.
+// Temporarily disabled due to regressions introduced by
+// https://github.com/intel/llvm/pull/8412.
 // REQUIRES: TEMPORARY_DISABLED
-
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_80
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/GroupAlgorithm/barrier.cpp
+++ b/SYCL/GroupAlgorithm/barrier.cpp
@@ -1,3 +1,6 @@
+// Temporarily disable:
+// XFAIL: *
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_80
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/GroupAlgorithm/barrier.cpp
+++ b/SYCL/GroupAlgorithm/barrier.cpp
@@ -1,5 +1,6 @@
-// Temporarily disable:
-// XFAIL: *
+// Temporarily disabled due to regressions introduced by https://github.com/intel/llvm/pull/8412.
+// REQUIRES: TEMPORARY_DISABLED
+
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_80
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/HierPar/hier_par_wgscope_O0.cpp
+++ b/SYCL/HierPar/hier_par_wgscope_O0.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Temporarily disable:
+// XFAIL: *
+
 // RUN: %clangxx -O0 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/HierPar/hier_par_wgscope_O0.cpp
+++ b/SYCL/HierPar/hier_par_wgscope_O0.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Temporarily disable:
-// XFAIL: *
+// Test hangs on AMD
+// UNSUPPORTED: hip_amd
 
 // RUN: %clangxx -O0 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 

--- a/SYCL/HierPar/hier_par_wgscope_O0.cpp
+++ b/SYCL/HierPar/hier_par_wgscope_O0.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Test hangs on AMD
+// Test hangs on AMD with https://github.com/intel/llvm/pull/8412
 // UNSUPPORTED: hip_amd
 
 // RUN: %clangxx -O0 -fsycl -fsycl-targets=%sycl_triple %s -o %t.out

--- a/SYCL/Regression/unoptimized_stream.cpp
+++ b/SYCL/Regression/unoptimized_stream.cpp
@@ -1,3 +1,6 @@
+// Temporarily disable:
+// XFAIL: *
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O0 -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Regression/unoptimized_stream.cpp
+++ b/SYCL/Regression/unoptimized_stream.cpp
@@ -1,5 +1,5 @@
-// Temporarily disable:
-// XFAIL: *
+// Test hangs on AMD
+// UNSUPPORTED: hip_amd
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O0 -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/Regression/unoptimized_stream.cpp
+++ b/SYCL/Regression/unoptimized_stream.cpp
@@ -1,4 +1,4 @@
-// Test hangs on AMD
+// Test hangs on AMD with https://github.com/intel/llvm/pull/8412
 // UNSUPPORTED: hip_amd
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -O0 -o %t.out


### PR DESCRIPTION
We decided to disable these tests:
"The AMD failures are fairly limited as they only happen at -O0 so we can fix them in the sycl branch after the merge."
SYCL/GroupAlgorithm/barrier.cpp may be okay now, but I can't test it as the CUDA workdlow is broken for now.
PD PR: https://github.com/intel/llvm/pull/8412