### PR TITLE
[SYCL][ESIMD] Add tests for new raw send{s} API

### DIFF
--- a/SYCL/ESIMD/histogram_raw_send.cpp
+++ b/SYCL/ESIMD/histogram_raw_send.cpp
@@ -9,8 +9,10 @@
 // REQUIRES: gpu-intel-gen9
 // UNSUPPORTED: gpu-intel-dg1,gpu-intel-dg2,cuda,hip, gpu-intel-pvc
 // UNSUPPORTED: ze_debug-1,ze_debug4
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %clangxx -fsycl %s -o %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+// RUN: %clangxx -fsycl -DNEW_API %s -o %t2.out
+// RUN: %GPU_RUN_PLACEHOLDER %t2.out
 
 // The test checks raw send functionality with atomic write implementation
 // on SKL. It does not work on DG1 due to send instruction incompatibility.
@@ -85,10 +87,15 @@ ESIMD_INLINE void atomic_write(T *bins, simd<unsigned, n> offset,
   constexpr uint8_t numSrc1 = 0x1;
   constexpr uint8_t isEOT = 0;
   constexpr uint8_t isSendc = 0;
-
+#ifdef NEW_API
+  experimental::esimd::raw_sends(oldDst, vAddr, src0, exDesc, desc, execSize,
+                                 sfid, numSrc0, numSrc1, numDst, isEOT, isSendc,
+                                 pred);
+#else
   experimental::esimd::raw_sends_load(oldDst, vAddr, src0, exDesc, desc,
                                       execSize, sfid, numSrc0, numSrc1, numDst,
                                       isEOT, isSendc, pred);
+#endif
 }
 
 int main(int argc, char *argv[]) {

--- a/SYCL/ESIMD/vadd_raw_send.cpp
+++ b/SYCL/ESIMD/vadd_raw_send.cpp
@@ -10,8 +10,10 @@
 // UNSUPPORTED: gpu-intel-dg1,gpu-intel-dg2,cuda,hip
 // TODO: esimd_emulator fails due to unimplemented 'raw_send' intrinsic
 // XFAIL: esimd_emulator
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %clangxx -fsycl %s -o %t1.out
+// RUN: %GPU_RUN_PLACEHOLDER %t1.out
+// RUN: %clangxx -fsycl -DNEW_API %s -o %t2.out
+// RUN: %GPU_RUN_PLACEHOLDER %t2.out
 
 // The test checks raw send functionality with block read/write implementation
 // on SKL. It does not work on DG1 due to send instruction incompatibility.
@@ -41,9 +43,13 @@ ESIMD_INLINE simd<T, N> dwaligned_block_read(AccessorTy acc,
   constexpr uint8_t sfid = 0x0;
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numDst = 0x2;
-
+#ifdef NEW_API
+  return experimental::esimd::raw_send(oldDst, src0, exDesc, desc, execSize,
+                                       sfid, numSrc0, numDst);
+#else
   return experimental::esimd::raw_send_load(oldDst, src0, exDesc, desc,
                                             execSize, sfid, numSrc0, numDst);
+#endif
 }
 
 template <typename T, int N, typename AccessorTy>
@@ -59,9 +65,13 @@ ESIMD_INLINE void block_write1(AccessorTy acc, unsigned int offset,
   constexpr uint8_t sfid = 0x0;
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numSrc1 = 0x1;
-
+#ifdef NEW_API
+  return experimental::esimd::raw_sends(src0, data, exDesc, desc, execSize,
+                                        sfid, numSrc0, numSrc1);
+#else
   return experimental::esimd::raw_sends_store(src0, data, exDesc, desc,
                                               execSize, sfid, numSrc0, numSrc1);
+#endif
 }
 
 template <typename T, int N, typename AccessorTy>
@@ -80,9 +90,13 @@ ESIMD_INLINE void block_write2(AccessorTy acc, unsigned int offset,
   constexpr uint8_t execSize = 0x83;
   constexpr uint8_t sfid = 0x0;
   constexpr uint8_t numSrc0 = 0x2;
-
+#ifdef NEW_API
+  return experimental::esimd::raw_send(src0, exDesc, desc, execSize, sfid,
+                                       numSrc0);
+#else
   return experimental::esimd::raw_send_store(src0, exDesc, desc, execSize, sfid,
                                              numSrc0);
+#endif
 }
 
 int main(void) {


### PR DESCRIPTION
It seems no gen9 tests are run in this repo, but I manually tested it on gen9 and it passes.

Compiler PR: https://github.com/intel/llvm/pull/8666