### PR TITLE
[SYCL] Disables gpu_max_wgs_error test for unsupported backends.

### DIFF
--- a/SYCL/Basic/gpu_max_wgs_error.cpp
+++ b/SYCL/Basic/gpu_max_wgs_error.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out -fno-sycl-id-queries-fit-in-int
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 


### PR DESCRIPTION
Disable gpu_max_wgs_error.cpp test for CUDA and HIP, as these backends are unsupported.