### PR TITLE
[SYCL][ESIMD] Mark tests that fail on gen9 windows as unsupported

### DIFF
--- a/SYCL/ESIMD/BitonicSortK.cpp
+++ b/SYCL/ESIMD/BitonicSortK.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/BitonicSortKv2.cpp
+++ b/SYCL/ESIMD/BitonicSortKv2.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/PrefixSum.cpp
+++ b/SYCL/ESIMD/PrefixSum.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20

--- a/SYCL/ESIMD/Prefix_Local_sum1.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum1.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20

--- a/SYCL/ESIMD/Prefix_Local_sum2.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum2.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 20

--- a/SYCL/ESIMD/Prefix_Local_sum3.cpp
+++ b/SYCL/ESIMD/Prefix_Local_sum3.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/Stencil.cpp
+++ b/SYCL/ESIMD/Stencil.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/acc_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/acc_gather_scatter_rgba.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/acc_gather_scatter_rgba_stateless.cpp
+++ b/SYCL/ESIMD/acc_gather_scatter_rgba_stateless.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-esimd-force-stateless-mem %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/accessor.cpp
+++ b/SYCL/ESIMD/accessor.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -D_CRT_SECURE_NO_WARNINGS=1 %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/accessor_gather_scatter.cpp
+++ b/SYCL/ESIMD/accessor_gather_scatter.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/accessor_gather_scatter_stateless.cpp
+++ b/SYCL/ESIMD/accessor_gather_scatter_stateless.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-esimd-force-stateless-mem %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/accessor_load_store.cpp
+++ b/SYCL/ESIMD/accessor_load_store.cpp
@@ -10,6 +10,7 @@
 // intrinsics.
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/accessor_load_store_stateless.cpp
+++ b/SYCL/ESIMD/accessor_load_store_stateless.cpp
@@ -11,6 +11,7 @@
 // based accesses are automatically converted to stateless accesses.
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-esimd-force-stateless-mem %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/accessor_stateless.cpp
+++ b/SYCL/ESIMD/accessor_stateless.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-esimd-force-stateless-mem -D_CRT_SECURE_NO_WARNINGS=1 %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/ballot.cpp
+++ b/SYCL/ESIMD/api/ballot.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/bin_and_cmp_ops_heavy.cpp
+++ b/SYCL/ESIMD/api/bin_and_cmp_ops_heavy.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 // Exclude PVC not to run same test cases twice (via the *_pvc.cpp variant).
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/esimd_bit_ops.cpp
+++ b/SYCL/ESIMD/api/esimd_bit_ops.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/esimd_merge.cpp
+++ b/SYCL/ESIMD/api/esimd_merge.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/esimd_pack_unpack_mask.cpp
+++ b/SYCL/ESIMD/api/esimd_pack_unpack_mask.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/esimd_rgba_smoke.cpp
+++ b/SYCL/ESIMD/api/esimd_rgba_smoke.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/esimd_rgba_smoke_64.cpp
+++ b/SYCL/ESIMD/api/esimd_rgba_smoke_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/functional/ctors/ctor_array_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_array_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_array_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_array_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_broadcast_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_broadcast_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_broadcast_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_broadcast_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_converting_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_converting_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_converting_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_converting_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_copy_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_copy_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_copy_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_copy_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_default_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_default_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_accuracy_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_acc_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_acc_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_acc_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_acc_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_usm_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_usm_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_load_usm_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_load_usm_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_vector_core.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_vector_core.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/ctors/ctor_vector_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/ctors/ctor_vector_fp_extra.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_2d_core.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_2d_core.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_2d_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_2d_fp_extra.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_lvalue_core.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_lvalue_core.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_lvalue_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_lvalue_fp_extra.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_rvalue_core.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_rvalue_core.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_rvalue_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_rvalue_fp_extra.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_simd_view_rval_core.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_simd_view_rval_core.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/functions/functions_select_simd_view_rval_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/functions/functions_select_simd_view_rval_fp_extra.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/operators/operator_bitwise_not_sint.cpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_bitwise_not_sint.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/operators/operator_bitwise_not_uint.cpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_bitwise_not_uint.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_accuracy_core.cpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_accuracy_core.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_accuracy_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_accuracy_fp_extra.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_core.cpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_core.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_fp_extra.cpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_decrement_and_increment_fp_extra.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // XREQUIRES: gpu
 // TODO gpu and level_zero in REQUIRES due to only this platforms supported yet.
 // The current "REQUIRES" should be replaced with "gpu" only as mentioned in

