### PR TITLE
[SYCL] Updated tests to comply with SYCL 2020 aspect list

### DIFF
--- a/SYCL/Basic/aspects.cpp
+++ b/SYCL/Basic/aspects.cpp
@@ -93,9 +93,6 @@ int main() {
     if (plt.has(aspect::usm_atomic_shared_allocations)) {
       std::cout << "  USM atomic shared allocations" << std::endl;
     }
-    if (plt.has(aspect::usm_restricted_shared_allocations)) {
-      std::cout << "  USM restricted shared allocations" << std::endl;
-    }
     if (plt.has(aspect::usm_system_allocator)) {
       std::cout << "  USM system allocator" << std::endl;
     }

--- a/SYCL/Basic/aspects.cpp
+++ b/SYCL/Basic/aspects.cpp
@@ -26,10 +26,7 @@ int main() {
   int pltIdx = 0;
   for (const auto &plt : platform::get_platforms()) {
     pltIdx++;
-    if (plt.has(aspect::host)) {
-      std::cout << "Platform #" << pltIdx
-                << " type: Host supports:" << std::endl;
-    } else if (plt.has(aspect::cpu)) {
+    if (plt.has(aspect::cpu)) {
       std::cout << "Platform #" << pltIdx
                 << " type: CPU supports:" << std::endl;
     } else if (plt.has(aspect::gpu)) {
@@ -56,12 +53,6 @@ int main() {
     }
     if (plt.has(aspect::ext_oneapi_bfloat16_math_functions)) {
       std::cout << " ext_oneapi_bfloat16_math_functions" << std::endl;
-    }
-    if (plt.has(aspect::int64_base_atomics)) {
-      std::cout << "  base atomic operations" << std::endl;
-    }
-    if (plt.has(aspect::int64_extended_atomics)) {
-      std::cout << "  extended atomic operations" << std::endl;
     }
     if (plt.has(aspect::atomic64)) {
       std::cout << "  atomic64" << std::endl;
@@ -92,9 +83,6 @@ int main() {
     }
     if (plt.has(aspect::usm_atomic_shared_allocations)) {
       std::cout << "  USM atomic shared allocations" << std::endl;
-    }
-    if (plt.has(aspect::usm_system_allocator)) {
-      std::cout << "  USM system allocator" << std::endl;
     }
     if (plt.has(aspect::usm_system_allocations)) {
       std::cout << "  USM system allocations" << std::endl;

--- a/SYCL/Basic/diagnostics/non-uniform-wk-gp-test.cpp
+++ b/SYCL/Basic/diagnostics/non-uniform-wk-gp-test.cpp
@@ -52,7 +52,7 @@ int test() {
 int main() {
   int pltCount = 0, ret = 0;
   for (const auto &plt : platform::get_platforms()) {
-    if (!plt.has(aspect::host)) {
+    if (!plt.has(aspect::cpu)) {
       std::cout << "Platform #" << pltCount++ << ":" << std::endl;
       if (plt.get_backend() == backend::ext_oneapi_level_zero) {
         std::cout << "Backend: Level Zero" << std::endl;

--- a/SYCL/Basic/diagnostics/non-uniform-wk-gp-test.cpp
+++ b/SYCL/Basic/diagnostics/non-uniform-wk-gp-test.cpp
@@ -52,12 +52,10 @@ int test() {
 int main() {
   int pltCount = 0, ret = 0;
   for (const auto &plt : platform::get_platforms()) {
-    if (!plt.has(aspect::cpu)) {
-      std::cout << "Platform #" << pltCount++ << ":" << std::endl;
-      if (plt.get_backend() == backend::ext_oneapi_level_zero) {
-        std::cout << "Backend: Level Zero" << std::endl;
-        ret += test();
-      }
+    std::cout << "Platform #" << pltCount++ << ":" << std::endl;
+    if (plt.get_backend() == backend::ext_oneapi_level_zero) {
+      std::cout << "Backend: Level Zero" << std::endl;
+      ret += test();
     }
     std::cout << std::endl;
   }

--- a/SYCL/Basic/intel-ext-device.cpp
+++ b/SYCL/Basic/intel-ext-device.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
 
   int pltCount = 1;
   for (const auto &plt : platform::get_platforms()) {
-    if (!plt.has(aspect::host)) {
+    if (!plt.has(aspect::cpu)) {
       int devCount = 1;
       int totalEUs = 0;
       int numSlices = 0;

--- a/SYCL/Basic/intel-ext-device.cpp
+++ b/SYCL/Basic/intel-ext-device.cpp
@@ -35,136 +35,134 @@ int main(int argc, char **argv) {
 
   int pltCount = 1;
   for (const auto &plt : platform::get_platforms()) {
-    if (!plt.has(aspect::cpu)) {
-      int devCount = 1;
-      int totalEUs = 0;
-      int numSlices = 0;
-      int numSubslices = 0;
-      int numEUsPerSubslice = 0;
-      int numHWThreadsPerEU = 0;
-      for (const auto &dev : plt.get_devices()) {
-        std::cout << "Platform #" << pltCount++ << ":" << std::endl;
-        if (dev.has(aspect::gpu)) {
-          auto name = dev.get_info<info::device::name>();
-          std::cout << "Device #" << devCount++ << ": "
-                    << dev.get_info<info::device::name>() << ":" << std::endl;
+    int devCount = 1;
+    int totalEUs = 0;
+    int numSlices = 0;
+    int numSubslices = 0;
+    int numEUsPerSubslice = 0;
+    int numHWThreadsPerEU = 0;
+    for (const auto &dev : plt.get_devices()) {
+      std::cout << "Platform #" << pltCount++ << ":" << std::endl;
+      if (dev.has(aspect::gpu)) {
+        auto name = dev.get_info<info::device::name>();
+        std::cout << "Device #" << devCount++ << ": "
+                  << dev.get_info<info::device::name>() << ":" << std::endl;
 
-          std::cout << "Backend: ";
-          if (plt.get_backend() == backend::ext_oneapi_level_zero) {
-            std::cout << "Level Zero" << std::endl;
-          } else if (plt.get_backend() == backend::opencl) {
-            std::cout << "OpenCL" << std::endl;
-          } else if (plt.get_backend() == backend::ext_oneapi_cuda) {
-            std::cout << "CUDA" << std::endl;
-          } else {
-            std::cout << "Unknown" << std::endl;
-          }
-
-          // Use Feature Test macro to see if extensions are supported.
-          if (SYCL_EXT_INTEL_DEVICE_INFO >= 1) {
-
-            if (dev.has(aspect::ext_intel_pci_address)) {
-              std::cout << "PCI address = "
-                        << dev.get_info<ext::intel::info::device::pci_address>()
-                        << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_eu_count)) {
-              totalEUs = dev.get_info<ext::intel::info::device::gpu_eu_count>();
-              std::cout << "Number of EUs = " << totalEUs << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_eu_simd_width)) {
-              int w =
-                  dev.get_info<ext::intel::info::device::gpu_eu_simd_width>();
-              std::cout << "EU SIMD width = " << w << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_slices)) {
-              numSlices = dev.get_info<ext::intel::info::device::gpu_slices>();
-              std::cout << "Number of slices = " << numSlices << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_subslices_per_slice)) {
-              numSubslices = dev.get_info<
-                  ext::intel::info::device::gpu_subslices_per_slice>();
-              std::cout << "Number of subslices per slice = " << numSubslices
-                        << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_eu_count_per_subslice)) {
-              numEUsPerSubslice = dev.get_info<
-                  ext::intel::info::device::gpu_eu_count_per_subslice>();
-              std::cout << "Number of EUs per subslice = " << numEUsPerSubslice
-                        << std::endl;
-            }
-            if (SYCL_EXT_INTEL_DEVICE_INFO >= 3 &&
-                dev.has(aspect::ext_intel_gpu_hw_threads_per_eu)) {
-              numHWThreadsPerEU = dev.get_info<
-                  ext::intel::info::device::gpu_hw_threads_per_eu>();
-              std::cout << "Number of HW threads per EU = " << numHWThreadsPerEU
-                        << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_max_mem_bandwidth)) {
-              // not supported yet
-              long m =
-                  dev.get_info<ext::intel::info::device::max_mem_bandwidth>();
-              std::cout << "Maximum memory bandwidth = " << m << std::endl;
-            }
-            // This is the only data we can verify.
-            if (totalEUs != numSlices * numSubslices * numEUsPerSubslice) {
-              std::cout << "Error: EU Count is incorrect!" << std::endl;
-              std::cout << "Failed!" << std::endl;
-              return 1;
-            }
-            if (SYCL_EXT_INTEL_DEVICE_INFO >= 2 &&
-                dev.has(aspect::ext_intel_device_info_uuid)) {
-              auto UUID = dev.get_info<ext::intel::info::device::uuid>();
-              std::cout << "Device UUID = ";
-              for (int i = 0; i < 16; i++) {
-                std::cout << std::to_string(UUID[i]);
-              }
-              std::cout << "\n";
-            }
-            if (SYCL_EXT_INTEL_DEVICE_INFO >= 5 &&
-                dev.has(aspect::ext_intel_device_id)) {
-              int deviceID =
-                  dev.get_info<ext::intel::info::device::device_id>();
-              std::cout << "Device ID = " << deviceID << std::endl;
-            }
-          } // SYCL_EXT_INTEL_DEVICE_INFO
+        std::cout << "Backend: ";
+        if (plt.get_backend() == backend::ext_oneapi_level_zero) {
+          std::cout << "Level Zero" << std::endl;
+        } else if (plt.get_backend() == backend::opencl) {
+          std::cout << "OpenCL" << std::endl;
+        } else if (plt.get_backend() == backend::ext_oneapi_cuda) {
+          std::cout << "CUDA" << std::endl;
+        } else {
+          std::cout << "Unknown" << std::endl;
         }
+
+        // Use Feature Test macro to see if extensions are supported.
+        if (SYCL_EXT_INTEL_DEVICE_INFO >= 1) {
+
+          if (dev.has(aspect::ext_intel_pci_address)) {
+            std::cout << "PCI address = "
+                      << dev.get_info<ext::intel::info::device::pci_address>()
+                      << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_eu_count)) {
+            totalEUs = dev.get_info<ext::intel::info::device::gpu_eu_count>();
+            std::cout << "Number of EUs = " << totalEUs << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_eu_simd_width)) {
+            int w =
+                dev.get_info<ext::intel::info::device::gpu_eu_simd_width>();
+            std::cout << "EU SIMD width = " << w << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_slices)) {
+            numSlices = dev.get_info<ext::intel::info::device::gpu_slices>();
+            std::cout << "Number of slices = " << numSlices << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_subslices_per_slice)) {
+            numSubslices = dev.get_info<
+                ext::intel::info::device::gpu_subslices_per_slice>();
+            std::cout << "Number of subslices per slice = " << numSubslices
+                      << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_eu_count_per_subslice)) {
+            numEUsPerSubslice = dev.get_info<
+                ext::intel::info::device::gpu_eu_count_per_subslice>();
+            std::cout << "Number of EUs per subslice = " << numEUsPerSubslice
+                      << std::endl;
+          }
+          if (SYCL_EXT_INTEL_DEVICE_INFO >= 3 &&
+              dev.has(aspect::ext_intel_gpu_hw_threads_per_eu)) {
+            numHWThreadsPerEU = dev.get_info<
+                ext::intel::info::device::gpu_hw_threads_per_eu>();
+            std::cout << "Number of HW threads per EU = " << numHWThreadsPerEU
+                      << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_max_mem_bandwidth)) {
+            // not supported yet
+            long m =
+                dev.get_info<ext::intel::info::device::max_mem_bandwidth>();
+            std::cout << "Maximum memory bandwidth = " << m << std::endl;
+          }
+          // This is the only data we can verify.
+          if (totalEUs != numSlices * numSubslices * numEUsPerSubslice) {
+            std::cout << "Error: EU Count is incorrect!" << std::endl;
+            std::cout << "Failed!" << std::endl;
+            return 1;
+          }
+          if (SYCL_EXT_INTEL_DEVICE_INFO >= 2 &&
+              dev.has(aspect::ext_intel_device_info_uuid)) {
+            auto UUID = dev.get_info<ext::intel::info::device::uuid>();
+            std::cout << "Device UUID = ";
+            for (int i = 0; i < 16; i++) {
+              std::cout << std::to_string(UUID[i]);
+            }
+            std::cout << "\n";
+          }
+          if (SYCL_EXT_INTEL_DEVICE_INFO >= 5 &&
+              dev.has(aspect::ext_intel_device_id)) {
+            int deviceID =
+                dev.get_info<ext::intel::info::device::device_id>();
+            std::cout << "Device ID = " << deviceID << std::endl;
+          }
+        } // SYCL_EXT_INTEL_DEVICE_INFO
+      }
 
 // Check if this experimental feature is supported
 #ifdef SYCL_EXT_ONEAPI_MAX_WORK_GROUP_QUERY
-        sycl::id<1> groupD =
-            dev.get_info<sycl::ext::oneapi::experimental::info::device::
-                             max_work_groups<1>>();
-        std::cout << "Max work group size in 1D \n";
-        std::cout << "Dimension 1:" << groupD[0] << std::endl;
+      sycl::id<1> groupD =
+          dev.get_info<sycl::ext::oneapi::experimental::info::device::
+                            max_work_groups<1>>();
+      std::cout << "Max work group size in 1D \n";
+      std::cout << "Dimension 1:" << groupD[0] << std::endl;
 
-        sycl::id<2> group2D =
-            dev.get_info<sycl::ext::oneapi::experimental::info::device::
-                             max_work_groups<2>>();
-        std::cout << "Max work group size in 2D \n";
-        std::cout << "Dimension 1:" << group2D[0] << "\n"
-                  << "Dimension 2:" << group2D[1] << std::endl;
+      sycl::id<2> group2D =
+          dev.get_info<sycl::ext::oneapi::experimental::info::device::
+                            max_work_groups<2>>();
+      std::cout << "Max work group size in 2D \n";
+      std::cout << "Dimension 1:" << group2D[0] << "\n"
+                << "Dimension 2:" << group2D[1] << std::endl;
 
-        sycl::id<3> group3D =
-            dev.get_info<sycl::ext::oneapi::experimental::info::device::
-                             max_work_groups<3>>();
-        std::cout << "Max work group size in 3D \n";
-        std::cout << "Dimension 1:" << group3D[0] << "\n"
-                  << "Dimension 2:" << group3D[1] << "\n"
-                  << "Dimension 3:" << group3D[2] << std::endl;
+      sycl::id<3> group3D =
+          dev.get_info<sycl::ext::oneapi::experimental::info::device::
+                            max_work_groups<3>>();
+      std::cout << "Max work group size in 3D \n";
+      std::cout << "Dimension 1:" << group3D[0] << "\n"
+                << "Dimension 2:" << group3D[1] << "\n"
+                << "Dimension 3:" << group3D[2] << std::endl;
 
-        size_t group_max = dev.get_info<sycl::ext::oneapi::experimental::info::
-                                            device::max_global_work_groups>();
-        std::cout << "Max global work group size:" << group_max << "\n";
+      size_t group_max = dev.get_info<sycl::ext::oneapi::experimental::info::
+                                          device::max_global_work_groups>();
+      std::cout << "Max global work group size:" << group_max << "\n";
 
-        assert((group3D[0] <= group_max && group3D[1] <= group_max &&
-                group3D[2] <= group_max) &&
-               "Max work-group size of each dimension must be smaller than "
-               "global work-group size");
+      assert((group3D[0] <= group_max && group3D[1] <= group_max &&
+              group3D[2] <= group_max) &&
+              "Max work-group size of each dimension must be smaller than "
+              "global work-group size");
 #endif
 
-        std::cout << std::endl;
-      }
+      std::cout << std::endl;
     }
   }
   std::cout << "Passed!" << std::endl;

--- a/SYCL/Basic/intel-ext-device.cpp
+++ b/SYCL/Basic/intel-ext-device.cpp
@@ -72,8 +72,7 @@ int main(int argc, char **argv) {
             std::cout << "Number of EUs = " << totalEUs << std::endl;
           }
           if (dev.has(aspect::ext_intel_gpu_eu_simd_width)) {
-            int w =
-                dev.get_info<ext::intel::info::device::gpu_eu_simd_width>();
+            int w = dev.get_info<ext::intel::info::device::gpu_eu_simd_width>();
             std::cout << "EU SIMD width = " << w << std::endl;
           }
           if (dev.has(aspect::ext_intel_gpu_slices)) {
@@ -94,8 +93,8 @@ int main(int argc, char **argv) {
           }
           if (SYCL_EXT_INTEL_DEVICE_INFO >= 3 &&
               dev.has(aspect::ext_intel_gpu_hw_threads_per_eu)) {
-            numHWThreadsPerEU = dev.get_info<
-                ext::intel::info::device::gpu_hw_threads_per_eu>();
+            numHWThreadsPerEU =
+                dev.get_info<ext::intel::info::device::gpu_hw_threads_per_eu>();
             std::cout << "Number of HW threads per EU = " << numHWThreadsPerEU
                       << std::endl;
           }
@@ -122,8 +121,7 @@ int main(int argc, char **argv) {
           }
           if (SYCL_EXT_INTEL_DEVICE_INFO >= 5 &&
               dev.has(aspect::ext_intel_device_id)) {
-            int deviceID =
-                dev.get_info<ext::intel::info::device::device_id>();
+            int deviceID = dev.get_info<ext::intel::info::device::device_id>();
             std::cout << "Device ID = " << deviceID << std::endl;
           }
         } // SYCL_EXT_INTEL_DEVICE_INFO
@@ -131,22 +129,19 @@ int main(int argc, char **argv) {
 
 // Check if this experimental feature is supported
 #ifdef SYCL_EXT_ONEAPI_MAX_WORK_GROUP_QUERY
-      sycl::id<1> groupD =
-          dev.get_info<sycl::ext::oneapi::experimental::info::device::
-                            max_work_groups<1>>();
+      sycl::id<1> groupD = dev.get_info<
+          sycl::ext::oneapi::experimental::info::device::max_work_groups<1>>();
       std::cout << "Max work group size in 1D \n";
       std::cout << "Dimension 1:" << groupD[0] << std::endl;
 
-      sycl::id<2> group2D =
-          dev.get_info<sycl::ext::oneapi::experimental::info::device::
-                            max_work_groups<2>>();
+      sycl::id<2> group2D = dev.get_info<
+          sycl::ext::oneapi::experimental::info::device::max_work_groups<2>>();
       std::cout << "Max work group size in 2D \n";
       std::cout << "Dimension 1:" << group2D[0] << "\n"
                 << "Dimension 2:" << group2D[1] << std::endl;
 
-      sycl::id<3> group3D =
-          dev.get_info<sycl::ext::oneapi::experimental::info::device::
-                            max_work_groups<3>>();
+      sycl::id<3> group3D = dev.get_info<
+          sycl::ext::oneapi::experimental::info::device::max_work_groups<3>>();
       std::cout << "Max work group size in 3D \n";
       std::cout << "Dimension 1:" << group3D[0] << "\n"
                 << "Dimension 2:" << group3D[1] << "\n"
@@ -158,8 +153,8 @@ int main(int argc, char **argv) {
 
       assert((group3D[0] <= group_max && group3D[1] <= group_max &&
               group3D[2] <= group_max) &&
-              "Max work-group size of each dimension must be smaller than "
-              "global work-group size");
+             "Max work-group size of each dimension must be smaller than "
+             "global work-group size");
 #endif
 
       std::cout << std::endl;

--- a/SYCL/DeprecatedFeatures/deprecated_intel_ext_device.cpp
+++ b/SYCL/DeprecatedFeatures/deprecated_intel_ext_device.cpp
@@ -81,8 +81,8 @@ int main(int argc, char **argv) {
             std::cout << "Number of slices = " << numSlices << std::endl;
           }
           if (dev.has(aspect::ext_intel_gpu_subslices_per_slice)) {
-            numSubslices = dev.get_info<
-                info::device::ext_intel_gpu_subslices_per_slice>();
+            numSubslices =
+                dev.get_info<info::device::ext_intel_gpu_subslices_per_slice>();
             std::cout << "Number of subslices per slice = " << numSubslices
                       << std::endl;
           }
@@ -100,8 +100,7 @@ int main(int argc, char **argv) {
           }
           if (dev.has(aspect::ext_intel_max_mem_bandwidth)) {
             // not supported yet
-            long m =
-                dev.get_info<info::device::ext_intel_max_mem_bandwidth>();
+            long m = dev.get_info<info::device::ext_intel_max_mem_bandwidth>();
             std::cout << "Maximum memory bandwidth = " << m << std::endl;
           }
           // This is the only data we can verify.

--- a/SYCL/DeprecatedFeatures/deprecated_intel_ext_device.cpp
+++ b/SYCL/DeprecatedFeatures/deprecated_intel_ext_device.cpp
@@ -36,85 +36,83 @@ int main(int argc, char **argv) {
 
   int pltCount = 1;
   for (const auto &plt : platform::get_platforms()) {
-    if (!plt.has(aspect::cpu)) {
-      int devCount = 1;
-      int totalEUs = 0;
-      int numSlices = 0;
-      int numSubslices = 0;
-      int numEUsPerSubslice = 0;
-      int numHWThreadsPerEU = 0;
-      for (const auto &dev : plt.get_devices()) {
-        std::cout << "Platform #" << pltCount++ << ":" << std::endl;
-        if (dev.has(aspect::gpu)) {
-          auto name = dev.get_info<info::device::name>();
-          std::cout << "Device #" << devCount++ << ": "
-                    << dev.get_info<info::device::name>() << ":" << std::endl;
+    int devCount = 1;
+    int totalEUs = 0;
+    int numSlices = 0;
+    int numSubslices = 0;
+    int numEUsPerSubslice = 0;
+    int numHWThreadsPerEU = 0;
+    for (const auto &dev : plt.get_devices()) {
+      std::cout << "Platform #" << pltCount++ << ":" << std::endl;
+      if (dev.has(aspect::gpu)) {
+        auto name = dev.get_info<info::device::name>();
+        std::cout << "Device #" << devCount++ << ": "
+                  << dev.get_info<info::device::name>() << ":" << std::endl;
 
-          std::cout << "Backend: ";
-          if (plt.get_backend() == backend::ext_oneapi_level_zero) {
-            std::cout << "Level Zero" << std::endl;
-          } else if (plt.get_backend() == backend::opencl) {
-            std::cout << "OpenCL" << std::endl;
-          } else if (plt.get_backend() == backend::ext_oneapi_cuda) {
-            std::cout << "CUDA" << std::endl;
-          } else {
-            std::cout << "Unknown" << std::endl;
-          }
-
-          // Use Feature Test macro to see if extensions are supported.
-          if (SYCL_EXT_INTEL_DEVICE_INFO >= 1) {
-
-            if (dev.has(aspect::ext_intel_pci_address)) {
-              std::cout << "PCI address = "
-                        << dev.get_info<info::device::ext_intel_pci_address>()
-                        << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_eu_count)) {
-              totalEUs = dev.get_info<info::device::ext_intel_gpu_eu_count>();
-              std::cout << "Number of EUs = " << totalEUs << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_eu_simd_width)) {
-              int w = dev.get_info<info::device::ext_intel_gpu_eu_simd_width>();
-              std::cout << "EU SIMD width = " << w << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_slices)) {
-              numSlices = dev.get_info<info::device::ext_intel_gpu_slices>();
-              std::cout << "Number of slices = " << numSlices << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_subslices_per_slice)) {
-              numSubslices = dev.get_info<
-                  info::device::ext_intel_gpu_subslices_per_slice>();
-              std::cout << "Number of subslices per slice = " << numSubslices
-                        << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_eu_count_per_subslice)) {
-              numEUsPerSubslice = dev.get_info<
-                  info::device::ext_intel_gpu_eu_count_per_subslice>();
-              std::cout << "Number of EUs per subslice = " << numEUsPerSubslice
-                        << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_gpu_hw_threads_per_eu)) {
-              numHWThreadsPerEU =
-                  dev.get_info<info::device::ext_intel_gpu_hw_threads_per_eu>();
-              std::cout << "Number of HW threads per EU = " << numHWThreadsPerEU
-                        << std::endl;
-            }
-            if (dev.has(aspect::ext_intel_max_mem_bandwidth)) {
-              // not supported yet
-              long m =
-                  dev.get_info<info::device::ext_intel_max_mem_bandwidth>();
-              std::cout << "Maximum memory bandwidth = " << m << std::endl;
-            }
-            // This is the only data we can verify.
-            if (totalEUs != numSlices * numSubslices * numEUsPerSubslice) {
-              std::cout << "Error: EU Count is incorrect!" << std::endl;
-              std::cout << "Failed!" << std::endl;
-              return 1;
-            }
-          } // SYCL_EXT_INTEL_DEVICE_INFO
+        std::cout << "Backend: ";
+        if (plt.get_backend() == backend::ext_oneapi_level_zero) {
+          std::cout << "Level Zero" << std::endl;
+        } else if (plt.get_backend() == backend::opencl) {
+          std::cout << "OpenCL" << std::endl;
+        } else if (plt.get_backend() == backend::ext_oneapi_cuda) {
+          std::cout << "CUDA" << std::endl;
+        } else {
+          std::cout << "Unknown" << std::endl;
         }
-        std::cout << std::endl;
+
+        // Use Feature Test macro to see if extensions are supported.
+        if (SYCL_EXT_INTEL_DEVICE_INFO >= 1) {
+
+          if (dev.has(aspect::ext_intel_pci_address)) {
+            std::cout << "PCI address = "
+                      << dev.get_info<info::device::ext_intel_pci_address>()
+                      << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_eu_count)) {
+            totalEUs = dev.get_info<info::device::ext_intel_gpu_eu_count>();
+            std::cout << "Number of EUs = " << totalEUs << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_eu_simd_width)) {
+            int w = dev.get_info<info::device::ext_intel_gpu_eu_simd_width>();
+            std::cout << "EU SIMD width = " << w << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_slices)) {
+            numSlices = dev.get_info<info::device::ext_intel_gpu_slices>();
+            std::cout << "Number of slices = " << numSlices << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_subslices_per_slice)) {
+            numSubslices = dev.get_info<
+                info::device::ext_intel_gpu_subslices_per_slice>();
+            std::cout << "Number of subslices per slice = " << numSubslices
+                      << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_eu_count_per_subslice)) {
+            numEUsPerSubslice = dev.get_info<
+                info::device::ext_intel_gpu_eu_count_per_subslice>();
+            std::cout << "Number of EUs per subslice = " << numEUsPerSubslice
+                      << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_gpu_hw_threads_per_eu)) {
+            numHWThreadsPerEU =
+                dev.get_info<info::device::ext_intel_gpu_hw_threads_per_eu>();
+            std::cout << "Number of HW threads per EU = " << numHWThreadsPerEU
+                      << std::endl;
+          }
+          if (dev.has(aspect::ext_intel_max_mem_bandwidth)) {
+            // not supported yet
+            long m =
+                dev.get_info<info::device::ext_intel_max_mem_bandwidth>();
+            std::cout << "Maximum memory bandwidth = " << m << std::endl;
+          }
+          // This is the only data we can verify.
+          if (totalEUs != numSlices * numSubslices * numEUsPerSubslice) {
+            std::cout << "Error: EU Count is incorrect!" << std::endl;
+            std::cout << "Failed!" << std::endl;
+            return 1;
+          }
+        } // SYCL_EXT_INTEL_DEVICE_INFO
       }
+      std::cout << std::endl;
     }
   }
   std::cout << "Passed!" << std::endl;

--- a/SYCL/DeprecatedFeatures/deprecated_intel_ext_device.cpp
+++ b/SYCL/DeprecatedFeatures/deprecated_intel_ext_device.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
 
   int pltCount = 1;
   for (const auto &plt : platform::get_platforms()) {
-    if (!plt.has(aspect::host)) {
+    if (!plt.has(aspect::cpu)) {
       int devCount = 1;
       int totalEUs = 0;
       int numSlices = 0;

--- a/SYCL/Regression/device_pci_address_bdf_format.cpp
+++ b/SYCL/Regression/device_pci_address_bdf_format.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
       "^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}.[0-9a-fA-F]$"};
 
   for (const auto &plt : platform::get_platforms()) {
-    if (plt.has(aspect::host))
+    if (plt.has(aspect::cpu))
       continue;
     for (const auto &dev : plt.get_devices()) {
       if (!dev.has(aspect::ext_intel_pci_address))

--- a/SYCL/Regression/device_pci_address_bdf_format.cpp
+++ b/SYCL/Regression/device_pci_address_bdf_format.cpp
@@ -38,8 +38,6 @@ int main(int argc, char **argv) {
       "^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}.[0-9a-fA-F]$"};
 
   for (const auto &plt : platform::get_platforms()) {
-    if (plt.has(aspect::cpu))
-      continue;
     for (const auto &dev : plt.get_devices()) {
       if (!dev.has(aspect::ext_intel_pci_address))
         continue;


### PR DESCRIPTION
This patch updates the E2E tests to account for the changes made to aspects in [Section 4.6.4.3](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:device-aspects) of the specification:

- The concept of a "host" device no longer exists in SYCL 2020 - any `host` should now be a `cpu`, so the aspect has been deprecated accordingly.
- `usm_restricted_shared_allocations` has been removed.
- `usm_system_allocator` has been renamed `usm_system_allocations`.
- `int64_*` aspects were replaced with `atomic64`, so no longer should be tested.

_(May require https://github.com/intel/llvm/pull/8751 but should pass without.)_