### PR TITLE
[SYCL] enabled kernelinfo (global_work_size) support for CUDA, HIP

### DIFF
--- a/SYCL/Basic/kernel_info.cpp
+++ b/SYCL/Basic/kernel_info.cpp
@@ -5,9 +5,6 @@
 //
 // Fail is flaky for level_zero, enable when fixed.
 // UNSUPPORTED: level_zero
-//
-// CUDA and HIP do not currently implement global_work_size
-// UNSUPPORTED: cuda, hip
 
 //==--- kernel_info.cpp - SYCL kernel info test ----------------------------==//
 //


### PR DESCRIPTION
Enables support for the kernel_info to CUDA, HIP plugins.

Disabled at: https://github.com/intel/llvm-test-suite/pull/1693