--- a/SYCL/ESIMD/api/functional/operators/operator_logical_not.cpp
+++ b/SYCL/ESIMD/api/functional/operators/operator_logical_not.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: windows, gpu, level_zero
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // TODO This test freezed on Linux OS, enable test on linux once this issue will
 // be fixed.
 // XREQUIRES: gpu

--- a/SYCL/ESIMD/api/saturation_smoke.cpp
+++ b/SYCL/ESIMD/api/saturation_smoke.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // TODO: esimd_emulator fails due to unimplemented 'half' type
 // XFAIL: esimd_emulator

--- a/SYCL/ESIMD/api/simd_any_all.cpp
+++ b/SYCL/ESIMD/api/simd_any_all.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_binop_integer_promotion.cpp
+++ b/SYCL/ESIMD/api/simd_binop_integer_promotion.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_copy_to_from.cpp
+++ b/SYCL/ESIMD/api/simd_copy_to_from.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_mask.cpp
+++ b/SYCL/ESIMD/api/simd_mask.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-unnamed-lambda -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_memory_access.cpp
+++ b/SYCL/ESIMD/api/simd_memory_access.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_negation_operator.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_subscript_operator.cpp
+++ b/SYCL/ESIMD/api/simd_subscript_operator.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
+++ b/SYCL/ESIMD/api/simd_view_copy_move_assign.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_view_negation_operator.cpp
+++ b/SYCL/ESIMD/api/simd_view_negation_operator.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_view_select_2d_fp.cpp
+++ b/SYCL/ESIMD/api/simd_view_select_2d_fp.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_view_select_2d_int.cpp
+++ b/SYCL/ESIMD/api/simd_view_select_2d_int.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/simd_view_subscript_operator.cpp
+++ b/SYCL/ESIMD/api/simd_view_subscript_operator.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/slm_gather_scatter.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/slm_gather_scatter_heavy.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter_heavy.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/api/slm_gather_scatter_rgba.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/svm_gather_scatter.cpp
+++ b/SYCL/ESIMD/api/svm_gather_scatter.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/svm_gather_scatter_64.cpp
+++ b/SYCL/ESIMD/api/svm_gather_scatter_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/svm_gather_scatter_scalar_off.cpp
+++ b/SYCL/ESIMD/api/svm_gather_scatter_scalar_off.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/api/unary_ops_heavy.cpp
+++ b/SYCL/ESIMD/api/unary_ops_heavy.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 // Exclude PVC not to run same test cases twice (via the *_pvc.cpp variant).
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/dword_atomic_cmpxchg.cpp
+++ b/SYCL/ESIMD/dword_atomic_cmpxchg.cpp
@@ -8,6 +8,7 @@
 // This test checks DWORD compare-and-exchange atomic operations.
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // TODO: esimd_emulator fails due to random timeouts (_XFAIL_: esimd_emulator)
 // UNSUPPORTED: esimd_emulator

--- a/SYCL/ESIMD/dword_atomic_cmpxchg_scalar_off.cpp
+++ b/SYCL/ESIMD/dword_atomic_cmpxchg_scalar_off.cpp
@@ -8,6 +8,7 @@
 // This test checks LSC atomic operations.
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // TODO: esimd_emulator fails due to random timeouts (_XFAIL_: esimd_emulator)
 // UNSUPPORTED: esimd_emulator

--- a/SYCL/ESIMD/dword_atomic_smoke.cpp
+++ b/SYCL/ESIMD/dword_atomic_smoke.cpp
@@ -8,6 +8,7 @@
 // This test checks DWORD atomic operations.
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/dword_atomic_smoke_scalar_off.cpp
+++ b/SYCL/ESIMD/dword_atomic_smoke_scalar_off.cpp
@@ -8,6 +8,7 @@
 // This test checks LSC atomic operations.
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // TODO: esimd_emulator fails due to random timeouts (_XFAIL_: esimd_emulator)
 // UNSUPPORTED: esimd_emulator

--- a/SYCL/ESIMD/esimd_check_vc_codegen.cpp
+++ b/SYCL/ESIMD/esimd_check_vc_codegen.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // esimd_emulator does not support online-compiler that invokes 'piProgramBuild'
 // UNSUPPORTED: esimd_emulator

--- a/SYCL/ESIMD/ext_math.cpp
+++ b/SYCL/ESIMD/ext_math.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_192.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_256.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_512.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_char_int_size_96.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_192.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_256.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_512.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
+++ b/SYCL/ESIMD/fp_args_size/fp_args_int_size_96.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -Xclang -fsycl-allow-func-ptr -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram.cpp
+++ b/SYCL/ESIMD/histogram.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram_256_slm.cpp
+++ b/SYCL/ESIMD/histogram_256_slm.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram_2d.cpp
+++ b/SYCL/ESIMD/histogram_2d.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram_2d_64.cpp
+++ b/SYCL/ESIMD/histogram_2d_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram_64.cpp
+++ b/SYCL/ESIMD/histogram_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-gen9
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: gpu-intel-dg1,gpu-intel-dg2,cuda,hip, gpu-intel-pvc
 // UNSUPPORTED: ze_debug-1,ze_debug4
 // RUN: %clangxx -fsycl %s -o %t.out

--- a/SYCL/ESIMD/kmeans/kmeans.cpp
+++ b/SYCL/ESIMD/kmeans/kmeans.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %S/points.csv

--- a/SYCL/ESIMD/linear/linear.cpp
+++ b/SYCL/ESIMD/linear/linear.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp

--- a/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/SYCL/ESIMD/mandelbrot/mandelbrot.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out %T/output.ppm %S/golden_hw.ppm

--- a/SYCL/ESIMD/matrix_transpose_usm.cpp
+++ b/SYCL/ESIMD/matrix_transpose_usm.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_192.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_192.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_256.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_256.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_512.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_512.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_64.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_96.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_char_int_size_96.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_192.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_192.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_256.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_256.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_512.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_512.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_64.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_96.cpp
+++ b/SYCL/ESIMD/noinline_args_size/noinline_args_int_size_96.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: env IGC_FunctionControl=3 IGC_ForceInlineStackCallWithImplArg=1 %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/printf.cpp
+++ b/SYCL/ESIMD/printf.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // CUDA and HIP don't support printf.
 //

--- a/SYCL/ESIMD/radix_sort.cpp
+++ b/SYCL/ESIMD/radix_sort.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/reduction.cpp
+++ b/SYCL/ESIMD/reduction.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/abs_fix_test.cpp
+++ b/SYCL/ESIMD/regression/abs_fix_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/big_const_initializer.cpp
+++ b/SYCL/ESIMD/regression/big_const_initializer.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/bit_shift_compilation_test.cpp
+++ b/SYCL/ESIMD/regression/bit_shift_compilation_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/copyto_char_test.cpp
+++ b/SYCL/ESIMD/regression/copyto_char_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/dgetrf.cpp
+++ b/SYCL/ESIMD/regression/dgetrf.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 3 2 1

--- a/SYCL/ESIMD/regression/dgetrf_8x8.cpp
+++ b/SYCL/ESIMD/regression/dgetrf_8x8.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -I%S/.. -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out 1

--- a/SYCL/ESIMD/regression/dgetrf_ref.cpp
+++ b/SYCL/ESIMD/regression/dgetrf_ref.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -DUSE_REF %s -I%S/.. -o %t.ref.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.ref.out 3 2 1

--- a/SYCL/ESIMD/regression/fmod_compatibility_test.cpp
+++ b/SYCL/ESIMD/regression/fmod_compatibility_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // TODO online compiler check fails for esimd_emulator
 // XFAIL: esimd_emulator

--- a/SYCL/ESIMD/regression/globals.cpp
+++ b/SYCL/ESIMD/regression/globals.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // TODO: esimd_emulator fails due to unimplemented sub-group support
 // XFAIL: esimd_emulator

--- a/SYCL/ESIMD/regression/half_conversion_test.cpp
+++ b/SYCL/ESIMD/regression/half_conversion_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_kernel %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/iselect.cpp
+++ b/SYCL/ESIMD/regression/iselect.cpp
@@ -8,6 +8,7 @@
 // This is basic test for testing proper intrinsics generation.
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/math_const_fix_test.cpp
+++ b/SYCL/ESIMD/regression/math_const_fix_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/operator_decrement.cpp
+++ b/SYCL/ESIMD/regression/operator_decrement.cpp
@@ -8,6 +8,7 @@
 // This is a test for a bug found simd_view::operator--
 //
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/replicate_bug.cpp
+++ b/SYCL/ESIMD/regression/replicate_bug.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/store_zero_const.cpp
+++ b/SYCL/ESIMD/regression/store_zero_const.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_kernel -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/sycl_esimd_mixed_unnamed.cpp
+++ b/SYCL/ESIMD/regression/sycl_esimd_mixed_unnamed.cpp
@@ -9,6 +9,7 @@
 // source and in the same program .
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out

--- a/SYCL/ESIMD/regression/tanh_fix_test.cpp
+++ b/SYCL/ESIMD/regression/tanh_fix_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/unused_load.cpp
+++ b/SYCL/ESIMD/regression/unused_load.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/usm_gather_scatter_32.cpp
+++ b/SYCL/ESIMD/regression/usm_gather_scatter_32.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/regression/variable_gather_mask.cpp
+++ b/SYCL/ESIMD/regression/variable_gather_mask.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/slm_alloc.cpp
+++ b/SYCL/ESIMD/slm_alloc.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || esimd_emulator
 //
 // RUN: %clangxx -fsycl %s -o %t.1.out

--- a/SYCL/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
+++ b/SYCL/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || esimd_emulator
 //
 // RUN: %clangxx -fsycl %s -o %t.1.out

--- a/SYCL/ESIMD/slm_alloc_many_kernels_one_func.cpp
+++ b/SYCL/ESIMD/slm_alloc_many_kernels_one_func.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || esimd_emulator
 //
 // RUN: %clangxx -fsycl %s -o %t.1.out

--- a/SYCL/ESIMD/slm_barrier.cpp
+++ b/SYCL/ESIMD/slm_barrier.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/slm_split_barrier.cpp
+++ b/SYCL/ESIMD/slm_split_barrier.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_bool.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_bool.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_char.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_char.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_double.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_double.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_float.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_float.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_int.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_int.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_int64.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_int64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_short.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_short.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uchar.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_uint.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uint.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_uint64.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_uint64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
+++ b/SYCL/ESIMD/spec_const/spec_const_ushort.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl -I%S/.. %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // UNSUPPORTED: cuda || hip

--- a/SYCL/ESIMD/spec_const/unused_spec_const.cpp
+++ b/SYCL/ESIMD/spec_const/unused_spec_const.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // XFAIL: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out

--- a/SYCL/ESIMD/stencil2.cpp
+++ b/SYCL/ESIMD/stencil2.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/sycl_esimd_mix.cpp
+++ b/SYCL/ESIMD/sycl_esimd_mix.cpp
@@ -9,6 +9,7 @@
 // in the same program .
 
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // TODO/FIXME: esimd_emulator does not support online compilation that
 //             invokes 'piProgramBuild'/'piKernelCreate'

--- a/SYCL/ESIMD/template.cpp
+++ b/SYCL/ESIMD/template.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/test_id_3d.cpp
+++ b/SYCL/ESIMD/test_id_3d.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/usm_gather_scatter_rgba.cpp
+++ b/SYCL/ESIMD/usm_gather_scatter_rgba.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/usm_gather_scatter_rgba_64.cpp
+++ b/SYCL/ESIMD/usm_gather_scatter_rgba_64.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/vadd_1d.cpp
+++ b/SYCL/ESIMD/vadd_1d.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/vadd_2d.cpp
+++ b/SYCL/ESIMD/vadd_2d.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/vadd_2d_acc.cpp
+++ b/SYCL/ESIMD/vadd_2d_acc.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/SYCL/ESIMD/vadd_half.cpp
+++ b/SYCL/ESIMD/vadd_half.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/vadd_raw_send.cpp
+++ b/SYCL/ESIMD/vadd_raw_send.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-gen9
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: gpu-intel-dg1,gpu-intel-dg2,cuda,hip
 // TODO: esimd_emulator fails due to unimplemented 'raw_send' intrinsic
 // XFAIL: esimd_emulator

--- a/SYCL/ESIMD/vadd_usm.cpp
+++ b/SYCL/ESIMD/vadd_usm.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out

--- a/SYCL/ESIMD/vadd_usm_opqptr.cpp
+++ b/SYCL/ESIMD/vadd_usm_opqptr.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -Xclang -opaque-pointers %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
The Gen9 GPU driver on Windows and Linux is different, so some tests don't work on Gen9 on Windows. Disable the ones that fail.

This change was implemented by our QA team, I'm just submitting the PR.

Thanks